### PR TITLE
dso-conclusion fix (margins van een geneste P)

### DIFF
--- a/src/styles/components/_conclusion.scss
+++ b/src/styles/components/_conclusion.scss
@@ -30,6 +30,10 @@ ul.dso-conclusion {
       font-style: italic;
       margin: 0 0 8px;
       padding: 0;
+
+      p {
+        margin: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Omdat we nu ook links ondersteunen (diep genest in de dso-conclusion) gebruiken we markdown parsing, deze maakt overal een paragraph van waardoor de styling niet meer overeenkwam met de door ons bedachte ontwerpen. Vandaar deze minuscule fix. Het gaat dus om de 'Let op: ... ' meldingen. 

<img width="568" alt="Screenshot 2019-04-12 at 11 35 25" src="https://user-images.githubusercontent.com/18580063/56027827-15083080-5d17-11e9-8c83-8da38f8f4b1d.png">
