### PR TITLE
dso-icons.svg via instelbaar pad inlezen #435

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## NEXT - UNRELEASED
+* Locatie van scg-icons.svg in variabele `$dso-icons-path` ondergebracht (default: `../`).
 
 ## 9.0.0 - 14-10-2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## NEXT - UNRELEASED
-* Locatie van scg-icons.svg in variabele `$dso-icons-path` ondergebracht (default: `../`).
+
+### Added
+* Locatie van scg-icons.svg in variabele `$dso-icons-path` ondergebracht (default: `../`) (#435).
 
 ## 9.0.0 - 14-10-2019
 

--- a/src/styles/icons/_di.scss
+++ b/src/styles/icons/_di.scss
@@ -2,7 +2,7 @@ $dso-icon-size: 1em;
 $dso-icon-vertical-align: -.17em;
 
 @mixin di($icon, $size: $dso-icon-size) {
-  background: url("../dso-icons.svg#img-#{$icon}") no-repeat;
+  background: url("#{$dso-icons-path}dso-icons.svg#img-#{$icon}") no-repeat;
   background-position: center;
   background-size: cover;
   height: $size;
@@ -10,7 +10,7 @@ $dso-icon-vertical-align: -.17em;
 }
 
 @mixin di-variant($icon) {
-  background-image: url("../dso-icons.svg#img-#{$icon}");
+  background-image: url("#{$dso-icons-path}dso-icons.svg#img-#{$icon}");
 }
 
 svg.di {

--- a/src/styles/mixins/_dso-variables.scss
+++ b/src/styles/mixins/_dso-variables.scss
@@ -109,6 +109,7 @@ $dso-full-width-color: $grasgroen-10;
 $dso-row-divider-color: #d3ddd6;
 
 $asap-font-path: "../fonts/Asap/" !default;
+$dso-icons-path: "../" !default;
 
 $dso-footer-border-color: #bcbebd;
 


### PR DESCRIPTION
* Locatie van scg-icons.svg in variabele `$dso-icons-path` ondergebracht (default: `../`).