### PR TITLE
#767.Banner; WCAG verbeteringen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * Diverse library en build fixes (#890)
 * WCAG Navbalk verbeteren (#833)
-* **BREAKING**: sr-only tekst toevoeging bij status icoon banner (#767) **Markup changes, see PR #848**
+* **BREAKING**: Heading toevoeging bij banner om een beschrijving te geven bij het icoon (#767) **Markup changes, see PR #848**
 
 ### Fixed
 Search Bar border kleur gelijk maken aan invoerveld (#846)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Search Bar border kleur gelijk maken aan invoerveld (#846)
 * **BREAKING**: Bootstrap ingecheckt onder `/libs`: Geen node_modules dependency meer (#835) **Build changes, see PR #868**
 * **BREAKING**: sr-only tekst toevoeging bij status icoon alert (#765) **Markup changes, see PR #847**
 * **BREAKING**: List-button volgorde is niet logisch (#829) **Markup changes, see PR #831**
+* **BREAKING**: sr-only tekst toevoeging bij status icoon banner (#767) **Markup changes, see PR #848**
 
 ### Added
 * Nieuw component: Input Number (#797)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * Diverse library en build fixes (#890)
 * WCAG Navbalk verbeteren (#833)
+* **BREAKING**: sr-only tekst toevoeging bij status icoon banner (#767) **Markup changes, see PR #848**
 
 ### Fixed
 Search Bar border kleur gelijk maken aan invoerveld (#846)
@@ -28,7 +29,6 @@ Search Bar border kleur gelijk maken aan invoerveld (#846)
 * **BREAKING**: Bootstrap ingecheckt onder `/libs`: Geen node_modules dependency meer (#835) **Build changes, see PR #868**
 * **BREAKING**: sr-only tekst toevoeging bij status icoon alert (#765) **Markup changes, see PR #847**
 * **BREAKING**: List-button volgorde is niet logisch (#829) **Markup changes, see PR #831**
-* **BREAKING**: sr-only tekst toevoeging bij status icoon banner (#767) **Markup changes, see PR #848**
 
 ### Added
 * Nieuw component: Input Number (#797)

--- a/components/Componenten/banner/banner.config.yml
+++ b/components/Componenten/banner/banner.config.yml
@@ -7,17 +7,20 @@ collated: true
 context:
   __title: danger
   modifier: danger
+  sronly: "Fout:"
   message: <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
 variants:
   - name: warning
     context:
       __title: warning
       modifier: warning
+      sronly: "Waarschuwing:"
       message: <p>Op <strong>zondag 8 december 2019 van 10.00 uur tot 17.00 uur</strong> vindt er onderhoud plaats aan het Omgevingsloket. <a href="#">Meer informatie</a></p>
   - name: rich-content
     context:
       __title: rich content
       modifier: danger
+      sronly: "Fout:"
       message:
         <p>Banners zullen vaak worden ingezet voor 'one-liners', maar kunnen ook rijkere content bevatten, zoals meerdere paragrafen, en/of een geordende lijst. Zolang de markup maar aan de juiste voorschriften voldoet gaat dit prima:</p>
         <ul>

--- a/components/Componenten/banner/banner.config.yml
+++ b/components/Componenten/banner/banner.config.yml
@@ -7,20 +7,17 @@ collated: true
 context:
   __title: danger
   modifier: danger
-  sronly: "Fout:"
   message: <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
 variants:
   - name: warning
     context:
       __title: warning
       modifier: warning
-      sronly: "Waarschuwing:"
       message: <p>Op <strong>zondag 8 december 2019 van 10.00 uur tot 17.00 uur</strong> vindt er onderhoud plaats aan het Omgevingsloket. <a href="#">Meer informatie</a></p>
   - name: rich-content
     context:
       __title: rich content
       modifier: danger
-      sronly: "Fout:"
       message:
         <p>Banners zullen vaak worden ingezet voor 'one-liners', maar kunnen ook rijkere content bevatten, zoals meerdere paragrafen, en/of een geordende lijst. Zolang de markup maar aan de juiste voorschriften voldoet gaat dit prima:</p>
         <ul>

--- a/components/Componenten/banner/banner.njk
+++ b/components/Componenten/banner/banner.njk
@@ -2,11 +2,11 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
-      <span class="sr-only">{{ sronly }}</span>
-        {% render '@button', {type: 'button', modifier: 'link', label: 'Sluiten', icon: 'times', iconOnly: true} -%}
         <div class="dso-rich-content">
+          <span class="sr-only">{{ sronly }}</span>
           {{ message | safe }}
         </div>
+        {% render '@button', {type: 'button', modifier: 'link', label: 'Sluiten', icon: 'times', iconOnly: true} -%}
       </div>
     </div>
   </div>

--- a/components/Componenten/banner/banner.njk
+++ b/components/Componenten/banner/banner.njk
@@ -3,7 +3,14 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="dso-rich-content">
-          <span class="sr-only">{{ sronly }}</span>
+          <h2>
+          {% if modifier === "danger" -%}
+            Storingsmelding:
+          {%- endif %}
+          {%- if modifier === "warning" -%}
+            Onderhoudsmelding:
+          {%- endif %}
+          </h2>
           {{ message | safe }}
         </div>
         {% render '@button', {type: 'button', modifier: 'link', label: 'Sluiten', icon: 'times', iconOnly: true} -%}

--- a/components/Componenten/banner/banner.njk
+++ b/components/Componenten/banner/banner.njk
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
+      <span class="sr-only">{{ sronly }}</span>
         {% render '@button', {type: 'button', modifier: 'link', label: 'Sluiten', icon: 'times', iconOnly: true} -%}
         <div class="dso-rich-content">
           {{ message | safe }}

--- a/reference/render/banner--default.html
+++ b/reference/render/banner--default.html
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
+        <span class="sr-only">Fout:</span>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>

--- a/reference/render/banner--default.html
+++ b/reference/render/banner--default.html
@@ -3,7 +3,9 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="dso-rich-content">
-          <span class="sr-only">Fout:</span>
+          <h2>
+            Storingsmelding:
+          </h2>
           <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
         </div>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">

--- a/reference/render/banner--default.html
+++ b/reference/render/banner--default.html
@@ -2,13 +2,13 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
-        <span class="sr-only">Fout:</span>
+        <div class="dso-rich-content">
+          <span class="sr-only">Fout:</span>
+          <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
+        </div>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>
-        <div class="dso-rich-content">
-          <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
-        </div>
       </div>
     </div>
   </div>

--- a/reference/render/banner--rich-content.html
+++ b/reference/render/banner--rich-content.html
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
+        <span class="sr-only">Fout:</span>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>

--- a/reference/render/banner--rich-content.html
+++ b/reference/render/banner--rich-content.html
@@ -3,7 +3,9 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="dso-rich-content">
-          <span class="sr-only">Fout:</span>
+          <h2>
+            Storingsmelding:
+          </h2>
           <p>Banners zullen vaak worden ingezet voor 'one-liners', maar kunnen ook rijkere content bevatten, zoals meerdere paragrafen, en/of een geordende lijst. Zolang de markup maar aan de juiste voorschriften voldoet gaat dit prima:</p>
           <ul>
             <li>class <code>.dso-rich-content</code> op de omringende <code>&lt;div&gt;</code></li>

--- a/reference/render/banner--rich-content.html
+++ b/reference/render/banner--rich-content.html
@@ -2,17 +2,17 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
-        <span class="sr-only">Fout:</span>
-        <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
-            <use href="../../dso-icons.svg#times" />
-          </svg></button>
         <div class="dso-rich-content">
+          <span class="sr-only">Fout:</span>
           <p>Banners zullen vaak worden ingezet voor 'one-liners', maar kunnen ook rijkere content bevatten, zoals meerdere paragrafen, en/of een geordende lijst. Zolang de markup maar aan de juiste voorschriften voldoet gaat dit prima:</p>
           <ul>
             <li>class <code>.dso-rich-content</code> op de omringende <code>&lt;div&gt;</code></li>
             <li>een <code>&lt;p&gt;</code>-tag om paragrafen</li>
           </ul>
         </div>
+        <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
+            <use href="../../dso-icons.svg#times" />
+          </svg></button>
       </div>
     </div>
   </div>

--- a/reference/render/banner--warning.html
+++ b/reference/render/banner--warning.html
@@ -2,13 +2,13 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
-        <span class="sr-only">Waarschuwing:</span>
+        <div class="dso-rich-content">
+          <span class="sr-only">Waarschuwing:</span>
+          <p>Op <strong>zondag 8 december 2019 van 10.00 uur tot 17.00 uur</strong> vindt er onderhoud plaats aan het Omgevingsloket. <a href="#">Meer informatie</a></p>
+        </div>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>
-        <div class="dso-rich-content">
-          <p>Op <strong>zondag 8 december 2019 van 10.00 uur tot 17.00 uur</strong> vindt er onderhoud plaats aan het Omgevingsloket. <a href="#">Meer informatie</a></p>
-        </div>
       </div>
     </div>
   </div>

--- a/reference/render/banner--warning.html
+++ b/reference/render/banner--warning.html
@@ -3,7 +3,9 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="dso-rich-content">
-          <span class="sr-only">Waarschuwing:</span>
+          <h2>
+            Onderhoudsmelding:
+          </h2>
           <p>Op <strong>zondag 8 december 2019 van 10.00 uur tot 17.00 uur</strong> vindt er onderhoud plaats aan het Omgevingsloket. <a href="#">Meer informatie</a></p>
         </div>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">

--- a/reference/render/banner--warning.html
+++ b/reference/render/banner--warning.html
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
+        <span class="sr-only">Waarschuwing:</span>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>

--- a/reference/render/pagina-met-banner.html
+++ b/reference/render/pagina-met-banner.html
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
+        <span class="sr-only">Fout:</span>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>

--- a/reference/render/pagina-met-banner.html
+++ b/reference/render/pagina-met-banner.html
@@ -3,7 +3,9 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="dso-rich-content">
-          <span class="sr-only">Fout:</span>
+          <h2>
+            Storingsmelding:
+          </h2>
           <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
         </div>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">

--- a/reference/render/pagina-met-banner.html
+++ b/reference/render/pagina-met-banner.html
@@ -2,13 +2,13 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-12">
-        <span class="sr-only">Fout:</span>
+        <div class="dso-rich-content">
+          <span class="sr-only">Fout:</span>
+          <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
+        </div>
         <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
             <use href="../../dso-icons.svg#times" />
           </svg></button>
-        <div class="dso-rich-content">
-          <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
-        </div>
       </div>
     </div>
   </div>

--- a/src/styles/components/_banner.scss
+++ b/src/styles/components/_banner.scss
@@ -18,7 +18,9 @@ $dso-banner-left-padding: $u6;
       }
 
       button {
-        float: right;
+        position: absolute;
+        right: $u2;
+        top: 0;
 
         svg.di {
           color: $zwart;
@@ -30,6 +32,8 @@ $dso-banner-left-padding: $u6;
       }
 
       > .dso-rich-content {
+        padding-right: $u3;
+
         *:first-child {
           margin-top: 0;
         }

--- a/src/styles/components/_banner.scss
+++ b/src/styles/components/_banner.scss
@@ -34,6 +34,27 @@ $dso-banner-left-padding: $u6;
       > .dso-rich-content {
         padding-right: $u3;
 
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+          color: $zwart;
+          display: inline-block;
+          font-size: 1rem;
+          line-height: $line-height-base;
+          margin-bottom: 0;
+
+          + p {
+            display: inline;
+
+            + * {
+              margin-top: $u2;
+            }
+          }
+        }
+
         *:first-child {
           margin-top: 0;
         }


### PR DESCRIPTION
## Markup change "banner"

Dit is een breaking change, markupvoorschrift is gewijzigd.

---
Er is een toevoeging gedaan met betrekking tot een heading voor de banner tekst. Voor de melding moet een `<h2>` (of bij uitzondering een andere heading, zie documentatie) worden toegevoegd waar de volgende teksten in kunnen staan (let op de dubbele punt):

- danger > `<h2>Storingsmelding:</h2>`
- warning >  `<h2>Onderhoudsmelding:</h2>`

Een valide banner kan er zo uit zien:

```
<section class="banner alert-danger" role="alert">
  <div class="container">
    <div class="row">
      <div class="col-sm-12">
        <div class="dso-rich-content">
          <h2>
          Storingsmelding:
          </h2>
          <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
        </div>
        <button type="button" class="btn btn-link"><span class="sr-only">Sluiten</span><svg class="di di-times">
  <use href="/dso-icons.svg#times"></use>
</svg></button>
</div>
    </div>
  </div>
</section>
```