### PR TITLE
#910.Pager deprecaten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+## Changed
+* **styling:** Pager deprecaten ([#910](https://github.com/dso-toolkit/dso-toolkit/issues/910))
+
 ## 16.0.1 - 2020-01-04
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
-## Changed
-* **styling:** Pager deprecaten ([#910](https://github.com/dso-toolkit/dso-toolkit/issues/910))
+### Deprecated
+* **styling:** Pager deprecaten ([#910](https://github.com/dso-toolkit/dso-toolkit/issues/910)) **Deprecation notice, see PR ([#924](https://github.com/dso-toolkit/dso-toolkit/pull/924))**
 
 ## 16.0.1 - 2020-01-04
 

--- a/packages/dso-toolkit/src/styles/components/_pager.scss
+++ b/packages/dso-toolkit/src/styles/components/_pager.scss
@@ -3,7 +3,7 @@ $dso-pager-border-width: $dso-button-border-width;
 $dso-pager-height: $u6;
 
 .pager { // DEPRECATED
-  background-color: $brand-danger;
+  background-color: $dso-invalid-color;
 
   li {
     > a,

--- a/packages/dso-toolkit/src/styles/components/_pager.scss
+++ b/packages/dso-toolkit/src/styles/components/_pager.scss
@@ -2,7 +2,9 @@ $dso-pager-icon-space: $dso-unit / 2;
 $dso-pager-border-width: $dso-button-border-width;
 $dso-pager-height: $u6;
 
-.pager {
+.pager { // DEPRECATED
+  background-color: $brand-danger;
+
   li {
     > a,
     > span {


### PR DESCRIPTION
## Deprecation notice "Pager"

Dit is geen breaking change, enkel een deprecation notice.

---
`.pager` zal niet weldra niet meer in de styling voorkomen: er was namelijk al geen markup voorschrift voor, het component en z'n voorbeelden zijn verwijderd in #604 (toen werd het `form-pager`) en deze is uiteindelijk in #670 verwijderd.