### PR TITLE
#929.grote whiteboxes aanpassingen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Changed
 * **dso-toolkit:** Toelichting direct onder/na de vraag ([#906](https://github.com/dso-toolkit/dso-toolkit/issues/906))
 * **dso-toolkit + styling:** Consequente styling van anchor links in lopende tekst ([#895](https://github.com/dso-toolkit/dso-toolkit/issues/895))
+* **dso-toolkit:** "Grote" Whiteboxes aanpassingen ([#929](https://github.com/dso-toolkit/dso-toolkit/issues/929))
 
 ### Fixed
 * **styling:** Tertiaire button grasgroen in highlightbox met witte achtergrond ([#925](https://github.com/dso-toolkit/dso-toolkit/issues/925))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Changed
 * **dso-toolkit:** Toelichting direct onder/na de vraag ([#906](https://github.com/dso-toolkit/dso-toolkit/issues/906))
 * **dso-toolkit + styling:** Consequente styling van anchor links in lopende tekst ([#895](https://github.com/dso-toolkit/dso-toolkit/issues/895))
-* **dso-toolkit:** "Grote" Whiteboxes aanpassingen ([#929](https://github.com/dso-toolkit/dso-toolkit/issues/929))
+* **BREAKING:** **dso-toolkit:** "Grote" Whiteboxes aanpassingen ([#929](https://github.com/dso-toolkit/dso-toolkit/issues/929)) **Markup changes, see PR ([#948](https://github.com/dso-toolkit/dso-toolkit/issues/948))**
 
 ### Fixed
 * **styling:** Tertiaire button grasgroen in highlightbox met witte achtergrond ([#925](https://github.com/dso-toolkit/dso-toolkit/issues/925))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Changed
 * **dso-toolkit:** Toelichting direct onder/na de vraag ([#906](https://github.com/dso-toolkit/dso-toolkit/issues/906))
 * **dso-toolkit + styling:** Consequente styling van anchor links in lopende tekst ([#895](https://github.com/dso-toolkit/dso-toolkit/issues/895))
-* **BREAKING:** **dso-toolkit:** "Grote" Whiteboxes aanpassingen ([#929](https://github.com/dso-toolkit/dso-toolkit/issues/929)) **Markup changes, see PR ([#948](https://github.com/dso-toolkit/dso-toolkit/issues/948))**
+* **BREAKING:** **dso-toolkit + styling:** "Grote" Whiteboxes aanpassingen ([#929](https://github.com/dso-toolkit/dso-toolkit/issues/929)) **Markup changes, see PR ([#948](https://github.com/dso-toolkit/dso-toolkit/issues/948))**
 
 ### Fixed
 * **styling:** Tertiaire button grasgroen in highlightbox met witte achtergrond ([#925](https://github.com/dso-toolkit/dso-toolkit/issues/925))

--- a/packages/dso-toolkit/components/Componenten/whitebox/whitebox.njk
+++ b/packages/dso-toolkit/components/Componenten/whitebox/whitebox.njk
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row dso-equal-heights">
   <div class="col-lg-2 col-md-4 col-xs-6">
     {% render '@whitebox-small' -%}
   </div>
@@ -19,7 +19,7 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row dso-equal-heights">
   <div class="col-md-4 col-sm-6 col-xs-12 ">
     {% render '@whitebox-regular' -%}
   </div>
@@ -31,7 +31,7 @@
   </div>
 </div>
 
-<div class="row">
+<div class="row dso-equal-heights">
   {% for column in columns %}
     <div {{ className(column.modifier) }}>
       {% render '@whitebox-regular', column.whitebox, true %}

--- a/packages/dso-toolkit/components/Voorbeelden/Homepage.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/Homepage.njk
@@ -49,7 +49,7 @@
     </div>
   </div>
   <h1 class="text-center">Waarmee kunnen we u helpen?</h1>
-  <div class="row dso-featured">
+  <div class="row dso-equal-heights dso-featured">
     <div class="col-md-4 col-sm-6 col-xs-12">
       {% render '@whitebox-regular', {title: vergunning.title, description: vergunning.description, linktext: vergunning.linktext, source: vergunning.source} -%}
     </div>

--- a/packages/dso-toolkit/reference/render/homepage.html
+++ b/packages/dso-toolkit/reference/render/homepage.html
@@ -138,7 +138,7 @@
     </div>
   </div>
   <h1 class="text-center">Waarmee kunnen we u helpen?</h1>
-  <div class="row dso-featured">
+  <div class="row dso-equal-heights dso-featured">
     <div class="col-md-4 col-sm-6 col-xs-12">
       <div class="dso-whitebox">
         <div class="dso-whitebox-title">

--- a/packages/dso-toolkit/reference/render/whitebox.html
+++ b/packages/dso-toolkit/reference/render/whitebox.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row dso-equal-heights">
   <div class="col-lg-2 col-md-4 col-xs-6">
     <div class="dso-whitebox-small">
       <a href="#">
@@ -72,7 +72,7 @@
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row dso-equal-heights">
   <div class="col-md-4 col-sm-6 col-xs-12 ">
     <div class="dso-whitebox">
       <div class="dso-whitebox-title">
@@ -128,7 +128,7 @@
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row dso-equal-heights">
   <div class="col-md-3 col-sm-6 col-xs-12">
     <div class="dso-whitebox dso-has-counter">
       <div class="dso-step-counter">

--- a/packages/dso-toolkit/src/styles/components/_whitebox.scss
+++ b/packages/dso-toolkit/src/styles/components/_whitebox.scss
@@ -1,6 +1,9 @@
+$dso-highlight-box-box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+$dso-whitebox-box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+
 .dso-whitebox {
   background: $wit;
-  box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+  box-shadow: $dso-whitebox-box-shadow;
   margin-bottom: $dso-whitebox-margin-bottom;
   padding: $u2 $u3;
   position: relative;
@@ -33,7 +36,7 @@
 
 .dso-whitebox-small {
   background: $wit;
-  box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+  box-shadow: $dso-whitebox-box-shadow;
   margin-bottom: $dso-whitebox-small-margin-bottom;
   min-height: $dso-whitebox-small-min-height;
   padding: $u3 $u2 $u2;

--- a/packages/dso-toolkit/src/styles/components/_whitebox.scss
+++ b/packages/dso-toolkit/src/styles/components/_whitebox.scss
@@ -2,14 +2,15 @@
   background: $wit;
   box-shadow: 0 6px $u1 0 $opac10, 0 6px $u1 0 $opac10;
   margin-bottom: $dso-whitebox-margin-bottom;
-  min-height: $dso-whitebox-min-height;
-  padding: $u2 $u3 0;
+  // min-height: $dso-whitebox-min-height;
+  padding: $u2 $u3;
   position: relative;
   top: $u7;
 
   .dso-whitebox-title {
     h2 {
       margin: 0 0 $u6;
+      text-align: center;
     }
   }
 
@@ -28,9 +29,9 @@
     }
   }
 
-  &.dso-has-counter {
-    min-height: $dso-whitebox-min-height + $u5;
-  }
+  // &.dso-has-counter {
+  //   min-height: $dso-whitebox-min-height + $u5;
+  // }
 
   @include step-counter();
 }

--- a/packages/dso-toolkit/src/styles/components/_whitebox.scss
+++ b/packages/dso-toolkit/src/styles/components/_whitebox.scss
@@ -1,8 +1,7 @@
 .dso-whitebox {
   background: $wit;
-  box-shadow: 0 6px $u1 0 $opac10, 0 6px $u1 0 $opac10;
+  box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
   margin-bottom: $dso-whitebox-margin-bottom;
-  // min-height: $dso-whitebox-min-height;
   padding: $u2 $u3;
   position: relative;
   top: $u7;
@@ -29,16 +28,12 @@
     }
   }
 
-  // &.dso-has-counter {
-  //   min-height: $dso-whitebox-min-height + $u5;
-  // }
-
   @include step-counter();
 }
 
 .dso-whitebox-small {
   background: $wit;
-  box-shadow: 0 6px $u1 0 $opac10, 0 6px $u1 0 $opac10;
+  box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
   margin-bottom: $dso-whitebox-small-margin-bottom;
   min-height: $dso-whitebox-small-min-height;
   padding: $u3 $u2 $u2;

--- a/packages/dso-toolkit/src/styles/components/_whitebox.scss
+++ b/packages/dso-toolkit/src/styles/components/_whitebox.scss
@@ -1,5 +1,4 @@
-$dso-highlight-box-box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
-$dso-whitebox-box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+$dso-whitebox-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
 
 .dso-whitebox {
   background: $wit;

--- a/packages/styling/components/highlight-box.scss
+++ b/packages/styling/components/highlight-box.scss
@@ -17,7 +17,7 @@ $dso-highlight-box-margin-top: $dso-shared-equal-heights-highlight-box-height;
   }
 
   &.dso-drop-shadow {
-    box-shadow: 0 6px $u1 0 $opac10, 0 6px $u1 0 $opac10;
+    box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
   }
 
   &.dso-border {

--- a/packages/styling/components/highlight-box.scss
+++ b/packages/styling/components/highlight-box.scss
@@ -2,7 +2,7 @@
 @import "../mixins/step-counter";
 
 $dso-highlight-box-margin-top: $dso-shared-equal-heights-highlight-box-height;
-$dso-highlight-box-box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+$dso-highlight-box-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
 
 .dso-highlight-box {
   background-color: $grijs-10;

--- a/packages/styling/components/highlight-box.scss
+++ b/packages/styling/components/highlight-box.scss
@@ -2,6 +2,7 @@
 @import "../mixins/step-counter";
 
 $dso-highlight-box-margin-top: $dso-shared-equal-heights-highlight-box-height;
+$dso-highlight-box-box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
 
 .dso-highlight-box {
   background-color: $grijs-10;
@@ -17,7 +18,7 @@ $dso-highlight-box-margin-top: $dso-shared-equal-heights-highlight-box-height;
   }
 
   &.dso-drop-shadow {
-    box-shadow: 0 4px 8px 0 rgba(0, 0 , 0, .2);
+    box-shadow: $dso-highlight-box-box-shadow;
   }
 
   &.dso-border {


### PR DESCRIPTION
**Breaking** Markup change: de `min-height` is van de `dso-whitebox` en 'dso-whitebox-small` gehaald. Als het nodig is dat de whiteboxes even hoog zijn, dan moet op de omliggende `div.row` de class `dso-equal-heights` toegevoegd worden (https://www.dso-toolkit.nl/16.0.0/components/detail/row-equal-heights.html).