### PR TITLE
#928 voorbeeldpagina aanpassingen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Fixed
+* Voorbeeld pagina's updates en fixes (#928)
+
 ## 17.1.0
 
 ### Fixed

--- a/packages/dso-toolkit/components/Voorbeelden/Zoeken-in-lijst-cards.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/Zoeken-in-lijst-cards.njk
@@ -47,7 +47,11 @@
         </div>
       </div>
       <div class="col-md-4">
-        <h2 class="dso-steps-indicator">Filters</h2>
+        <div class="row">
+          <div class="col-md-12">
+            <h2 class="dso-steps-indicator">Filters</h2>
+          </div>
+        </div>
         <div class="row">
           <div class="col-md-12">
             <form>

--- a/packages/dso-toolkit/components/Voorbeelden/accordion-table.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/accordion-table.njk
@@ -7,8 +7,8 @@
       <th scope="col">Status</th>
       <th scope="col">Ingediend</th>
       <th scope="col">Type</th>
-      <th scope="col" width="50"></th>
-      <th scope="col" width="250"></th>
+      <th scope="col" width="50"><span class="sr-only">Bijlagen</span></th>
+      <th scope="col" width="250"><span class="sr-only">Acties</span></th>
     </tr>
   </thead>
   <tbody>

--- a/packages/dso-toolkit/components/Voorbeelden/beheer-basis.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/beheer-basis.njk
@@ -9,26 +9,41 @@
   </div>
   <hr>
   <div class="row">
-    <div class="col-md-6">
-      <dl>
-        <dt>Organisator</dt>
-        <dd>Gemeente Rotterdam</dd>
-        <dt>Verzoeknummer:</dt>
-        <dd>12123497987</dd>
-        <dt>Status:</dt>
-        <dd>Open</dd>
-        <dt>Creatie datum:</dt>
-        <dd>17-12-2019</dd>
-      </dl>
-    </div>
-    <div class="col-md-6">
-      <dl>
-        <dt>Contactpersoon:</dt>
-        <dd>Jan van Veen</dd>
-        <dt>Emailadres:</dt>
-        <dd>j.veen@testmail.nl</dd>
-        <dt>Telefoonnummer:</dt>
-        <dd>06-12345678</dd>
+    <div class="col-md-12">
+      <dl class="dso-columns dso-3-columns">
+        <div>
+            <dt>Aangemaakt door:</dt>
+            <dd>Gemeente Rotterdam</dd>
+        </div>
+        <div>
+            <dt>Verzoeknummer:</dt>
+            <dd>12123497987</dd>
+        </div>
+        <div>
+            <dt>Status:</dt>
+            <dd>Open</dd>
+        </div>
+        <div>
+            <dt>Contactpersoon:</dt>
+            <dd>Jan van Veen</dd>
+        </div>
+        <div>
+            <dt>Emailadres:</dt>
+            <dd>j.veen@testmail.nl</dd>
+        </div>
+
+        <div>
+            <dt>Telefoonnummer:</dt>
+            <dd>06-12345678</dd>
+        </div>
+        <div>
+            <dt>Creatie datum:</dt>
+            <dd>17-12-2019</dd>
+        </div>
+        <div>
+            <dt>Beschrijving:</dt>
+            <dd>-</dd>
+        </div>
       </dl>
     </div>
   </div>
@@ -36,98 +51,100 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Subtitel voor het tabeloverzicht</h2>
-      <table class="table">
-        <caption class="sr-only">Titel van de tabel voor screenreaders</caption>
-        <thead>
-          <tr>
-            <th scope="col">Ketenpartner</th>
-            <th scope="col">Toegang</th>
-            <th scope="col">Acties</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Gemeente Den Haag</td>
-            <td>Alle documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Rotterdam</td>
-            <td>Alle documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente IJsselstein</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Delft</td>
-            <td>Alle documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Eindhoven</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Tilburg</td>
-            <td>Alle documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Breda</td>
-            <td>Alle documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Maastricht</td>
-            <td>Alle documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Amsterdam</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Utrecht</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
-              {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="dso-table-responsive">
+        <table class="table">
+          <caption class="sr-only">Titel van de tabel voor screenreaders</caption>
+          <thead>
+            <tr>
+              <th scope="col">Ketenpartner</th>
+              <th scope="col">Toegang</th>
+              <th scope="col">Acties</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Gemeente Den Haag</td>
+              <td>Alle documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Rotterdam</td>
+              <td>Alle documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente IJsselstein</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Delft</td>
+              <td>Alle documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Eindhoven</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Tilburg</td>
+              <td>Alle documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Breda</td>
+              <td>Alle documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Maastricht</td>
+              <td>Alle documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Amsterdam</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Utrecht</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                {% render '@button', {type:'button', modifier:'link', label:'Bewerk', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Verwijder', icon:'trash', iconOnly:true} %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/packages/dso-toolkit/components/Voorbeelden/samenwerken.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/samenwerken.njk
@@ -8,38 +8,40 @@
   </div>
   <div class="row">
     <div class="col-md-3">
-      {% render '@button', {label:'samenwerking toevoegen', type:'button', modifier:'link', icon:'plus'} %}
+      {% render '@button', {label:'Samenwerking toevoegen', type:'button', modifier:'default'} %}
     </div>
   </div>
   <div class="row">
     <div class="col-md-12">
-      <table class="table">
-        <caption class="sr-only">Table met alle samenwerkingen</caption>
-        <thead>
-          <tr>
-            <th scope="col">Naam samenwerking</th>
-            <th scope="col">Status</th>
-            <th scope="col">Initiator</th>
-            <th scope="col">Verzoeknummer</th>
-            <th scope="col">Vertrouwelijkheid</th>
-            <th></th>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><a href="#fabien" ><b>Aanleg rondweg Leiden</b></a></td>
-            <td>Open</td>
-            <td>Gemeente Den Haag</td>
-            <td>123456789123</td>
-            <td>Geheim</td>
-            <td>{% render '@anchor', {url:'#', modifier:'btn btn-link', label:'Gebruikers', icon:'users', iconOnly:true} %}</td>
-            <td>{% render '@anchor', {url:'#', modifier:'btn btn-link', label:'Gegevens wijzigen', icon:'pencil', iconOnly:true} %}</td>
-            <td>{% render '@button', {type:'button', modifier:'link pull-right', label:'Openen', icon:'angle-right'} %}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="dso-table-responsive">
+        <table class="table">
+          <caption class="sr-only">Table met alle samenwerkingen</caption>
+          <thead>
+            <tr>
+              <th scope="col">Naam samenwerking</th>
+              <th scope="col">Status</th>
+              <th scope="col">Initiator</th>
+              <th scope="col">Verzoeknummer</th>
+              <th scope="col">Vertrouwelijkheid</th>
+              <th>Acties</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="#fabien" ><b>Aanleg rondweg Leiden</b></a></td>
+              <td>Open</td>
+              <td>Gemeente Den Haag</td>
+              <td>123456789123</td>
+              <td>Geheim</td>
+              <td class="text-right">
+                {% render '@anchor', {url:'#', modifier:'btn btn-link', label:'Gebruikers', icon:'users', iconOnly:true} %}
+                {% render '@anchor', {url:'#', modifier:'btn btn-link', label:'Gegevens wijzigen', icon:'pencil', iconOnly:true} %}
+                {% render '@button', {type:'button', modifier:'link', label:'Openen', icon:'angle-right'} %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </main>

--- a/packages/dso-toolkit/reference/render/accordion-table.html
+++ b/packages/dso-toolkit/reference/render/accordion-table.html
@@ -7,8 +7,8 @@
       <th scope="col">Status</th>
       <th scope="col">Ingediend</th>
       <th scope="col">Type</th>
-      <th scope="col" width="50"></th>
-      <th scope="col" width="250"></th>
+      <th scope="col" width="50"><span class="sr-only">Bijlagen</span></th>
+      <th scope="col" width="250"><span class="sr-only">Acties</span></th>
     </tr>
   </thead>
   <tbody>

--- a/packages/dso-toolkit/reference/render/beheer-basis.html
+++ b/packages/dso-toolkit/reference/render/beheer-basis.html
@@ -58,26 +58,40 @@
   </div>
   <hr>
   <div class="row">
-    <div class="col-md-6">
-      <dl>
-        <dt>Organisator</dt>
-        <dd>Gemeente Rotterdam</dd>
-        <dt>Verzoeknummer:</dt>
-        <dd>12123497987</dd>
-        <dt>Status:</dt>
-        <dd>Open</dd>
-        <dt>Creatie datum:</dt>
-        <dd>17-12-2019</dd>
-      </dl>
-    </div>
-    <div class="col-md-6">
-      <dl>
-        <dt>Contactpersoon:</dt>
-        <dd>Jan van Veen</dd>
-        <dt>Emailadres:</dt>
-        <dd>j.veen@testmail.nl</dd>
-        <dt>Telefoonnummer:</dt>
-        <dd>06-12345678</dd>
+    <div class="col-md-12">
+      <dl class="dso-columns dso-3-columns">
+        <div>
+          <dt>Aangemaakt door:</dt>
+          <dd>Gemeente Rotterdam</dd>
+        </div>
+        <div>
+          <dt>Verzoeknummer:</dt>
+          <dd>12123497987</dd>
+        </div>
+        <div>
+          <dt>Status:</dt>
+          <dd>Open</dd>
+        </div>
+        <div>
+          <dt>Contactpersoon:</dt>
+          <dd>Jan van Veen</dd>
+        </div>
+        <div>
+          <dt>Emailadres:</dt>
+          <dd>j.veen@testmail.nl</dd>
+        </div>
+        <div>
+          <dt>Telefoonnummer:</dt>
+          <dd>06-12345678</dd>
+        </div>
+        <div>
+          <dt>Creatie datum:</dt>
+          <dd>17-12-2019</dd>
+        </div>
+        <div>
+          <dt>Beschrijving:</dt>
+          <dd>-</dd>
+        </div>
       </dl>
     </div>
   </div>
@@ -85,118 +99,120 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Subtitel voor het tabeloverzicht</h2>
-      <table class="table">
-        <caption class="sr-only">Titel van de tabel voor screenreaders</caption>
-        <thead>
-          <tr>
-            <th scope="col">Ketenpartner</th>
-            <th scope="col">Toegang</th>
-            <th scope="col">Acties</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Gemeente Den Haag</td>
-            <td>Alle documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Rotterdam</td>
-            <td>Alle documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente IJsselstein</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Delft</td>
-            <td>Alle documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Eindhoven</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Tilburg</td>
-            <td>Alle documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Breda</td>
-            <td>Alle documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Maastricht</td>
-            <td>Alle documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Amsterdam</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-          <tr>
-            <td>Gemeente Utrecht</td>
-            <td>Alleen niet vertrouwelijke documenten</td>
-            <td>
-              <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
-                <dso-icon icon="pencil"></dso-icon></button>
-              <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
-                <dso-icon icon="trash"></dso-icon></button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="dso-table-responsive">
+        <table class="table">
+          <caption class="sr-only">Titel van de tabel voor screenreaders</caption>
+          <thead>
+            <tr>
+              <th scope="col">Ketenpartner</th>
+              <th scope="col">Toegang</th>
+              <th scope="col">Acties</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Gemeente Den Haag</td>
+              <td>Alle documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Rotterdam</td>
+              <td>Alle documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente IJsselstein</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Delft</td>
+              <td>Alle documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Eindhoven</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Tilburg</td>
+              <td>Alle documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Breda</td>
+              <td>Alle documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Maastricht</td>
+              <td>Alle documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Amsterdam</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+            <tr>
+              <td>Gemeente Utrecht</td>
+              <td>Alleen niet vertrouwelijke documenten</td>
+              <td>
+                <button type="button" class="btn btn-link"><span class="sr-only">Bewerk</span>
+                  <dso-icon icon="pencil"></dso-icon></button>
+                <button type="button" class="btn btn-link"><span class="sr-only">Verwijder</span>
+                  <dso-icon icon="trash"></dso-icon></button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/packages/dso-toolkit/reference/render/samenwerken.html
+++ b/packages/dso-toolkit/reference/render/samenwerken.html
@@ -52,47 +52,44 @@
   </div>
   <div class="row">
     <div class="col-md-3">
-      <button type="button" class="btn btn-link">
-        <dso-icon icon="plus"></dso-icon><span >samenwerking toevoegen</span>
-      </button>
+      <button type="button" class="btn btn-default"><span >Samenwerking toevoegen</span></button>
     </div>
   </div>
   <div class="row">
     <div class="col-md-12">
-      <table class="table">
-        <caption class="sr-only">Table met alle samenwerkingen</caption>
-        <thead>
-          <tr>
-            <th scope="col">Naam samenwerking</th>
-            <th scope="col">Status</th>
-            <th scope="col">Initiator</th>
-            <th scope="col">Verzoeknummer</th>
-            <th scope="col">Vertrouwelijkheid</th>
-            <th></th>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><a href="#fabien"><b>Aanleg rondweg Leiden</b></a></td>
-            <td>Open</td>
-            <td>Gemeente Den Haag</td>
-            <td>123456789123</td>
-            <td>Geheim</td>
-            <td><a href="#" title="Gebruikers" class="btn btn-link"><span class="sr-only">Gebruikers</span>
-                <dso-icon icon="users"></dso-icon></a>
-            </td>
-            <td><a href="#" title="Gegevens wijzigen" class="btn btn-link"><span class="sr-only">Gegevens wijzigen</span>
-                <dso-icon icon="pencil"></dso-icon></a>
-            </td>
-            <td><button type="button" class="btn btn-link pull-right">
-                <dso-icon icon="angle-right"></dso-icon><span >Openen</span>
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="dso-table-responsive">
+        <table class="table">
+          <caption class="sr-only">Table met alle samenwerkingen</caption>
+          <thead>
+            <tr>
+              <th scope="col">Naam samenwerking</th>
+              <th scope="col">Status</th>
+              <th scope="col">Initiator</th>
+              <th scope="col">Verzoeknummer</th>
+              <th scope="col">Vertrouwelijkheid</th>
+              <th>Acties</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="#fabien"><b>Aanleg rondweg Leiden</b></a></td>
+              <td>Open</td>
+              <td>Gemeente Den Haag</td>
+              <td>123456789123</td>
+              <td>Geheim</td>
+              <td class="text-right">
+                <a href="#" title="Gebruikers" class="btn btn-link"><span class="sr-only">Gebruikers</span>
+                  <dso-icon icon="users"></dso-icon></a>
+                <a href="#" title="Gegevens wijzigen" class="btn btn-link"><span class="sr-only">Gegevens wijzigen</span>
+                  <dso-icon icon="pencil"></dso-icon></a>
+                <button type="button" class="btn btn-link">
+                  <dso-icon icon="angle-right"></dso-icon><span >Openen</span>
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </main>

--- a/packages/dso-toolkit/reference/render/zoeken-in-lijst-cards.html
+++ b/packages/dso-toolkit/reference/render/zoeken-in-lijst-cards.html
@@ -162,7 +162,11 @@
         </div>
       </div>
       <div class="col-md-4">
-        <h2 class="dso-steps-indicator">Filters</h2>
+        <div class="row">
+          <div class="col-md-12">
+            <h2 class="dso-steps-indicator">Filters</h2>
+          </div>
+        </div>
         <div class="row">
           <div class="col-md-12">
             <form>


### PR DESCRIPTION
Aanpassingen aan: 

Beheerbasis -> Definition list implementatie uit toolkit opgenomen, table responsive toegevoegd
Samenwerken - > Table responsive toegevoegd en lege th verwijderdt ivm toegankelijkheid
Accordion table -> sr only span toegevoegd zodat headers een definitie hebben ivm met toegankelijkheid. (Voorstel bij Tim bij PR02 tabellen hier toegepast) 
Zoeken in lijst cards-> Row en cols aan h2 filters toegevoegd. Deze drukte de daadwerkelijke filters aan de kant. 