### PR TITLE
#996.dso-info-moet-buiten-legend-staan

### DIFF
--- a/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.njk
@@ -1,8 +1,9 @@
 {% set localId = generateLocalId(prefix, id ) %}
 
 <fieldset {{ className('form-group', 'dso-checkboxes', [state, 'dso-' + state], [required, 'dso-required']) }}>
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">{{ label }}</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       {{ label }}
     </span>
     {% if infoText %}
@@ -11,7 +12,7 @@
     {% if infoOpen %}
       {% render '@info', {infoText: infoText} %}
     {% endif %}
-  </legend>
+  </div>
   <div class="dso-field-container">
     {% for option in options %}
       <div class="dso-selectable">

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-radios.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-radios.njk
@@ -1,8 +1,9 @@
 {% set localId = generateLocalId(prefix, id) %}
 
 <fieldset {{ className('form-group', 'dso-radios', [state, 'dso-' + state], [inline, 'dso-inline'], [required, 'dso-required']) }}{% if helpText %} aria-describedby="helpTextId_{{ id }}"{% endif%}>
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">{{ label }}</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       {{ label }}
     </span>
     {% if infoText %}
@@ -11,7 +12,7 @@
     {% if infoOpen %}
       {% render '@info', {infoText: infoText} %}
     {% endif %}
-  </legend>
+  </div>
   <div class="dso-field-container">
     {% for option in options %}
       <div class="dso-selectable">

--- a/packages/dso-toolkit/reference/render/accordion--default-met-formulier.html
+++ b/packages/dso-toolkit/reference/render/accordion--default-met-formulier.html
@@ -15,11 +15,12 @@
         </div>
       </div>
       <fieldset class="form-group dso-radios">
-        <legend class="dso-label-container">
-          <span class="control-label">
+        <legend class="sr-only">Brandstof</legend>
+        <div class="dso-label-container">
+          <span class="control-label" aria-hidden>
       Brandstof
     </span>
-        </legend>
+        </div>
         <div class="dso-field-container">
           <div class="dso-selectable">
             <input type="radio" id="brandstof-0" name="brandstof" value="1">
@@ -36,11 +37,12 @@
         </div>
       </fieldset>
       <fieldset class="form-group dso-radios">
-        <legend class="dso-label-container">
-          <span class="control-label">
+        <legend class="sr-only">Schrijfwaar</legend>
+        <div class="dso-label-container">
+          <span class="control-label" aria-hidden>
       Schrijfwaar
     </span>
-        </legend>
+        </div>
         <div class="dso-field-container">
           <div class="dso-selectable">
             <input type="radio" id="schrijfwaar-0" name="schrijfwaar" value="1">
@@ -97,11 +99,12 @@
         </div>
       </div>
       <fieldset class="form-group dso-radios">
-        <legend class="dso-label-container">
-          <span class="control-label">
+        <legend class="sr-only">Type melder</legend>
+        <div class="dso-label-container">
+          <span class="control-label" aria-hidden>
       Type melder
     </span>
-        </legend>
+        </div>
         <div class="dso-field-container">
           <div class="dso-selectable">
             <input type="radio" id="type_melder-0" name="type_melder" value="particulier">
@@ -183,11 +186,12 @@
       <fieldset>
         <legend>Melder gegevens</legend>
         <fieldset class="form-group dso-radios">
-          <legend class="dso-label-container">
-            <span class="control-label">
+          <legend class="sr-only">Type melder</legend>
+          <div class="dso-label-container">
+            <span class="control-label" aria-hidden>
       Type melder
     </span>
-          </legend>
+          </div>
           <div class="dso-field-container">
             <div class="dso-selectable">
               <input type="radio" id="type_melder-0" name="type_melder" value="particulier">

--- a/packages/dso-toolkit/reference/render/dialog--invalid.html
+++ b/packages/dso-toolkit/reference/render/dialog--invalid.html
@@ -8,11 +8,12 @@
     </div>
     <div class="dso-body">
       <fieldset class="form-group dso-checkboxes">
-        <legend class="dso-label-container">
-          <span class="control-label">
+        <legend class="sr-only">Alle activiteiten</legend>
+        <div class="dso-label-container">
+          <span class="control-label" aria-hidden>
       Alle activiteiten
     </span>
-        </legend>
+        </div>
         <div class="dso-field-container">
           <div class="dso-selectable">
             <input type="checkbox" id="alle-activiteiten-0" name="alle-activiteiten" value="bouwactiviteit-vergunning">

--- a/packages/dso-toolkit/reference/render/form--form-horizontal.html
+++ b/packages/dso-toolkit/reference/render/form--form-horizontal.html
@@ -212,11 +212,12 @@
   <fieldset>
     <legend>Aanhanger</legend>
     <fieldset class="form-group dso-radios">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Welke aanhanger</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Welke aanhanger
     </span>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="radio" id="form-horizontal-aanhanger-0" name="aanhanger" value="bak">
@@ -245,11 +246,12 @@
       </div>
     </fieldset>
     <fieldset class="form-group dso-checkboxes">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Maak een keuze</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Maak een keuze
     </span>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="checkbox" id="form-horizontal-input-checkbox-0" name="input-checkbox" value="1">
@@ -305,14 +307,15 @@
   <fieldset>
     <legend>Vraag met infobutton</legend>
     <fieldset class="form-group dso-radios">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Soms laat de vraagstelling aan duidelijkheid te wensen over. Wenst u een toelichting hierop?</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Soms laat de vraagstelling aan duidelijkheid te wensen over. Wenst u een toelichting hierop?
     </span>
         <button type="button" class="btn dso-info-button" aria-expanded="false">
           <span class="sr-only">Toelichting bij vraag</span>
         </button>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="radio" id="form-horizontal-input-radio-infobutton-0" name="input-radio-infobutton" value="1" checked>
@@ -335,8 +338,9 @@
   <fieldset>
     <legend>Vraag met infobutton uitgeklapt</legend>
     <fieldset class="form-group dso-radios">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Toelichting op uw vraag</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Toelichting op uw vraag
     </span>
         <button type="button" class="btn dso-info-button dso-open" aria-expanded="true">
@@ -351,7 +355,7 @@
             <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
           </div>
         </div>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="radio" id="form-horizontal-input-radio-infobutton-open-0" name="input-radio-infobutton-open" value="1" checked>

--- a/packages/dso-toolkit/reference/render/form--form-vertical.html
+++ b/packages/dso-toolkit/reference/render/form--form-vertical.html
@@ -212,11 +212,12 @@
   <fieldset>
     <legend>Aanhanger</legend>
     <fieldset class="form-group dso-radios">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Welke aanhanger</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Welke aanhanger
     </span>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="radio" id="form-vertical-aanhanger-0" name="aanhanger" value="bak">
@@ -245,11 +246,12 @@
       </div>
     </fieldset>
     <fieldset class="form-group dso-checkboxes">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Maak een keuze</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Maak een keuze
     </span>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="checkbox" id="form-vertical-input-checkbox-0" name="input-checkbox" value="1">
@@ -305,14 +307,15 @@
   <fieldset>
     <legend>Vraag met infobutton</legend>
     <fieldset class="form-group dso-radios">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Soms laat de vraagstelling aan duidelijkheid te wensen over. Wenst u een toelichting hierop?</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Soms laat de vraagstelling aan duidelijkheid te wensen over. Wenst u een toelichting hierop?
     </span>
         <button type="button" class="btn dso-info-button" aria-expanded="false">
           <span class="sr-only">Toelichting bij vraag</span>
         </button>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="radio" id="form-vertical-input-radio-infobutton-0" name="input-radio-infobutton" value="1" checked>
@@ -335,8 +338,9 @@
   <fieldset>
     <legend>Vraag met infobutton uitgeklapt</legend>
     <fieldset class="form-group dso-radios">
-      <legend class="dso-label-container">
-        <span class="control-label">
+      <legend class="sr-only">Toelichting op uw vraag</legend>
+      <div class="dso-label-container">
+        <span class="control-label" aria-hidden>
       Toelichting op uw vraag
     </span>
         <button type="button" class="btn dso-info-button dso-open" aria-expanded="true">
@@ -351,7 +355,7 @@
             <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
           </div>
         </div>
-      </legend>
+      </div>
       <div class="dso-field-container">
         <div class="dso-selectable">
           <input type="radio" id="form-vertical-input-radio-infobutton-open-0" name="input-radio-infobutton-open" value="1" checked>

--- a/packages/dso-toolkit/reference/render/form--simple-form.html
+++ b/packages/dso-toolkit/reference/render/form--simple-form.html
@@ -1,10 +1,11 @@
 <form class="form-horizontal">
   <fieldset class="form-group dso-radios dso-inline">
-    <legend class="dso-label-container">
-      <span class="control-label">
+    <legend class="sr-only">Heeft de dakkapel een plat dak?</legend>
+    <div class="dso-label-container">
+      <span class="control-label" aria-hidden>
       Heeft de dakkapel een plat dak?
     </span>
-    </legend>
+    </div>
     <div class="dso-field-container">
       <div class="dso-selectable">
         <input type="radio" id="Simpel-form-plat-dak-0" name="plat-dak" value="1">
@@ -21,11 +22,12 @@
     </div>
   </fieldset>
   <fieldset class="form-group dso-checkboxes">
-    <legend class="dso-label-container">
-      <span class="control-label">
+    <legend class="sr-only">Wat is de afstand tussen de zijkanten van de dakkapel en de zijranden van het dak?</legend>
+    <div class="dso-label-container">
+      <span class="control-label" aria-hidden>
       Wat is de afstand tussen de zijkanten van de dakkapel en de zijranden van het dak?
     </span>
-    </legend>
+    </div>
     <div class="dso-field-container">
       <div class="dso-selectable">
         <input type="checkbox" id="Simpel-form-afstand-0" name="afstand" value="">

--- a/packages/dso-toolkit/reference/render/group-checkboxes--default.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--default.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-checkboxes">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group checkboxes - Default</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group checkboxes - Default
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="checkbox" id="input-checkbox-0" name="input-checkbox" value="1">

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-disabled.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-disabled.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-checkboxes dso-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group checkboxes - Disabled</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group checkboxes - Disabled
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="checkbox" id="input-checkbox-disabled-0" name="input-checkbox-disabled" value="1" disabled checked>

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-info-button.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-info-button.html
@@ -1,6 +1,7 @@
 <fieldset class="form-group dso-checkboxes dso-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group checkboxes - Default</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group checkboxes - Default
     </span>
     <button type="button" class="btn dso-info-button dso-open" aria-expanded="true">
@@ -19,7 +20,7 @@
         </p>
       </div>
     </div>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="checkbox" id="input-checkbox-info-button-0" name="input-checkbox-info-button" value="1">

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-invalid.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-invalid.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-checkboxes dso-invalid dso-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group checkboxes - Invalid</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group checkboxes - Invalid
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="checkbox" id="input-checkbox-invalid-0" name="input-checkbox-invalid" value="1" aria-invalid="true">

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-required.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-required.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-checkboxes dso-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group checkboxes - Required</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group checkboxes - Required
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="checkbox" id="input-checkbox-required-0" name="input-checkbox-required" value="1">

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-valid.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-valid.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-checkboxes dso-valid dso-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group checkboxes - Valid</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group checkboxes - Valid
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="checkbox" id="input-checkbox-valid-0" name="input-checkbox-valid" value="1">

--- a/packages/dso-toolkit/reference/render/group-input--input-text-invalid-input.html
+++ b/packages/dso-toolkit/reference/render/group-input--input-text-invalid-input.html
@@ -1,7 +1,7 @@
 <div class="form-group dso-input dso-input-email dso-invalid dso-required">
   <div class="dso-label-container">
     <label for="input-text-invalid-input" class="control-label">
-      Group input - type Email - Invalid (wrong input)
+      Group input - type Email - Invalid (foutieve invoer)
     </label>
   </div>
   <div class="dso-field-container">

--- a/packages/dso-toolkit/reference/render/group-radios--default.html
+++ b/packages/dso-toolkit/reference/render/group-radios--default.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-radios" aria-describedby="helpTextId_input-radio">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Default</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Default
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-0" name="input-radio" value="1" checked>

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-disabled.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-disabled.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-radios dso-valid dso-required" aria-describedby="helpTextId_input-radio-disabled">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Disabled</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Disabled
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-disabled-0" name="input-radio-disabled" value="1" disabled>

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-inline-info.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-inline-info.html
@@ -1,6 +1,7 @@
 <fieldset class="form-group dso-radios dso-required" aria-describedby="helpTextId_input-radio-inline-info">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Inline</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Inline
     </span>
     <button type="button" class="btn dso-info-button dso-open" aria-expanded="true">
@@ -19,7 +20,7 @@
         </p>
       </div>
     </div>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-inline-info-0" name="input-radio-inline-info" value="1" checked>

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-inline.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-inline.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-radios dso-invalid dso-inline dso-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Inline - Invalid</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Inline - Invalid
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-inline-0" name="input-radio-inline" value="1" aria-invalid="true">

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-invalid.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-invalid.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-radios dso-invalid dso-required" aria-describedby="helpTextId_input-radio-invalid">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Invalid</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Invalid
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-invalid-0" name="input-radio-invalid" value="1" aria-invalid="true">

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-required.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-required.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-radios dso-required" aria-describedby="helpTextId_input-radio-required">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Required</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Required
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-required-0" name="input-radio-required" value="1" checked>

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-valid.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-valid.html
@@ -1,9 +1,10 @@
 <fieldset class="form-group dso-radios dso-valid dso-required" aria-describedby="helpTextId_input-radio-valid">
-  <legend class="dso-label-container">
-    <span class="control-label">
+  <legend class="sr-only">Group radios - Valid</legend>
+  <div class="dso-label-container">
+    <span class="control-label" aria-hidden>
       Group radios - Valid
     </span>
-  </legend>
+  </div>
   <div class="dso-field-container">
     <div class="dso-selectable">
       <input type="radio" id="input-radio-valid-0" name="input-radio-valid" value="1" checked>

--- a/packages/dso-toolkit/reference/render/modal.html
+++ b/packages/dso-toolkit/reference/render/modal.html
@@ -235,11 +235,12 @@
       <fieldset>
         <legend>Aanhanger</legend>
         <fieldset class="form-group dso-radios">
-          <legend class="dso-label-container">
-            <span class="control-label">
+          <legend class="sr-only">Welke aanhanger</legend>
+          <div class="dso-label-container">
+            <span class="control-label" aria-hidden>
       Welke aanhanger
     </span>
-          </legend>
+          </div>
           <div class="dso-field-container">
             <div class="dso-selectable">
               <input type="radio" id="form-vertical-aanhanger-0" name="aanhanger" value="bak">
@@ -268,11 +269,12 @@
           </div>
         </fieldset>
         <fieldset class="form-group dso-checkboxes">
-          <legend class="dso-label-container">
-            <span class="control-label">
+          <legend class="sr-only">Maak een keuze</legend>
+          <div class="dso-label-container">
+            <span class="control-label" aria-hidden>
       Maak een keuze
     </span>
-          </legend>
+          </div>
           <div class="dso-field-container">
             <div class="dso-selectable">
               <input type="checkbox" id="form-vertical-input-checkbox-0" name="input-checkbox" value="1">
@@ -328,14 +330,15 @@
       <fieldset>
         <legend>Vraag met infobutton</legend>
         <fieldset class="form-group dso-radios">
-          <legend class="dso-label-container">
-            <span class="control-label">
+          <legend class="sr-only">Soms laat de vraagstelling aan duidelijkheid te wensen over. Wenst u een toelichting hierop?</legend>
+          <div class="dso-label-container">
+            <span class="control-label" aria-hidden>
       Soms laat de vraagstelling aan duidelijkheid te wensen over. Wenst u een toelichting hierop?
     </span>
             <button type="button" class="btn dso-info-button" aria-expanded="false">
               <span class="sr-only">Toelichting bij vraag</span>
             </button>
-          </legend>
+          </div>
           <div class="dso-field-container">
             <div class="dso-selectable">
               <input type="radio" id="form-vertical-input-radio-infobutton-0" name="input-radio-infobutton" value="1" checked>
@@ -358,8 +361,9 @@
       <fieldset>
         <legend>Vraag met infobutton uitgeklapt</legend>
         <fieldset class="form-group dso-radios">
-          <legend class="dso-label-container">
-            <span class="control-label">
+          <legend class="sr-only">Toelichting op uw vraag</legend>
+          <div class="dso-label-container">
+            <span class="control-label" aria-hidden>
       Toelichting op uw vraag
     </span>
             <button type="button" class="btn dso-info-button dso-open" aria-expanded="true">
@@ -374,7 +378,7 @@
                 <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
               </div>
             </div>
-          </legend>
+          </div>
           <div class="dso-field-container">
             <div class="dso-selectable">
               <input type="radio" id="form-vertical-input-radio-infobutton-open-0" name="input-radio-infobutton-open" value="1" checked>

--- a/packages/dso-toolkit/reference/render/wizard-stap-3.html
+++ b/packages/dso-toolkit/reference/render/wizard-stap-3.html
@@ -41,11 +41,12 @@
         </div>
       </div>
       <fieldset class="form-group dso-checkboxes">
-        <legend class="dso-label-container">
-          <span class="control-label">
+        <legend class="sr-only">4 gevonden activiteiten</legend>
+        <div class="dso-label-container">
+          <span class="control-label" aria-hidden>
       4 gevonden activiteiten
     </span>
-        </legend>
+        </div>
         <div class="dso-field-container">
           <div class="dso-selectable">
             <input type="checkbox" id="form-vertical-activiteiten-0" name="activiteiten" value="1">

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -35,7 +35,10 @@ form,
       border-bottom: 0;
       margin-bottom: $dso-fieldset-separator-unit;
 
-      .dso-info {
+    }
+
+    .dso-label-container {
+      > .dso-info {
         font-weight: 400;
         margin-bottom: $u2;
         margin-top: $u1;
@@ -49,18 +52,9 @@ form,
       }
     }
 
-    &.form-group legend {
-      color: $legend-color;
-    }
-
     fieldset {
       margin-bottom: 0;
       padding-bottom: 0;
-
-      > legend {
-        border-top: 0;
-        padding-top: 0;
-      }
 
       + fieldset {
         margin-top: 0;
@@ -116,14 +110,8 @@ form,
     text-align: left;
   }
 
-  legend.dso-label-container {
-    border-bottom: 0;
-    font-size: $font-size-base;
+  .dso-label-container {
     margin-bottom: $u1;
-
-    .control-label {
-      display: inline;
-    }
   }
 
   &.dso-required {
@@ -229,10 +217,6 @@ select:not([multiple]) {
   .form-group {
     > .dso-label-container {
       @include make-sm-column($dso-label-column);
-    }
-
-    > legend.dso-label-container {
-      margin-top: ($padding-base-vertical + 1); // Default padding plus a border;
     }
 
     > .dso-field-container {

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -109,10 +109,6 @@ form,
     text-align: left;
   }
 
-  .dso-label-container {
-    margin-bottom: $u1;
-  }
-
   &.dso-required {
     &.dso-checkboxes,
     &.dso-confirm,

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -51,6 +51,10 @@ form,
       }
     }
 
+    &.form-group legend {
+      color: $legend-color;
+    }
+
     fieldset {
       margin-bottom: 0;
       padding-bottom: 0;
@@ -107,6 +111,23 @@ form,
     margin-bottom: $u1;
     max-width: 100%;
     text-align: left;
+  }
+
+  legend.dso-label-container,
+  legend + .dso-label-container {
+    .control-label {
+      display: inline;
+    }
+  }
+
+  legend.dso-label-container {
+    border-bottom: 0;
+    font-size: $font-size-base;
+    margin-bottom: $u1;
+  }
+
+  legend + .dso-label-container {
+    margin-bottom: $u1;
   }
 
   &.dso-required {
@@ -212,6 +233,10 @@ select:not([multiple]) {
   .form-group {
     > .dso-label-container {
       @include make-sm-column($dso-label-column);
+    }
+
+    > legend + .dso-label-container {
+      margin-top: ($padding-base-vertical + 1); // Default padding plus a border;
     }
 
     > .dso-field-container {

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -34,7 +34,6 @@ form,
 
       border-bottom: 0;
       margin-bottom: $dso-fieldset-separator-unit;
-
     }
 
     .dso-label-container {

--- a/packages/dso-toolkit/src/styles/components/_info.scss
+++ b/packages/dso-toolkit/src/styles/components/_info.scss
@@ -76,5 +76,10 @@
 @media screen and (min-width: $screen-sm-min) {
   .control-label + .dso-info-button {
     margin-top: #{$u1 - 1};
+
+    .dso-radios &,
+    .dso-checkboxes & {
+      margin-top: 0;
+    }
   }
 }

--- a/packages/dso-toolkit/src/styles/components/_info.scss
+++ b/packages/dso-toolkit/src/styles/components/_info.scss
@@ -76,10 +76,5 @@
 @media screen and (min-width: $screen-sm-min) {
   .control-label + .dso-info-button {
     margin-top: #{$u1 - 1};
-
-    .dso-radios &,
-    .dso-checkboxes & {
-      margin-top: 0;
-    }
   }
 }


### PR DESCRIPTION
## Markup change "dso-info buiten legend"

Dit is een breaking change, markupvoorschrift is gewijzigd.

---
Een `<div>` element mag niet in een `<legend>` element staan. Om het ontwerp te waarborgen is gekozen om de legend te verbergen met een `sr-only` en in plaats daarvan na de `<legend>` een container `<div>` te maken waar een visuele `<span>` in zit met een `aria-hidden`. In deze `<div>` zullen ook de toelichting en de toelichting knop staan.

```
<legend class="sr-only">** INPUT LABEL **</legend>
<div class="dso-label-container">
  <span class="control-label" aria-hidden="">
    ** INPUT LABEL **
  </span>
  <button type="button" class="btn dso-info-button dso-open" aria-expanded="true">
    <span class="sr-only">Toelichting bij vraag</span>
  </button>
  <div class="dso-info">
    ** TOELICHTING **
  </div>
</div>
```