### PR TITLE
#1009.Anchor styling aanpassingen voor componenten met gekleurde achtergrond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Fixed
+* **dso-toolkit + styling:** Anchor styling aanpassingen voor componenten met gekleurde achtergrond ([#1009](https://github.com/dso-toolkit/dso-toolkit/issues/1009))
+
 ### Changed
-* **dso-toolkit + styling**: Moved table styling
+* **dso-toolkit + styling**: Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
 
 ## 19.0.0
 

--- a/packages/dso-toolkit/src/styles/components/_anchor.scss
+++ b/packages/dso-toolkit/src/styles/components/_anchor.scss
@@ -1,13 +1,5 @@
 $dso-anchor-spacer-width: 4px;
 
-dso-alert,
-.alert {
-  a,
-  a:visited {
-    color: $text-color;
-  }
-}
-
 a {
   text-decoration: underline;
 
@@ -53,5 +45,22 @@ sup,
 sub {
   a {
     @include anchor-reverse();
+  }
+}
+
+dso-alert,
+.alert {
+  a {
+    &,
+    &:not(.btn):visited {
+      color: $text-color;
+    }
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: $text-color;
+      text-decoration: none;
+    }
   }
 }

--- a/packages/dso-toolkit/src/styles/components/_banner.scss
+++ b/packages/dso-toolkit/src/styles/components/_banner.scss
@@ -36,6 +36,12 @@ $dso-banner-left-padding: $u6;
 
       a {
         text-decoration: underline;
+
+        &:hover,
+        &:focus,
+        &:active {
+          text-decoration: none;
+        }
       }
 
       > .dso-rich-content {

--- a/packages/dso-toolkit/src/styles/components/_info.scss
+++ b/packages/dso-toolkit/src/styles/components/_info.scss
@@ -50,6 +50,12 @@
     &:not(.btn) {
       color: $text-color;
     }
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: none;
+    }
   }
 }
 

--- a/packages/styling/components/highlight-box.scss
+++ b/packages/styling/components/highlight-box.scss
@@ -69,5 +69,11 @@ dso-highlight-box:not([border]):not([white]) {
     &:not(.btn) {
       color: $text-color;
     }
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: none;
+    }
   }
 }


### PR DESCRIPTION
Anchors op een gekleurde achtergrond worden iets anders behandelt dan normale anchors op een witte achtergrond. Het gaat hierbij om de anchors in een lopende tekst.

- De kleur is altijd zwart; default, hover, active, focus, visited
- De underline is alleen aanwezig bij de default state. Bij hover, active, focus en visited dus geen underline

Om het testen te vereenvoudigen heb ik de geraakte componenten hieronder gezet.

Te starten met de componenten in de huidige status:
Anchor: https://dso-toolkit.nl/19.0.0/components/detail/anchor.html
Alert: https://dso-toolkit.nl/19.0.0/components/detail/alert.html
Banner: https://dso-toolkit.nl/19.0.0/components/detail/banner.html
Highlightbox: https://dso-toolkit.nl/19.0.0/components/detail/highlight-box.html
Info: https://dso-toolkit.nl/19.0.0/components/detail/info.html

En de componenten na aanpassing:
Anchor: https://dso-toolkit.nl/_1009.anchor-styling-aanpassingen/components/detail/anchor.html
Alert: https://dso-toolkit.nl/_1009.anchor-styling-aanpassingen/components/detail/alert.html
Banner: https://dso-toolkit.nl/_1009.anchor-styling-aanpassingen/components/detail/banner.html
Highlightbox: https://dso-toolkit.nl/_1009.anchor-styling-aanpassingen/components/detail/highlight-box.html
Info: https://dso-toolkit.nl/_1009.anchor-styling-aanpassingen/components/detail/info.html
