### PR TITLE
#1008.Accordion anchor styling aanpassingen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## NEXT
 
 ### Fixed
+* **dso-toolkit:** Accordion anchor styling aanpassingen ([#1008](https://github.com/dso-toolkit/dso-toolkit/issues/1008))
 * **dso-toolkit + styling:** Anchor styling aanpassingen voor componenten met gekleurde achtergrond ([#1009](https://github.com/dso-toolkit/dso-toolkit/issues/1009))
 
 ### Changed

--- a/packages/dso-toolkit/src/styles/components/_accordion.scss
+++ b/packages/dso-toolkit/src/styles/components/_accordion.scss
@@ -99,6 +99,10 @@ $dso-accordion-light-border-color: $grijs-20;
         font-size: 1em;
         line-height: $dso-accordion-handle-line-height;
         margin: 0;
+
+        a:active {
+          text-decoration: none;
+        }
       }
 
       + .dso-accordion-section {
@@ -272,10 +276,6 @@ $dso-accordion-light-border-color: $grijs-20;
           color: $dso-accordion-light-main-color;
         }
 
-        &:focus {
-          text-decoration: underline;
-        }
-
         &::before {
           @include di("chevron-down");
 
@@ -287,7 +287,12 @@ $dso-accordion-light-border-color: $grijs-20;
       }
 
       a {
-        @include anchor-reverse();
+        &,
+        &:hover,
+        &:active,
+        &:focus {
+          text-decoration: none;
+        }
       }
     }
   }


### PR DESCRIPTION
De accordion heeft twee vormen, waarvan er een uit anchors bestaat. Het is de bedoeling dat de accordion handles met een anchor er hetzelfde uitzien als de variant met een button.

- Geen underline op alle mogelijke states; default, hover, active, focus, voor zowel button als anchor variant

Om het testen te vereenvoudigen heb ik de geraakte componenten hieronder gezet. Let op de verschillende varianten met button en anchor en de compacte variant onder aan.

Te starten met de componenten in de huidige status:
Accordion: https://dso-toolkit.nl/19.0.0/components/detail/accordion.html

En de componenten na aanpassing:
Accordion: https://dso-toolkit.nl/_1008.Accordion-anchor-styling-aanpassingen/components/detail/accordion.html
