### PR TITLE
#920.toelichting vraag onder antwoorden deprecaten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * **dso-toolkit + styling**: Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
 
+### Deprecated
+* **dso-toolkit:** Toelichting vraag onder antwoorden deprecaten ([#920](https://github.com/dso-toolkit/dso-toolkit/issues/920)) **Deprecation notice, see PR ([#1017](https://github.com/dso-toolkit/dso-toolkit/pull/1017))**
+
 ## 19.0.0
 
 ### Fixed

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.config.yml
@@ -121,7 +121,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "Maak een keuze" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Maak een keuze" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-input.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-input.config.yml
@@ -161,7 +161,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "E-mailadres" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "E-mailadres" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-radios.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-radios.config.yml
@@ -125,7 +125,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "Gaat het om de bouw van één of meer woningen?" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Gaat het om de bouw van één of meer woningen?" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-search-bar.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-search-bar.config.yml
@@ -45,7 +45,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "Activiteit" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Activiteit" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-select.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-select.config.yml
@@ -76,7 +76,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "Kies uw beleg" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Kies uw beleg" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-static.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-static.config.yml
@@ -35,7 +35,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "Kleur van object" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Kleur van object" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-textarea.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-textarea.config.yml
@@ -74,7 +74,7 @@ variants:
         Praesent consequat ligula id tortor elementum pretium. Integer ligula justo, volutpat sed tellus eu, faucibus fringilla lectus.
       </p>
     infoTextDeprecated: |
-      <h4>Toelichting bij vraag: "Wilt u nog wat kwijt?" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Wilt u nog wat kwijt?" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/components/Componenten/form/form.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form/form.config.yml
@@ -234,7 +234,7 @@ context:
         <h4>Toelichting bij vraag: "Toelichting op uw vraag"</h4>
         <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
       infoTextDeprecated: |
-        <h4>Toelichting bij vraag: "Toelichting op uw vraag" - BINNENKORT DEPRECATED</h4>
+        <h4>Toelichting bij vraag: "Toelichting op uw vraag" [DEPRECATED]</h4>
         <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
   buttons:
   - type: button

--- a/packages/dso-toolkit/reference/render/form--form-horizontal.html
+++ b/packages/dso-toolkit/reference/render/form--form-horizontal.html
@@ -378,7 +378,7 @@
           <span class="sr-only">Sluiten</span>
         </button>
         <div class="dso-rich-content">
-          <h4>Toelichting bij vraag: "Toelichting op uw vraag" - BINNENKORT DEPRECATED</h4>
+          <h4>Toelichting bij vraag: "Toelichting op uw vraag" [DEPRECATED]</h4>
           <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
         </div>
       </div>

--- a/packages/dso-toolkit/reference/render/form--form-vertical.html
+++ b/packages/dso-toolkit/reference/render/form--form-vertical.html
@@ -378,7 +378,7 @@
           <span class="sr-only">Sluiten</span>
         </button>
         <div class="dso-rich-content">
-          <h4>Toelichting bij vraag: "Toelichting op uw vraag" - BINNENKORT DEPRECATED</h4>
+          <h4>Toelichting bij vraag: "Toelichting op uw vraag" [DEPRECATED]</h4>
           <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
         </div>
       </div>

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-info-button.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-info-button.html
@@ -65,7 +65,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "Maak een keuze" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Maak een keuze" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/group-input--input-text-infobutton-open.html
+++ b/packages/dso-toolkit/reference/render/group-input--input-text-infobutton-open.html
@@ -28,7 +28,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "E-mailadres" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "E-mailadres" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-inline-info.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-inline-info.html
@@ -60,7 +60,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "Gaat het om de bouw van één of meer woningen?" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Gaat het om de bouw van één of meer woningen?" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/group-search-bar--search-bar-infobutton-expanded.html
+++ b/packages/dso-toolkit/reference/render/group-search-bar--search-bar-infobutton-expanded.html
@@ -38,7 +38,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "Activiteit" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Activiteit" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/group-select--input-select-infobutton-open.html
+++ b/packages/dso-toolkit/reference/render/group-select--input-select-infobutton-open.html
@@ -38,7 +38,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "Kies uw beleg" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Kies uw beleg" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/group-static--static-infobutton-open.html
+++ b/packages/dso-toolkit/reference/render/group-static--static-infobutton-open.html
@@ -26,7 +26,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "Kleur van object" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Kleur van object" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/group-textarea--input-textarea-infobutton-open.html
+++ b/packages/dso-toolkit/reference/render/group-textarea--input-textarea-infobutton-open.html
@@ -28,7 +28,7 @@
       <span class="sr-only">Sluiten</span>
     </button>
     <div class="dso-rich-content">
-      <h4>Toelichting bij vraag: "Wilt u nog wat kwijt?" - BINNENKORT DEPRECATED</h4>
+      <h4>Toelichting bij vraag: "Wilt u nog wat kwijt?" [DEPRECATED]</h4>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non metus dolor. Pellentesque velit arcu, pellentesque at lacus sit amet, porta semper est.
         Praesent mollis lorem lorem, non varius nisl lacinia et. Integer quis sollicitudin arcu. Nullam lacinia non ipsum sit amet varius.

--- a/packages/dso-toolkit/reference/render/modal.html
+++ b/packages/dso-toolkit/reference/render/modal.html
@@ -401,7 +401,7 @@
               <span class="sr-only">Sluiten</span>
             </button>
             <div class="dso-rich-content">
-              <h4>Toelichting bij vraag: "Toelichting op uw vraag" - BINNENKORT DEPRECATED</h4>
+              <h4>Toelichting bij vraag: "Toelichting op uw vraag" [DEPRECATED]</h4>
               <p>Bij verticale formulieren wordt het bij checkboxen en radio's onoverzichtelijk als de toelichting bij de vraag EN opties toont</p>
             </div>
           </div>

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -51,10 +51,6 @@ form,
       }
     }
 
-    &.form-group legend {
-      color: $legend-color;
-    }
-
     fieldset {
       margin-bottom: 0;
       padding-bottom: 0;

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -51,6 +51,10 @@ form,
       }
     }
 
+    &.form-group legend {
+      color: $legend-color;
+    }
+
     fieldset {
       margin-bottom: 0;
       padding-bottom: 0;

--- a/packages/dso-toolkit/src/styles/components/_info.scss
+++ b/packages/dso-toolkit/src/styles/components/_info.scss
@@ -1,3 +1,7 @@
+.dso-field-container + .dso-info {
+  background-color: $dso-invalid-color !important;
+}
+
 .dso-info:not(.dso-accordion-section) {
   background-color: $grijs-10;
   padding: $u2 $u4 $u2 $u2;

--- a/packages/dso-toolkit/src/styles/components/_info.scss
+++ b/packages/dso-toolkit/src/styles/components/_info.scss
@@ -82,5 +82,10 @@
 @media screen and (min-width: $screen-sm-min) {
   .control-label + .dso-info-button {
     margin-top: #{$u1 - 1};
+
+    .dso-radios &,
+    .dso-checkboxes & {
+      margin-top: 0;
+    }
   }
 }

--- a/packages/dso-toolkit/src/styles/components/_info.scss
+++ b/packages/dso-toolkit/src/styles/components/_info.scss
@@ -82,10 +82,5 @@
 @media screen and (min-width: $screen-sm-min) {
   .control-label + .dso-info-button {
     margin-top: #{$u1 - 1};
-
-    .dso-radios &,
-    .dso-checkboxes & {
-      margin-top: 0;
-    }
   }
 }


### PR DESCRIPTION
De DSO-info (toelichting blok) staat nu direct onder de vraag/het antwoord. De toelichting die voorheen als laatste kind in de fieldset stond is deprecated.

Situatie voorheen:
Group checkboxen: https://dso-toolkit.nl/19.0.0/components/detail/group-checkboxes.html
Group input: https://dso-toolkit.nl/19.0.0/components/detail/group-input.html
Group radios: https://dso-toolkit.nl/19.0.0/components/detail/group-radios.html
Group searchbar: https://dso-toolkit.nl/19.0.0/components/detail/group-search-bar.html
Group select: https://dso-toolkit.nl/19.0.0/components/detail/group-select.html
Group static: https://dso-toolkit.nl/19.0.0/components/detail/group-static.html
Group textarea: https://dso-toolkit.nl/19.0.0/components/detail/group-textarea.html
Group form: https://dso-toolkit.nl/19.0.0/components/detail/form.html

Nieuwe situatie met deprecated kleur:
Group checkboxen: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-checkboxes.html
Group input: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-input.html
Group radios: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-radios.html
Group searchbar: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-search-bar.html
Group select: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-select.html
Group static: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-static.html
Group textarea: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/group-textarea.html
Group form: https://dso-toolkit.nl/_920.Toelichting-vraag-onder-antwoorden-deprecaten/components/detail/form.html