### PR TITLE
#986 - Web Component: Alerts niet altijd een role=alert meegeven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **dso-toolkit + styling:** Anchor styling aanpassingen voor componenten met gekleurde achtergrond ([#1009](https://github.com/dso-toolkit/dso-toolkit/issues/1009))
 
 ### Changed
-* **dso-toolkit + styling**: Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
+* **dso-toolkit + styling:** Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
+* **dso-toolkit + core:** Alert role="alert" instelbaar door prop ([#986](https://github.com/dso-toolkit/dso-toolkit/issues/986))
 
 ### Deprecated
 * **dso-toolkit:** Toelichting vraag onder antwoorden deprecaten ([#920](https://github.com/dso-toolkit/dso-toolkit/issues/920)) **Deprecation notice, see PR ([#1017](https://github.com/dso-toolkit/dso-toolkit/pull/1017))**

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -8,6 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { DsoDatePickerChangeEvent, DsoDatePickerDirection, DsoDatePickerFocusEvent } from "./components/date-picker/date-picker";
 export namespace Components {
     interface DsoAlert {
+        "roleAlert"?: boolean;
         "status": 'success' | 'info' | 'warning' | 'danger';
     }
     interface DsoAttachmentsCounter {
@@ -147,6 +148,7 @@ declare global {
 }
 declare namespace LocalJSX {
     interface DsoAlert {
+        "roleAlert"?: boolean;
         "status": 'success' | 'info' | 'warning' | 'danger';
     }
     interface DsoAttachmentsCounter {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -8,7 +8,13 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { DsoDatePickerChangeEvent, DsoDatePickerDirection, DsoDatePickerFocusEvent } from "./components/date-picker/date-picker";
 export namespace Components {
     interface DsoAlert {
+        /**
+          * Whether or not to show the role attribute with value "alert". To control the tooltip add the `role-alert` attribute.
+         */
         "roleAlert"?: boolean;
+        /**
+          * Set status of alert
+         */
         "status": 'success' | 'info' | 'warning' | 'danger';
     }
     interface DsoAttachmentsCounter {
@@ -148,7 +154,13 @@ declare global {
 }
 declare namespace LocalJSX {
     interface DsoAlert {
+        /**
+          * Whether or not to show the role attribute with value "alert". To control the tooltip add the `role-alert` attribute.
+         */
         "roleAlert"?: boolean;
+        /**
+          * Set status of alert
+         */
         "status": 'success' | 'info' | 'warning' | 'danger';
     }
     interface DsoAttachmentsCounter {

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -10,6 +10,9 @@ export class Alert {
   @Prop()
   status!: 'success' | 'info' | 'warning' | 'danger';
 
+  @Prop()
+  roleAlert?: boolean;
+
   private static statusMap = new Map<string, string>([
     ['success', 'Gelukt'],
     ['info', 'Opmerking'],
@@ -24,7 +27,7 @@ export class Alert {
     }
 
     return (
-      <div class={clsx('alert', `alert-${this.status}`)} role="alert">
+      <div class={clsx('alert', `alert-${this.status}`)} role={this.roleAlert ? 'alert' : undefined}>
         <span class="sr-only">{status}:</span>
         <slot></slot>
       </div>

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -7,9 +7,15 @@ import clsx from 'clsx';
   shadow: true
 })
 export class Alert {
+  /**
+   * Set status of alert
+   */
   @Prop()
   status!: 'success' | 'info' | 'warning' | 'danger';
 
+  /**
+   * Whether or not to show the role attribute with value "alert". To control the tooltip add the `role-alert` attribute.
+   */
   @Prop()
   roleAlert?: boolean;
 

--- a/packages/core/src/components/alert/readme.md
+++ b/packages/core/src/components/alert/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property              | Attribute    | Description | Type                                           | Default     |
-| --------------------- | ------------ | ----------- | ---------------------------------------------- | ----------- |
-| `roleAlert`           | `role-alert` |             | `boolean \| undefined`                         | `undefined` |
-| `status` _(required)_ | `status`     |             | `"danger" \| "info" \| "success" \| "warning"` | `undefined` |
+| Property              | Attribute    | Description                                                                                                          | Type                                           | Default     |
+| --------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ----------- |
+| `roleAlert`           | `role-alert` | Whether or not to show the role attribute with value "alert". To control the tooltip add the `role-alert` attribute. | `boolean \| undefined`                         | `undefined` |
+| `status` _(required)_ | `status`     | Set status of alert                                                                                                  | `"danger" \| "info" \| "success" \| "warning"` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/alert/readme.md
+++ b/packages/core/src/components/alert/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property              | Attribute | Description | Type                                           | Default     |
-| --------------------- | --------- | ----------- | ---------------------------------------------- | ----------- |
-| `status` _(required)_ | `status`  |             | `"danger" \| "info" \| "success" \| "warning"` | `undefined` |
+| Property              | Attribute    | Description | Type                                           | Default     |
+| --------------------- | ------------ | ----------- | ---------------------------------------------- | ----------- |
+| `roleAlert`           | `role-alert` |             | `boolean \| undefined`                         | `undefined` |
+| `status` _(required)_ | `status`     |             | `"danger" \| "info" \| "success" \| "warning"` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/dso-toolkit/components/Componenten/alert/alert.config.yml
+++ b/packages/dso-toolkit/components/Componenten/alert/alert.config.yml
@@ -55,6 +55,12 @@ context:
   status: success
   message: Dit is een succesmelding. Deze wordt getoond als een proces succesvol is afgerond.
 variants:
+  - name: with-role-alert
+    context:
+      __title: met role alert
+      status: success
+      message: Dit is een succesmelding. Deze wordt getoond als een proces succesvol is afgerond.
+      roleAlert: true
   - name: danger
     context:
       __title: danger

--- a/packages/dso-toolkit/components/Componenten/alert/alert.njk
+++ b/packages/dso-toolkit/components/Componenten/alert/alert.njk
@@ -1,3 +1,3 @@
-<dso-alert status="{{ status }}">
+<dso-alert status="{{ status }}" {% if roleAlert %}role-alert="{{ roleAlert }}"{% endif %}>
   {{ message | safe }}
 </dso-alert>

--- a/packages/dso-toolkit/components/Componenten/alert/alert.njk
+++ b/packages/dso-toolkit/components/Componenten/alert/alert.njk
@@ -1,3 +1,3 @@
-<dso-alert status="{{ status }}" {% if roleAlert %}role-alert="{{ roleAlert }}"{% endif %}>
+<dso-alert status="{{ status }}" {{- attributes([roleAlert, 'role-alert']) }}>
   {{ message | safe }}
 </dso-alert>

--- a/packages/dso-toolkit/reference/render/alert--alert-with-headings.html
+++ b/packages/dso-toolkit/reference/render/alert--alert-with-headings.html
@@ -1,5 +1,5 @@
 <dso-alert status="info">
-  <div class="alert alert-info" role="alert">
+  <div class="alert alert-info">
     <span class="sr-only">Opmerking:</span>
     <div class="dso-rich-content">
       <h2>Dit is een H2</h2>

--- a/packages/dso-toolkit/reference/render/alert--danger-button.html
+++ b/packages/dso-toolkit/reference/render/alert--danger-button.html
@@ -1,5 +1,5 @@
 <dso-alert status="danger">
-  <div class="alert alert-danger" role="alert">
+  <div class="alert alert-danger">
     <span class="sr-only">Fout:</span>
     <div class="dso-rich-content">
       <p>Dit is een foutmelding. Deze wordt getoond als er iets is misgegaan.</p>

--- a/packages/dso-toolkit/reference/render/alert--danger.html
+++ b/packages/dso-toolkit/reference/render/alert--danger.html
@@ -1,5 +1,5 @@
 <dso-alert status="danger">
-  <div class="alert alert-danger" role="alert">
+  <div class="alert alert-danger">
     <span class="sr-only">Fout:</span> Dit is een <a href="#">foutmelding</a>. Deze wordt getoond als er iets is
     misgegaan.
   </div>

--- a/packages/dso-toolkit/reference/render/alert--info-button.html
+++ b/packages/dso-toolkit/reference/render/alert--info-button.html
@@ -1,5 +1,5 @@
 <dso-alert status="info">
-  <div class="alert alert-info" role="alert">
+  <div class="alert alert-info">
     <span class="sr-only">Opmerking:</span>
     <div class="dso-rich-content">
       <p>Dit is een informatiemelding. Deze wordt gebruikt voor aanvullende informatie of tips.</p>

--- a/packages/dso-toolkit/reference/render/alert--info.html
+++ b/packages/dso-toolkit/reference/render/alert--info.html
@@ -1,5 +1,5 @@
 <dso-alert status="info">
-  <div class="alert alert-info" role="alert">
+  <div class="alert alert-info">
     <span class="sr-only">Opmerking:</span> Dit is een informatiemelding. Deze wordt gebruikt voor
     <a href="#">aanvullende</a> informatie of tips.
   </div>

--- a/packages/dso-toolkit/reference/render/alert--success-button.html
+++ b/packages/dso-toolkit/reference/render/alert--success-button.html
@@ -1,5 +1,5 @@
 <dso-alert status="success">
-  <div class="alert alert-success" role="alert">
+  <div class="alert alert-success">
     <span class="sr-only">Gelukt:</span>
     <div class="dso-rich-content">
       <p>Dit is een succesmelding. Deze wordt getoond als een proces succesvol is afgerond.</p>

--- a/packages/dso-toolkit/reference/render/alert--warning-button.html
+++ b/packages/dso-toolkit/reference/render/alert--warning-button.html
@@ -1,5 +1,5 @@
 <dso-alert status="warning">
-  <div class="alert alert-warning" role="alert">
+  <div class="alert alert-warning">
     <span class="sr-only">Waarschuwing:</span>
     <div class="dso-rich-content">
       <p>Dit is een waarschuwingsmelding. Deze wordt gebruikt voor waarschuwingen.</p>

--- a/packages/dso-toolkit/reference/render/alert--warning.html
+++ b/packages/dso-toolkit/reference/render/alert--warning.html
@@ -1,5 +1,5 @@
 <dso-alert status="warning">
-  <div class="alert alert-warning" role="alert">
+  <div class="alert alert-warning">
     <span class="sr-only">Waarschuwing:</span> Dit is een waarschuwingsmelding. Deze wordt gebruikt voor waarschuwingen.
   </div>
 </dso-alert>

--- a/packages/dso-toolkit/reference/render/alert--with-role-alert.html
+++ b/packages/dso-toolkit/reference/render/alert--with-role-alert.html
@@ -1,5 +1,5 @@
-<dso-alert status="success">
-  <div class="alert alert-success">
+<dso-alert status="success" role-alert="true">
+  <div class="alert alert-success" role="alert">
     <span class="sr-only">Gelukt:</span> Dit is een succesmelding. Deze wordt getoond als een proces succesvol is
     afgerond.
   </div>

--- a/packages/dso-toolkit/reference/render/alert--with-role-alert.html
+++ b/packages/dso-toolkit/reference/render/alert--with-role-alert.html
@@ -1,4 +1,4 @@
-<dso-alert status="success" role-alert="true">
+<dso-alert status="success" role-alert>
   <div class="alert alert-success" role="alert">
     <span class="sr-only">Gelukt:</span> Dit is een succesmelding. Deze wordt getoond als een proces succesvol is
     afgerond.


### PR DESCRIPTION
**Implementatie informatie**

Een geldige alert webcomponent met als status `success` en waarbij de `role="alert"` wordt gezet:
```
<dso-alert status="success" role-alert>## TEKST ##</dso-alert>
```

-----

**Pull request informatie**

Het alert webcomponent heeft nu een toegevoegde @Prop genaamd `roleAlert` met type boolean. Wanneer deze op true staat wordt het attribuut `role="alert"` gezet, en wanneer deze false is zal de waarde in het attribuut `undefined` zijn, en dus ook niet tonen. Een extra variant is toegevoegd op de Alert component pagina, die deze `role="alert"` bevat.

Oude situatie:
https://dso-toolkit.nl/19.0.0/components/detail/alert.html

Nieuwe situatie:
https://dso-toolkit.nl/_986.alert-role-alert/components/detail/alert.html