### PR TITLE
#961 Dropdown rechts kunnen uitlijnen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## NEXT
+### Added
+* **dso-toolkit** Dropdown menu met uitlijning links en rechts toevoegen ([#961](https://github.com/dso-toolkit/dso-toolkit/issues/#961))
 
 ### Fixed
 * **dso-toolkit:** Accordion anchor styling aanpassingen ([#1008](https://github.com/dso-toolkit/dso-toolkit/issues/1008))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## NEXT
-### Added
-* **dso-toolkit** Dropdown menu met uitlijning links en rechts toevoegen ([#961](https://github.com/dso-toolkit/dso-toolkit/issues/#961))
 
 ### Fixed
 * **dso-toolkit:** Accordion anchor styling aanpassingen ([#1008](https://github.com/dso-toolkit/dso-toolkit/issues/1008))
@@ -18,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **dso-toolkit + styling**: Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
 
 ### Added
+* **dso-toolkit** Dropdown menu rechts uit kunnen lijnen ([#961](https://github.com/dso-toolkit/dso-toolkit/issues/#961))
 * **styling:** Variabelen voor verticale marges ([#1042](https://github.com/dso-toolkit/dso-toolkit/issues/1042))
 
 ### Deprecated

--- a/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.config.js
+++ b/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  notes: 'Toont een dropdown met daarin een gevulde uitklapper. Gebaseerd op de Bootstrap "Dropdowns" component',
+  notes: 'Toont een dropdown met daarin een gevulde uitklapper. Gebaseerd op de Bootstrap "Dropdowns" component. Class `text-right` op de parent van of op `.dropdown` zelf zorgt voor een rechter uitlijning.',
   status: 'ready',
   collated: true,
   collator: function (markup, item) {
@@ -263,6 +263,150 @@ module.exports = {
         id: 'dropdown_primary_button_open_checkable',
         modifier: 'primary',
         open: true,
+        modifiers: 'dso-checkable',
+        groups: [
+          {
+            label: 'Versies',
+            items: [
+              {
+                label: '10.6.0',
+                checked: true
+              },
+              {
+                label: '10.5.0'
+              },
+              {
+                label: '10.4.0'
+              }
+            ]
+          },
+          {
+            items: [
+              {
+                label: 'master'
+              }
+            ]
+          },
+          {
+            label: 'Branch releases',
+            items: [
+              {
+                label: '#500-Margins-Testbuilds'
+              },
+              {
+                label: '#611-Pager-component-uitbreiden'
+              },
+              {
+                label: '#663-Dropdown-button-toegankelijk-maken'
+              }
+            ]
+          },
+        ]
+      }
+    },
+    {
+      name: 'dropdown-link-button-align-right',
+      context: {
+        id: 'dropdown_link_button_align_right',
+        modifier: 'link',
+        open: true,
+        align: 'right',
+        modifiers: 'dso-checkable',
+        groups: [
+          {
+            label: 'Versies',
+            items: [
+              {
+                label: '10.6.0',
+                checked: true
+              },
+              {
+                label: '10.5.0'
+              },
+              {
+                label: '10.4.0'
+              }
+            ]
+          },
+          {
+            items: [
+              {
+                label: 'master'
+              }
+            ]
+          },
+          {
+            label: 'Branch releases',
+            items: [
+              {
+                label: '#500-Margins-Testbuilds'
+              },
+              {
+                label: '#611-Pager-component-uitbreiden'
+              },
+              {
+                label: '#663-Dropdown-button-toegankelijk-maken'
+              }
+            ]
+          },
+        ]
+      }
+    },
+    {
+      name: 'dropdown-default-button-align-right',
+      context: {
+        id: 'dropdown_default_button_align_right',
+        modifier: 'default',
+        open: true,
+        align: 'right',
+        modifiers: 'dso-checkable',
+        groups: [
+          {
+            label: 'Versies',
+            items: [
+              {
+                label: '10.6.0',
+                checked: true
+              },
+              {
+                label: '10.5.0'
+              },
+              {
+                label: '10.4.0'
+              }
+            ]
+          },
+          {
+            items: [
+              {
+                label: 'master'
+              }
+            ]
+          },
+          {
+            label: 'Branch releases',
+            items: [
+              {
+                label: '#500-Margins-Testbuilds'
+              },
+              {
+                label: '#611-Pager-component-uitbreiden'
+              },
+              {
+                label: '#663-Dropdown-button-toegankelijk-maken'
+              }
+            ]
+          },
+        ]
+      }
+    },
+    {
+      name: 'dropdown-primary-button-align-right',
+      context: {
+        id: 'dropdown_primary_button_align_right',
+        modifier: 'primary',
+        open: true,
+        align: 'right',
         modifiers: 'dso-checkable',
         groups: [
           {

--- a/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.config.js
+++ b/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  notes: 'Toont een dropdown met daarin een gevulde uitklapper. Gebaseerd op de Bootstrap "Dropdowns" component. Class `text-right` op de parent van of op `.dropdown` zelf zorgt voor een rechter uitlijning.',
+  notes: 'Toont een dropdown met daarin een gevulde uitklapper. Gebaseerd op de Bootstrap "Dropdowns" component. Class `dso-dropdown-right` op de parent van of op `.dropdown` zelf zorgt voor een rechter uitlijning.',
   status: 'ready',
   collated: true,
   collator: function (markup, item) {

--- a/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.njk
+++ b/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.njk
@@ -1,4 +1,4 @@
-<div {{ className('dropdown', [open, 'open'], [align, 'text-' + align]) }}>
+<div {{ className('dropdown', [open, 'open'], [align, 'dso-dropdown-' + align]) }}>
   {% render '@button', {type: 'button', modifier: modifier, label: label, id: id, icon: icon, iconAfter: iconAfter, ariaHasPopup: ariaHasPopup, ariaExpanded: not not open} %}
   {% if open %}
     <div {{ className('dropdown-menu', modifiers) }}>

--- a/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.njk
+++ b/packages/dso-toolkit/components/Componenten/dropdown-button/dropdown-button.njk
@@ -1,4 +1,4 @@
-<div {{ className('dropdown', [open, 'open']) }}>
+<div {{ className('dropdown', [open, 'open'], [align, 'text-' + align]) }}>
   {% render '@button', {type: 'button', modifier: modifier, label: label, id: id, icon: icon, iconAfter: iconAfter, ariaHasPopup: ariaHasPopup, ariaExpanded: not not open} %}
   {% if open %}
     <div {{ className('dropdown-menu', modifiers) }}>

--- a/packages/dso-toolkit/reference/render/dropdown-button--dropdown-default-button-align-right.html
+++ b/packages/dso-toolkit/reference/render/dropdown-button--dropdown-default-button-align-right.html
@@ -1,0 +1,34 @@
+<div class="dropdown open text-right">
+  <button type="button" id="dropdown_default_button_align_right" aria-haspopup="true" aria-expanded="true" class="btn btn-default"><span >Actie</span></button>
+  <div class="dropdown-menu dso-checkable">
+    <h2 class="dso-group-label">Versies</h2>
+    <ul aria-labelledby="dropdown_default_button_align_right">
+      <li class="dso-checked">
+        <a href="#">10.6.0</a>
+      </li>
+      <li>
+        <a href="#">10.5.0</a>
+      </li>
+      <li>
+        <a href="#">10.4.0</a>
+      </li>
+    </ul>
+    <ul aria-labelledby="dropdown_default_button_align_right">
+      <li>
+        <a href="#">master</a>
+      </li>
+    </ul>
+    <h2 class="dso-group-label">Branch releases</h2>
+    <ul aria-labelledby="dropdown_default_button_align_right">
+      <li>
+        <a href="#">#500-Margins-Testbuilds</a>
+      </li>
+      <li>
+        <a href="#">#611-Pager-component-uitbreiden</a>
+      </li>
+      <li>
+        <a href="#">#663-Dropdown-button-toegankelijk-maken</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/packages/dso-toolkit/reference/render/dropdown-button--dropdown-default-button-align-right.html
+++ b/packages/dso-toolkit/reference/render/dropdown-button--dropdown-default-button-align-right.html
@@ -1,4 +1,4 @@
-<div class="dropdown open text-right">
+<div class="dropdown open dso-dropdown-right">
   <button type="button" id="dropdown_default_button_align_right" aria-haspopup="true" aria-expanded="true" class="btn btn-default"><span >Actie</span></button>
   <div class="dropdown-menu dso-checkable">
     <h2 class="dso-group-label">Versies</h2>

--- a/packages/dso-toolkit/reference/render/dropdown-button--dropdown-link-button-align-right.html
+++ b/packages/dso-toolkit/reference/render/dropdown-button--dropdown-link-button-align-right.html
@@ -1,4 +1,4 @@
-<div class="dropdown open text-right">
+<div class="dropdown open dso-dropdown-right">
   <button type="button" id="dropdown_link_button_align_right" aria-haspopup="true" aria-expanded="true" class="btn btn-link"><span >Actie</span></button>
   <div class="dropdown-menu dso-checkable">
     <h2 class="dso-group-label">Versies</h2>

--- a/packages/dso-toolkit/reference/render/dropdown-button--dropdown-link-button-align-right.html
+++ b/packages/dso-toolkit/reference/render/dropdown-button--dropdown-link-button-align-right.html
@@ -1,0 +1,34 @@
+<div class="dropdown open text-right">
+  <button type="button" id="dropdown_link_button_align_right" aria-haspopup="true" aria-expanded="true" class="btn btn-link"><span >Actie</span></button>
+  <div class="dropdown-menu dso-checkable">
+    <h2 class="dso-group-label">Versies</h2>
+    <ul aria-labelledby="dropdown_link_button_align_right">
+      <li class="dso-checked">
+        <a href="#">10.6.0</a>
+      </li>
+      <li>
+        <a href="#">10.5.0</a>
+      </li>
+      <li>
+        <a href="#">10.4.0</a>
+      </li>
+    </ul>
+    <ul aria-labelledby="dropdown_link_button_align_right">
+      <li>
+        <a href="#">master</a>
+      </li>
+    </ul>
+    <h2 class="dso-group-label">Branch releases</h2>
+    <ul aria-labelledby="dropdown_link_button_align_right">
+      <li>
+        <a href="#">#500-Margins-Testbuilds</a>
+      </li>
+      <li>
+        <a href="#">#611-Pager-component-uitbreiden</a>
+      </li>
+      <li>
+        <a href="#">#663-Dropdown-button-toegankelijk-maken</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/packages/dso-toolkit/reference/render/dropdown-button--dropdown-primary-button-align-right.html
+++ b/packages/dso-toolkit/reference/render/dropdown-button--dropdown-primary-button-align-right.html
@@ -1,0 +1,34 @@
+<div class="dropdown open text-right">
+  <button type="button" id="dropdown_primary_button_align_right" aria-haspopup="true" aria-expanded="true" class="btn btn-primary"><span >Actie</span></button>
+  <div class="dropdown-menu dso-checkable">
+    <h2 class="dso-group-label">Versies</h2>
+    <ul aria-labelledby="dropdown_primary_button_align_right">
+      <li class="dso-checked">
+        <a href="#">10.6.0</a>
+      </li>
+      <li>
+        <a href="#">10.5.0</a>
+      </li>
+      <li>
+        <a href="#">10.4.0</a>
+      </li>
+    </ul>
+    <ul aria-labelledby="dropdown_primary_button_align_right">
+      <li>
+        <a href="#">master</a>
+      </li>
+    </ul>
+    <h2 class="dso-group-label">Branch releases</h2>
+    <ul aria-labelledby="dropdown_primary_button_align_right">
+      <li>
+        <a href="#">#500-Margins-Testbuilds</a>
+      </li>
+      <li>
+        <a href="#">#611-Pager-component-uitbreiden</a>
+      </li>
+      <li>
+        <a href="#">#663-Dropdown-button-toegankelijk-maken</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/packages/dso-toolkit/reference/render/dropdown-button--dropdown-primary-button-align-right.html
+++ b/packages/dso-toolkit/reference/render/dropdown-button--dropdown-primary-button-align-right.html
@@ -1,4 +1,4 @@
-<div class="dropdown open text-right">
+<div class="dropdown open dso-dropdown-right">
   <button type="button" id="dropdown_primary_button_align_right" aria-haspopup="true" aria-expanded="true" class="btn btn-primary"><span >Actie</span></button>
   <div class="dropdown-menu dso-checkable">
     <h2 class="dso-group-label">Versies</h2>

--- a/packages/dso-toolkit/src/styles/components/_dropdown.scss
+++ b/packages/dso-toolkit/src/styles/components/_dropdown.scss
@@ -154,3 +154,11 @@ $dso-dropdown-hor-padding: 20px;
     }
   }
 }
+
+.text-right {
+  &.dropdown-menu,
+  & .dropdown-menu {
+    left: auto;
+    right: 0;
+  }
+}

--- a/packages/dso-toolkit/src/styles/components/_dropdown.scss
+++ b/packages/dso-toolkit/src/styles/components/_dropdown.scss
@@ -59,7 +59,8 @@ $dso-dropdown-hor-padding: 20px;
         @include di-variant("chevron-up");
       }
 
-      &:hover::after {
+      &:hover::after,
+      &:focus::after {
         @include di-variant("chevron-up-wit");
       }
     }
@@ -155,7 +156,12 @@ $dso-dropdown-hor-padding: 20px;
   }
 }
 
-.text-right {
+.dso-dropdown-right {
+  text-align: right;
+}
+
+.navbar-right,
+.dso-dropdown-right {
   &.dropdown-menu,
   & .dropdown-menu {
     left: auto;

--- a/packages/dso-toolkit/src/styles/components/_dropdown.scss
+++ b/packages/dso-toolkit/src/styles/components/_dropdown.scss
@@ -160,11 +160,9 @@ $dso-dropdown-hor-padding: 20px;
   text-align: right;
 }
 
-.navbar-right,
-.dso-dropdown-right {
-  &.dropdown-menu,
-  & .dropdown-menu {
-    left: auto;
-    right: 0;
-  }
+.navbar-right .dropdown-menu,
+.dso-dropdown-right.dropdown-menu,
+.dso-dropdown-right .dropdown-menu {
+  left: auto;
+  right: 0;
 }


### PR DESCRIPTION
Voorbeelden toegevoegd voor de rechter uitlijning van het dropdown menu. Class `dso-dropdown-right` op de parent van, of op `.dropdown` zelf zorgt voor een rechter uitlijning:

```
<div class="dropdown dso-dropdown-right">
  <button type="button" id="dropdownmenu" aria-haspopup="true" aria-expanded="true" class="btn btn-default">
    <span>Actie</span>
  </button>
  <div class="dropdown-menu">
    <ul aria-labelledby="dropdownmenu">
      <li class="dso-checked">
        <a href="#">10.6.0</a>
      </li>
      <li>
        <a href="#">10.5.0</a>
      </li>
    </ul>
  </div>
</div>
```

```
<div class="dso-dropdown-right">
  <div class="dropdown">
    <button type="button" id="dropdownmenu" aria-haspopup="true" aria-expanded="true" class="btn btn-default">
      <span>Actie</span>
    </button>
    <div class="dropdown-menu">
      <ul aria-labelledby="dropdownmenu">
        <li class="dso-checked">
          <a href="#">10.6.0</a>
        </li>
        <li>
          <a href="#">10.5.0</a>
        </li>
      </ul>
    </div>
  </div>
</div>
```