### PR TITLE
#1032 : geen marge rond headings in legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * **dso-toolkit:** Margin onder tabs ([#1027](https://github.com/dso-toolkit/dso-toolkit/issues/1027))
 * **dso-toolkit:** Instelbare buttontekst mogelijk maken bij search-bar ([#1037](https://github.com/dso-toolkit/dso-toolkit/issues/1037))
+* **dso-toolkit:** Headings in legend moeten geen margins hebben ([#1032](https://github.com/dso-toolkit/dso-toolkit/issues/1032))
 
 ### Added
 * **dso-toolkit:** Horizontale plaatsing form-groups en dso-form-buttons ([#1046](https://github.com/dso-toolkit/dso-toolkit/issues/1046))
 
 ## 20.0.0
-
-### Changed
-* **dso-toolkit:** Headings in legend moeten geen margins hebben ([#1032](https://github.com/dso-toolkit/dso-toolkit/issues/1032))
 
 ### Fixed
 * **dso-toolkit:** dso-info buiten legend gebruikt aria-hidden ipv aria-hidden="true" ([#1031](https://github.com/dso-toolkit/dso-toolkit/issues/1031))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## 20.0.0
 
+### Changed
+* **dso-toolkit:** Headings in legend moeten geen margins hebben ([#1032](https://github.com/dso-toolkit/dso-toolkit/issues/1032))
+
 ### Fixed
 * **dso-toolkit:** dso-info buiten legend gebruikt aria-hidden ipv aria-hidden="true" ([#1031](https://github.com/dso-toolkit/dso-toolkit/issues/1031))
 

--- a/packages/dso-toolkit/src/styles/components/_form.scss
+++ b/packages/dso-toolkit/src/styles/components/_form.scss
@@ -58,6 +58,14 @@ form,
 
       border-bottom: 0;
       margin-bottom: $dso-fieldset-separator-unit;
+
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        margin: 0;
+      }
     }
 
     .dso-label-container {


### PR DESCRIPTION
In sommige gevallen is het gebruik van headings in een legend gewenst (en ook toegestaan want phrasing content). Alleen zijn in deze gevallen de standaard verticale margins van de headings niet gewenst.