### PR TITLE
#1034 : Definition lists in geneste accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## 20.0.0
 
-### Added
+### Fixed
 * **dso-toolkit:** Definition lists in geneste accordion ([#1034](https://github.com/dso-toolkit/dso-toolkit/issues/1034))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## 20.0.0
 
+### Added
+* **dso-toolkit:** Definition lists in geneste accordion ([#1034](https://github.com/dso-toolkit/dso-toolkit/issues/1034))
+
 ### Fixed
 * **dso-toolkit:** dso-info buiten legend gebruikt aria-hidden ipv aria-hidden="true" ([#1031](https://github.com/dso-toolkit/dso-toolkit/issues/1031))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 * **dso-toolkit:** Horizontale plaatsing form-groups en dso-form-buttons ([#1046](https://github.com/dso-toolkit/dso-toolkit/issues/1046))
+* **dso-toolkit:** Definition lists in geneste accordion ([#1034](https://github.com/dso-toolkit/dso-toolkit/issues/1034))
 
 ## 20.0.0
-
-### Fixed
-* **dso-toolkit:** Definition lists in geneste accordion ([#1034](https://github.com/dso-toolkit/dso-toolkit/issues/1034))
 
 ### Fixed
 * **dso-toolkit:** dso-info buiten legend gebruikt aria-hidden ipv aria-hidden="true" ([#1031](https://github.com/dso-toolkit/dso-toolkit/issues/1031))

--- a/packages/dso-toolkit/components/Componenten/accordion/accordion.njk
+++ b/packages/dso-toolkit/components/Componenten/accordion/accordion.njk
@@ -103,6 +103,9 @@
                           {{ subsection.richContent | safe }}
                         </div>
                       {% endif %}
+                      {% if subsection.definitions %}
+                        {% render '@definition-list', {definitions: subsection.definitions} %}
+                      {% endif %}
                       {% if subsection.fieldsets %}
                         {% render '@form-fieldsets', {fieldsets: subsection.fieldsets} %}
                         {% render '@form-buttons', {buttons: subsection.buttons} %}


### PR DESCRIPTION
In de njk markup is het mogelijk gemaakt dat er een definition-list in een geneste accordion geplaatst kan worden, dus niet alleen op het hoogste nivo.