### PR TITLE
#1037 : Instelbare buttontekst mogelijk maken bij search-bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## NEXT
 ### Changed
 * **dso-toolkit:** Margin onder tabs ([#1027](https://github.com/dso-toolkit/dso-toolkit/issues/1027))
+* **dso-toolkit:** Instelbare buttontekst mogelijk maken bij search-bar ([#1037](https://github.com/dso-toolkit/dso-toolkit/issues/1037))
 
 ## 20.0.0
 

--- a/packages/dso-toolkit/components/Componenten/search-bar/search-bar.njk
+++ b/packages/dso-toolkit/components/Componenten/search-bar/search-bar.njk
@@ -33,7 +33,11 @@
     {% endif %}
   </div>
   <button type="button" {{ className('btn btn-default', [hideSearchButton, 'sr-only']) }}>
-    Button
+    {% if buttonLabel -%}
+      { buttonLabel }
+    {% else -%}
+      Button
+    {% endif %}
   </button>
 </div>
 {% if resultsMessage -%}


### PR DESCRIPTION
In de njk markup was de buttontekst bij de serach-bar hard-coded