### PR TITLE
#1042 : Variabelen voor verticale marges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * **dso-toolkit + styling**: Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
 ### Added
-* **styling:** Variabelen voor verticale marges ([1042](https://github.com/dso-toolkit/dso-toolkit/issues/907))
+* **styling:** Variabelen voor verticale marges ([#1042](https://github.com/dso-toolkit/dso-toolkit/issues/1042))
 
 ### Deprecated
 * **dso-toolkit:** Toelichting vraag onder antwoorden deprecaten ([#920](https://github.com/dso-toolkit/dso-toolkit/issues/920)) **Deprecation notice, see PR ([#1017](https://github.com/dso-toolkit/dso-toolkit/pull/1017))**
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **BREAKING** **dso-toolkit:** Tree view: h3 buiten button ([#933](https://github.com/dso-toolkit/dso-toolkit/issues/933)) **Markup changes, see PR ([#971](https://github.com/dso-toolkit/dso-toolkit/pull/971))**
 
 ### Added
-* **dso-toolkit** Variabelen voor verticale marges ([1042](https://github.com/dso-toolkit/dso-toolkit/issues/1042))
+* **dso-toolkit** Info-component zonder sluitmogelijkheid ([#907](https://github.com/dso-toolkit/dso-toolkit/issues/907))
 
 ## 17.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **dso-toolkit + styling**: Moved table styling ([#935](https://github.com/dso-toolkit/dso-toolkit/issues/935))
+### Added
+* **styling:** Variabelen voor verticale marges ([1042](https://github.com/dso-toolkit/dso-toolkit/issues/907))
 
 ### Deprecated
 * **dso-toolkit:** Toelichting vraag onder antwoorden deprecaten ([#920](https://github.com/dso-toolkit/dso-toolkit/issues/920)) **Deprecation notice, see PR ([#1017](https://github.com/dso-toolkit/dso-toolkit/pull/1017))**
@@ -34,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **BREAKING** **dso-toolkit:** Tree view: h3 buiten button ([#933](https://github.com/dso-toolkit/dso-toolkit/issues/933)) **Markup changes, see PR ([#971](https://github.com/dso-toolkit/dso-toolkit/pull/971))**
 
 ### Added
-* **dso-toolkit** Info-component zonder sluitmogelijkheid ([#907](https://github.com/dso-toolkit/dso-toolkit/issues/907))
+* **dso-toolkit** Variabelen voor verticale marges ([1042](https://github.com/dso-toolkit/dso-toolkit/issues/1042))
 
 ## 17.1.0
 

--- a/packages/styling/variables/units.scss
+++ b/packages/styling/variables/units.scss
@@ -31,3 +31,8 @@ $input-border-radius: 4px;
 
 // Super weird shared unit..
 $dso-shared-equal-heights-highlight-box-height: $u6;
+
+$dso-vertical-spacing-small: $u1;
+$dso-vertical-spacing-medium: $u2;
+$dso-vertical-spacing-large: $u3;
+$dso-vertical-spacing-xlarge: $u4;


### PR DESCRIPTION
Voor een consequente toepassingen van verticale marges, worden de volgende variabelen gedefinieerd:
```
$dso-vertical-spacing-small: $u1;       //8px
$dso-vertical-spacing-medium: $u2; //16px
$dso-vertical-spacing-large: $u3;      //24px
$dso-vertical-spacing-xlarge: $u4;    //32px