### PR TITLE
#1078 Group checkboxes: bad value bij aria-expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## NEXT
 
 ### Changed
-* **dso-toolkit + styling:** H1 Anchor bovenaan toolkit herontwerp ([#1049](https://github.com/dso-toolkit/dso-toolkit/issues/1049))
-
-### Fixed
+* **dso-toolkit + styling:** Herontwerp link bij H1 om component preview te openen ([#1049](https://github.com/dso-toolkit/dso-toolkit/issues/1049))
 * **dso-toolkit:** Visited state in Tabs verwijderen ([#1073](https://github.com/dso-toolkit/dso-toolkit/issues/1073))
 * **styling:** Alert responsive styling op smalle viewport ([#1064](https://github.com/dso-toolkit/dso-toolkit/issues/1064))
+
+### Fixed
+* **dso-toolkit:** Group checkboxes: bad value bij aria-expanded ([#1078](https://github.com/dso-toolkit/dso-toolkit/issues/1078))
 
 ## 21.2.0
 

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.config.yml
@@ -95,6 +95,7 @@ variants:
     options:
     - value: 1
       label: een
+      infoOpen: false
       infoButtonLabel: Toelichting bij antwoord
       infoText: |
         Closed
@@ -137,6 +138,7 @@ variants:
     options:
     - value: 1
       label: een
+      infoOpen: false
       infoButtonLabel: Toelichting bij antwoord
       infoText: |
         Closed

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-checkboxes.njk
@@ -39,7 +39,7 @@
       {% render '@help-block', {helpText: helpText, id: localId} %}
     {% endif %}
   </div>
-  {% if infoOpen %}
+  {% if infoOpen and infoTextDeprecated %}
     {% render '@info', {infoText: infoTextDeprecated} %}
   {% endif %}
 </fieldset>

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-radios.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-radios.config.yml
@@ -112,6 +112,7 @@ variants:
         </p>
     - value: 2
       label: nee
+      infoOpen: false
       infoButtonLabel: Toelichting bij antwoord
       infoText: |
         Closed

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-radios.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-radios.njk
@@ -39,7 +39,7 @@
       {% render '@help-block', {helpText: helpText, id: localId} %}
     {% endif %}
   </div>
-  {% if infoOpen %}
+  {% if infoOpen and infoTextDeprecated %}
     {% render '@info', {infoText: infoTextDeprecated} %}
   {% endif %}
 </fieldset>

--- a/packages/dso-toolkit/components/Componenten/info-button/info-button.njk
+++ b/packages/dso-toolkit/components/Componenten/info-button/info-button.njk
@@ -1,4 +1,7 @@
-<button type="button" {{ className('btn dso-info-button', [infoOpen, 'dso-open']) }} aria-expanded="{{ infoOpen }}">
+<button type="button"
+  {{ className('btn dso-info-button', [infoOpen, 'dso-open']) }}
+  {{ attributes([infoOpen, 'aria-expanded', not(not(infoOpen)), true]) }}
+>
   <span class="sr-only">
     {%- if infoButtonLabel -%}
       {{ infoButtonLabel }}

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-info-button.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-info-button.html
@@ -27,7 +27,7 @@
       <label for="input-checkbox-info-button-0">
         een
       </label>
-      <button type="button" class="btn dso-info-button" aria-expanded="">
+      <button type="button" class="btn dso-info-button" aria-expanded="false">
         <span class="sr-only">Toelichting bij antwoord</span>
       </button>
     </div>

--- a/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-static-info.html
+++ b/packages/dso-toolkit/reference/render/group-checkboxes--input-checkbox-static-info.html
@@ -21,7 +21,7 @@
       <label for="input-checkbox-static-info-0">
         een
       </label>
-      <button type="button" class="btn dso-info-button" aria-expanded="">
+      <button type="button" class="btn dso-info-button" aria-expanded="false">
         <span class="sr-only">Toelichting bij antwoord</span>
       </button>
     </div>
@@ -46,13 +46,6 @@
       <label for="input-checkbox-static-info-2">
         drie
       </label>
-    </div>
-  </div>
-  <div class="dso-info">
-    <button type="button">
-      <span class="sr-only">Sluiten</span>
-    </button>
-    <div class="dso-rich-content">
     </div>
   </div>
 </fieldset>

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-inline-info.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-inline-info.html
@@ -49,7 +49,7 @@
       <label for="input-radio-inline-info-1">
         nee
       </label>
-      <button type="button" class="btn dso-info-button" aria-expanded="">
+      <button type="button" class="btn dso-info-button" aria-expanded="false">
         <span class="sr-only">Toelichting bij antwoord</span>
       </button>
     </div>

--- a/packages/dso-toolkit/reference/render/group-radios--input-radio-static-info.html
+++ b/packages/dso-toolkit/reference/render/group-radios--input-radio-static-info.html
@@ -40,11 +40,4 @@
     </div>
     <p class="dso-help-block" id="helpTextId_input-radio-static-info">Antwoord hier met &quot;Ja&quot; of &quot;Nee&quot;</p>
   </div>
-  <div class="dso-info">
-    <button type="button">
-      <span class="sr-only">Sluiten</span>
-    </button>
-    <div class="dso-rich-content">
-    </div>
-  </div>
 </fieldset>

--- a/packages/dso-toolkit/reference/render/omgevingsoverleg.html
+++ b/packages/dso-toolkit/reference/render/omgevingsoverleg.html
@@ -108,13 +108,6 @@
           </label>
         </div>
       </div>
-      <div class="dso-info">
-        <button type="button">
-          <span class="sr-only">Sluiten</span>
-        </button>
-        <div class="dso-rich-content">
-        </div>
-      </div>
     </fieldset>
     <dl>
       <dt>Verzoek 1:</dt>


### PR DESCRIPTION
* not(not()) om null 'falsy' te behandelen
* expliciete infoOpen: false bij infoText Closed
* geen loze dso-info vanwege deprecation