### PR TITLE
#1024.Scheidingslijnen-styling-consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Changed
+* **dso-toolkit + styling:** Scheidingslijnen styling consistent ([#1024](https://github.com/dso-toolkit/dso-toolkit/issues/1024))
+
 ## 21.3.0
 
 ### Added

--- a/packages/dso-toolkit/libs/bootstrap/_variables.scss
+++ b/packages/dso-toolkit/libs/bootstrap/_variables.scss
@@ -670,4 +670,4 @@ $dl-horizontal-offset:        $component-offset-horizontal !default;
 //** Point at which .dl-horizontal becomes horizontal
 $dl-horizontal-breakpoint:    $grid-float-breakpoint !default;
 //** Horizontal line color.
-$hr-border:                   $gray-lighter !default;
+$hr-border:                   $grijs-20 !default;

--- a/packages/dso-toolkit/src/styles/components/_card.scss
+++ b/packages/dso-toolkit/src/styles/components/_card.scss
@@ -26,7 +26,7 @@ ol {
     }
 
     > li + li {
-      border-top: 1px solid $grijs-10;
+      border-top: 1px solid $grijs-20;
     }
   }
 }

--- a/packages/dso-toolkit/src/styles/components/_definition-list.scss
+++ b/packages/dso-toolkit/src/styles/components/_definition-list.scss
@@ -7,7 +7,7 @@ $dso-definition-list-highlight-color: $grasgroen;
 dl {
   + dl {
     &::before {
-      border-bottom: 1px solid $grijs-10;
+      border-bottom: 1px solid $grijs-20;
       content: " ";
       display: block;
       float: left;

--- a/packages/dso-toolkit/src/styles/components/_footnotes.scss
+++ b/packages/dso-toolkit/src/styles/components/_footnotes.scss
@@ -1,7 +1,7 @@
 .dso-footnotes {
   @include list-unstyled();
 
-  border-top: 1px solid $grijs-40;
+  border-top: 1px solid $grijs-20;
   padding-top: #{$dso-unit * 1.5};
 
   .dso-footnote-backlink::after {

--- a/packages/dso-toolkit/src/styles/components/_modal.scss
+++ b/packages/dso-toolkit/src/styles/components/_modal.scss
@@ -5,7 +5,7 @@ $dso-modal-max-height: 70vh;
 $dso-modal-backdrop-bg: $wit;
 $dso-modal-backdrop-opacity: 0.2;
 $dso-modal-content-bg: $wit;
-$dso-modal-border-color: #d3ddd6;
+$dso-modal-border-color: $grijs-20;
 
 $dso-modal-close-icon-size: $u4;
 

--- a/packages/dso-toolkit/src/styles/components/_steps.scss
+++ b/packages/dso-toolkit/src/styles/components/_steps.scss
@@ -4,7 +4,7 @@ $step-padding: 12px;
 .dso-steps-indicator {
   @extend %is-h2;
 
-  border-bottom: 1px solid $bosgroen-60;
+  border-bottom: 1px solid $grijs-20;
   padding-bottom: $step-indicator-padding;
 
   span.dso-step {

--- a/packages/styling/components/table.scss
+++ b/packages/styling/components/table.scss
@@ -7,7 +7,7 @@ $table-cell-padding: $u1;
 $table-bg: transparent;
 $table-bg-hover: $grijs-10;
 $table-bg-active: $grijs-10;
-$table-border-color: $grijs-30;
+$table-border-color: $grijs-20;
 $table-link-color: $grijs-90;
 $table-header-border-color: $grijs-60;
 


### PR DESCRIPTION
**Implementatie informatie**

_Geen_

-----

**Pull request informatie**

Oude kleuren zijn nu vervangen in de $grijs-20 (#ccc) variant

Oude situatie:
https://dso-toolkit.nl/21.3.0/components/detail/cards.html
https://dso-toolkit.nl/21.3.0/components/detail/footnotes.html
https://dso-toolkit.nl/21.3.0/components/detail/form-steps.html
https://dso-toolkit.nl/21.3.0/components/detail/modal.html
https://dso-toolkit.nl/21.3.0/components/detail/panel.html
https://dso-toolkit.nl/21.3.0/components/detail/omgevingsoverleg.html
https://dso-toolkit.nl/21.3.0/components/detail/rich-content.html
https://dso-toolkit.nl/21.3.0/components/detail/table.html

Nieuwe situatie:
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/cards.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/footnotes.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/form-steps.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/modal.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/panel.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/omgevingsoverleg.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/rich-content.html
https://dso-toolkit.nl/_1024.Scheidingslijnen-styling-consistent/components/detail/table.html