### PR TITLE
#1083 : Variant toevoegen voor Progress Indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 Note: This release was first released as v21.3.0. We missed that [#857](https://github.com/dso-toolkit/dso-toolkit/issues/857)
  was a breaking change, so we re-released this version with updated CHANGELOG instructions.
 
-## 21.3.0
 
 ### Added
 * **dso-toolkit + core + styling:** Web component Banner ([#857](https://github.com/dso-toolkit/dso-toolkit/issues/857))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Added
+* **dso-toolkit:** Variant toevoegen voor Progress Indicator ([#1083](https://github.com/dso-toolkit/dso-toolkit/issues/1083))
+
 ### Fixed
 * **dso-toolkit:** Shopping Cart subitems hebben niet voldoende padding aan de rechterkant ([#1084](https://github.com/dso-toolkit/dso-toolkit/issues/1084))
 
@@ -17,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 Note: This release was first released as v21.3.0. We missed that [#857](https://github.com/dso-toolkit/dso-toolkit/issues/857)
  was a breaking change, so we re-released this version with updated CHANGELOG instructions.
+
 ## 21.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * **dso-toolkit:** Shopping Cart subitems hebben niet voldoende padding aan de rechterkant ([#1084](https://github.com/dso-toolkit/dso-toolkit/issues/1084))
 
-
 ### Changed
 * **dso-toolkit + styling:** Scheidingslijnen styling consistent ([#1024](https://github.com/dso-toolkit/dso-toolkit/issues/1024))
 * **dso-toolkit + styling:** Banner; Responsive ontwerp ([#768](https://github.com/dso-toolkit/dso-toolkit/issues/768))
@@ -20,7 +19,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 Note: This release was first released as v21.3.0. We missed that [#857](https://github.com/dso-toolkit/dso-toolkit/issues/857)
  was a breaking change, so we re-released this version with updated CHANGELOG instructions.
-
 
 ### Added
 * **dso-toolkit + core + styling:** Web component Banner ([#857](https://github.com/dso-toolkit/dso-toolkit/issues/857))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * **dso-toolkit:** Shopping Cart subitems hebben niet voldoende padding aan de rechterkant ([#1084](https://github.com/dso-toolkit/dso-toolkit/issues/1084))
 
+
 ### Changed
 * **dso-toolkit + styling:** Scheidingslijnen styling consistent ([#1024](https://github.com/dso-toolkit/dso-toolkit/issues/1024))
 * **dso-toolkit + styling:** Banner; Responsive ontwerp ([#768](https://github.com/dso-toolkit/dso-toolkit/issues/768))
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 Note: This release was first released as v21.3.0. We missed that [#857](https://github.com/dso-toolkit/dso-toolkit/issues/857)
  was a breaking change, so we re-released this version with updated CHANGELOG instructions.
+## 21.3.0
 
 ### Added
 * **dso-toolkit + core + styling:** Web component Banner ([#857](https://github.com/dso-toolkit/dso-toolkit/issues/857))

--- a/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.config.yml
+++ b/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.config.yml
@@ -1,10 +1,12 @@
 notes: |
-  De progress indicator is er in drie groottes (`dso-small`: 24px, `dso-medium`: 32px, `dso-large`: 48px).
-  Toevoeging class `dso-block` zorgt voor horizontaal en verticaal gecentreerde progress-indicator;
-  icm. class `dso-small` zorgt voor een (afhankelijk van de inhoud minimaal) 48px hoge progress indicator;
-  icm. class `dso-medium` zorgt voor een (afhankelijk van de inhoud minimaal) 64px hoge progress indicator;
-  icm. class `dso-large` zorgt voor een (afhankelijk van de inhoud minimaal) 96px hoge progress indicator;
-  icm. class `dso-gray` zorgt dit voor een lichtgrijze achtergrond.
+  De progress indicator is er in drie groottes (`dso-small`: 24px, `dso-medium`: 32px, `dso-large`: 48px);
+
+  * toevoeging class `dso-block` zorgt voor horizontaal en verticaal gecentreerde progress-indicator;
+  * icm. class `dso-small` zorgt dit voor een (afhankelijk van de inhoud minimaal) 48px hoge progress indicator;
+  * icm. class `dso-medium` zorgt dit voor een (afhankelijk van de inhoud minimaal) 64px hoge progress indicator;
+  * icm. class `dso-large` zorgt dit voor een (afhankelijk van de inhoud minimaal) 96px hoge progress indicator;
+  * icm. class `dso-gray` zorgt dit voor een lichtgrijze achtergrond.
+
 status: ready
 collated: true
 context:

--- a/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.config.yml
+++ b/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.config.yml
@@ -1,5 +1,10 @@
 notes: |
-  De progress indicator is er in drie groottes (small: 24px, medium: 32px, large: 48px). 
+  De progress indicator is er in drie groottes (`dso-small`: 24px, `dso-medium`: 32px, `dso-large`: 48px).
+  Toevoeging class `dso-block` zorgt voor horizontaal en verticaal gecentreerde progress-indicator;
+  icm. class `dso-small` zorgt voor een (afhankelijk van de inhoud minimaal) 48px hoge progress indicator;
+  icm. class `dso-medium` zorgt voor een (afhankelijk van de inhoud minimaal) 64px hoge progress indicator;
+  icm. class `dso-large` zorgt voor een (afhankelijk van de inhoud minimaal) 96px hoge progress indicator;
+  icm. class `dso-gray` zorgt dit voor een lichtgrijze achtergrond.
 status: ready
 collated: true
 context:

--- a/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.config.yml
+++ b/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.config.yml
@@ -3,16 +3,31 @@ notes: |
 status: ready
 collated: true
 context:
-  __title: Spinner 24px groot
+  __title: Spinner small (24px)
   status: Een moment geduld alstublieft.
   size: small
 variants:
 - name: spinner-medium-infinite
   context:
-    __title: Spinner 32px groot
+    __title: Spinner medium (32px)
     size: medium
 - name: spinner-large-infinite
   context:
-    __title: Spinner 48px groot
+    __title: Spinner large (48px)
     size: large
-
+- name: spinner-small-block
+  context:
+    __title: Spinner small - gecentreerd blok
+    size: small
+    block: true
+- name: spinner-medium-block-background
+  context:
+    __title: Spinner medium - gecentreerd blok met achtergrond
+    size: medium
+    block: true
+    color: gray
+- name: spinner-large-block
+  context:
+    __title: Spinner large - gecentreerd blok
+    size: large
+    block: true

--- a/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.njk
+++ b/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.njk
@@ -1,3 +1,3 @@
-<div {{ className('dso-progress-indicator', 'dso-progress-indicator-looping', [size, 'dso-' + size]) }} role="progressbar" aria-valuetext="{{ status }}">
+<div {{ className('dso-progress-indicator', 'dso-progress-indicator-looping', [size, 'dso-' + size], [block, 'dso-block'], [block, 'dso-' + color]) }} role="progressbar" aria-valuetext="{{ status }}">
   <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">{{- status -}}</span>
 </div>

--- a/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.njk
+++ b/packages/dso-toolkit/components/Componenten/progress-indicator/progress-indicator.njk
@@ -1,3 +1,3 @@
-<div {{ className('dso-progress-indicator', 'dso-progress-indicator-looping', [size, 'dso-' + size], [block, 'dso-block'], [block, 'dso-' + color]) }} role="progressbar" aria-valuetext="{{ status }}">
+<div {{ className('dso-progress-indicator', 'dso-progress-indicator-looping', [size, 'dso-' + size], [block, 'dso-block'], [(block and color), 'dso-' + color]) }} role="progressbar" aria-valuetext="{{ status }}">
   <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">{{- status -}}</span>
 </div>

--- a/packages/dso-toolkit/reference/render/progress-indicator--spinner-large-block.html
+++ b/packages/dso-toolkit/reference/render/progress-indicator--spinner-large-block.html
@@ -1,3 +1,3 @@
-<div class="dso-progress-indicator dso-progress-indicator-looping dso-large dso-block dso-undefined" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
+<div class="dso-progress-indicator dso-progress-indicator-looping dso-large dso-block" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
   <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">Een moment geduld alstublieft.</span>
 </div>

--- a/packages/dso-toolkit/reference/render/progress-indicator--spinner-large-block.html
+++ b/packages/dso-toolkit/reference/render/progress-indicator--spinner-large-block.html
@@ -1,0 +1,3 @@
+<div class="dso-progress-indicator dso-progress-indicator-looping dso-large dso-block dso-undefined" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
+  <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">Een moment geduld alstublieft.</span>
+</div>

--- a/packages/dso-toolkit/reference/render/progress-indicator--spinner-medium-block-background.html
+++ b/packages/dso-toolkit/reference/render/progress-indicator--spinner-medium-block-background.html
@@ -1,0 +1,3 @@
+<div class="dso-progress-indicator dso-progress-indicator-looping dso-medium dso-block dso-gray" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
+  <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">Een moment geduld alstublieft.</span>
+</div>

--- a/packages/dso-toolkit/reference/render/progress-indicator--spinner-small-block.html
+++ b/packages/dso-toolkit/reference/render/progress-indicator--spinner-small-block.html
@@ -1,0 +1,3 @@
+<div class="dso-progress-indicator dso-progress-indicator-looping dso-small dso-block dso-undefined" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
+  <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">Een moment geduld alstublieft.</span>
+</div>

--- a/packages/dso-toolkit/reference/render/progress-indicator--spinner-small-block.html
+++ b/packages/dso-toolkit/reference/render/progress-indicator--spinner-small-block.html
@@ -1,3 +1,3 @@
-<div class="dso-progress-indicator dso-progress-indicator-looping dso-small dso-block dso-undefined" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
+<div class="dso-progress-indicator dso-progress-indicator-looping dso-small dso-block" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
   <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">Een moment geduld alstublieft.</span>
 </div>

--- a/packages/dso-toolkit/src/styles/components/_progress-indicator.scss
+++ b/packages/dso-toolkit/src/styles/components/_progress-indicator.scss
@@ -5,12 +5,20 @@
     position: relative;
     vertical-align: middle;
   }
+
+  &.dso-block {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+
+    &.dso-gray {
+      background-color: $grijs-10;
+    }
+  }
 }
 
 @mixin dso-progress-indicator-looping-dims($dso-progress-indicator-name, $dso-progress-indicator-size, $dso-progress-indicator-border-width) {
   &.dso-#{$dso-progress-indicator-name} {
-    line-height: $dso-progress-indicator-size;
-
     .dso-progress-indicator-spinner {
       height: $dso-progress-indicator-size;
       width: $dso-progress-indicator-size;
@@ -26,19 +34,32 @@
 .dso-progress-indicator-looping {
   .dso-progress-indicator-spinner {
     background-image: url("data:image/svg+xml,%3Csvg class='spinner' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg' %3E%3Cstyle%3E .spinner %7B animation: rotator 8s linear infinite; transform-origin: center; %7D @keyframes rotator %7B 0%25 %7B transform: rotate(0deg); %7D 100%25 %7B transform: rotate(360deg); %7D %7D .path %7B stroke-dasharray: 265; stroke-dashoffset: 0; transform-origin: center; stroke: %2339870c; animation: dash 2s ease-in-out infinite; %7D @keyframes dash %7B 0%25 %7B stroke-dashoffset: 265; %7D 50%25 %7B stroke-dashoffset: 65; transform:rotate(90deg); %7D 100%25 %7B stroke-dashoffset: 265; transform:rotate(360deg); %7D %3C/style%3E%3Ccircle class='path' fill='none' stroke-width='10' stroke-linecap='butt' cx='50' cy='50' r='45'%3E%3C/circle%3E%3C/svg%3E");
+    background-repeat: no-repeat;
   }
 
   &.dso-small,
   &:not(.dso-medium):not(.dso-large) {
     @include dso-progress-indicator-looping-dims(small, 24px, 2px);
+
+    &.dso-block {
+      padding: $u1 * 1.5 $u2;
+    }
   }
 
   &.dso-medium {
     @include dso-progress-indicator-looping-dims(medium, 32px, 3px);
+
+    &.dso-block {
+      padding: $u2;
+    }
   }
 
   &.dso-large {
     @include dso-progress-indicator-looping-dims(large, 48px, 4px);
+
+    &.dso-block {
+      padding: $u3 $u2;
+    }
   }
 
   .dso-progress-indicator-spinner-mask {


### PR DESCRIPTION
**Implementatie informatie**

Toevoeging class `dso-block` zorgt voor horizontaal en verticaal gecentreerde progress-indicator;
icm. class `dso-small` zorgt voor een (afhankelijk van de inhoud minimaal) 48px hoge progress indicator;
icm. class `dso-medium` zorgt voor een (afhankelijk van de inhoud minimaal) 64px hoge progress indicator;
icm. class `dso-large` zorgt voor een (afhankelijk van de inhoud minimaal) 96px hoge progress indicator;
icm. class `dso-gray` zorgt dit voor een lichtgrijze achtergrond.

Voorbeeld: 

```
<div class="dso-progress-indicator dso-progress-indicator-looping dso-medium dso-block dso-gray" role="progressbar" aria-valuetext="Een moment geduld alstublieft.">
  <div class="dso-progress-indicator-spinner"></div><span class="dso-progress-indicator-label">Een moment geduld alstublieft.</span>
</div>
```

---

**Pull request informatie**

https://www.dso-toolkit.nl/_1083.Variant-toevoegen-voor-Progress-Indicator/components/detail/progress-indicator.html