### PR TITLE
#1131.Navigations-aria-current-page-toevoegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **css + dso-toolkit + stories + styling** Storybook HTML - Footnotes ([#1110](https://github.com/dso-toolkit/dso-toolkit/issues/1110))
 * **css + dso-toolkit + stories + styling** Storybook HTML - Description ([#1109](https://github.com/dso-toolkit/dso-toolkit/issues/1109))
 
+* **dso-toolkit:** Navigations:aria-current='page' toevoegen ([#1131](https://github.com/dso-toolkit/dso-toolkit/issues/1131))
 ## 24.0.0
 
 ### Fixed

--- a/packages/dso-toolkit/components/Componenten/navigations/navigations.njk
+++ b/packages/dso-toolkit/components/Componenten/navigations/navigations.njk
@@ -10,7 +10,7 @@
   <ul {{ className('dso-nav', 'dso-nav-' + modifier) }}>
     {%- for item in items %}
       <li {{ className([item.active, 'dso-active']) }}>
-        <a href="#">
+        <a href="#" {{ attributes([item.active, 'aria-current="page"']) }}>
           {{ item.label }}
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/404pagina.html
+++ b/packages/dso-toolkit/reference/render/404pagina.html
@@ -28,7 +28,7 @@
         </a>
       </li>
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Aanvragen
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/beheer-basis.html
+++ b/packages/dso-toolkit/reference/render/beheer-basis.html
@@ -18,7 +18,7 @@
     </div>
     <ul class="dso-nav dso-nav-main">
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Menu titel A
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/full-width.html
+++ b/packages/dso-toolkit/reference/render/full-width.html
@@ -8,7 +8,7 @@
     </div>
     <ul class="dso-nav dso-nav-main">
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Home
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/header.html
+++ b/packages/dso-toolkit/reference/render/header.html
@@ -33,7 +33,7 @@
         </a>
       </li>
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Regels op de kaart
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/homepage.html
+++ b/packages/dso-toolkit/reference/render/homepage.html
@@ -31,7 +31,7 @@
     </div>
     <ul class="dso-nav dso-nav-main">
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Home
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/landingspagina.html
+++ b/packages/dso-toolkit/reference/render/landingspagina.html
@@ -33,7 +33,7 @@
         </a>
       </li>
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Regels op de kaart
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/navigations--default.html
+++ b/packages/dso-toolkit/reference/render/navigations--default.html
@@ -7,7 +7,7 @@
   </div>
   <ul class="dso-nav dso-nav-main">
     <li class="dso-active">
-      <a href="#">
+      <a href="#" aria-current="page">
         Home
       </a>
     </li>

--- a/packages/dso-toolkit/reference/render/navigations--secondary.html
+++ b/packages/dso-toolkit/reference/render/navigations--secondary.html
@@ -1,7 +1,7 @@
 <nav class="dso-navbar">
   <ul class="dso-nav dso-nav-sub">
     <li class="dso-active">
-      <a href="#">
+      <a href="#" aria-current="page">
         Deze locatie
       </a>
     </li>

--- a/packages/dso-toolkit/reference/render/overzicht-samenwerkingen.html
+++ b/packages/dso-toolkit/reference/render/overzicht-samenwerkingen.html
@@ -18,7 +18,7 @@
     </div>
     <ul class="dso-nav dso-nav-main">
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Samenwerkingen
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/pagina-met-banner.html
+++ b/packages/dso-toolkit/reference/render/pagina-met-banner.html
@@ -50,7 +50,7 @@
           </a>
         </li>
         <li class="dso-active">
-          <a href="#">
+          <a href="#" aria-current="page">
             Regels op de kaart
           </a>
         </li>

--- a/packages/dso-toolkit/reference/render/row-equal-heights.html
+++ b/packages/dso-toolkit/reference/render/row-equal-heights.html
@@ -33,7 +33,7 @@
         </a>
       </li>
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Regels op de kaart
         </a>
       </li>

--- a/packages/dso-toolkit/reference/render/zoeken-in-lijst-cards.html
+++ b/packages/dso-toolkit/reference/render/zoeken-in-lijst-cards.html
@@ -23,7 +23,7 @@
         </a>
       </li>
       <li class="dso-active">
-        <a href="#">
+        <a href="#" aria-current="page">
           Zoeken in wetgeving
         </a>
       </li>

--- a/packages/dso-toolkit/theme/js/components/browser.js
+++ b/packages/dso-toolkit/theme/js/components/browser.js
@@ -22,14 +22,14 @@ export default class Browser {
     tabs.on('click', e => {
       const link = $(e.target).closest('a');
       const tab = link.parent();
-      tabs.removeClass(ac).find('a').attr('aria-selected', 'false');
+      tabs.removeClass(ac).find('a').attr('aria-selected', 'false').removeAttr('aria-current');
       set(`browser.selectedTabIndex`, tabs.index(tab));
-      tab.addClass(ac).find('a').attr('aria-selected', 'true');
+      tab.addClass(ac).find('a').attr('aria-selected', 'true').attr('aria-current', 'page');
       this._tabPanels.removeClass(ac).removeAttr('aria-current');
       this._tabPanels.filter(link.attr('href')).addClass(ac).attr('aria-current', true);
       return false;
     });
-    tabs.removeClass('is-active').find('a').attr('aria-selected', 'false');
+    tabs.removeClass('is-active').find('a').attr('aria-selected', 'false').removeAttr('aria-current');
     tabs.eq(selectedIndex).find('a').trigger('click');
   }
 }


### PR DESCRIPTION
**Implementatie informatie**

Een actief navigatie item dient nu een `aria-current="page"` op de `<a>` te bevatten.

```
<ul class="dso-nav dso-nav-main">
  <li class="dso-active">
    <a href="#" aria-current="page">
      Home
    </a>
  </li>
  <li>
    <a href="#">
      Vergunningcheck
    </a>
  </li>
</ul>
```

-----

**Pull request informatie**

Oude situatie:
https://dso-toolkit.nl/24.0.0/components/detail/navigations.html

Nieuwe situatie:
https://dso-toolkit.nl/_1131.Navigations-aria-current-page-toevoegen/components/detail/navigations.html