### PR TITLE
#1134.Navigations: aria-expanded en label hamburger knopje aanpassen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **css + dso-toolkit + stories + styling** Storybook HTML - Description ([#1109](https://github.com/dso-toolkit/dso-toolkit/issues/1109))
 
 * **dso-toolkit:** Navigations:aria-current='page' toevoegen ([#1131](https://github.com/dso-toolkit/dso-toolkit/issues/1131))
+
+### Fixed
+* **dso-toolkit**: Recente `dso.css` is niet te bundlen met Angular v12 ([#1140](https://github.com/dso-toolkit/dso-toolkit/issues/1140))
+
 ## 24.0.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **dso-toolkit:** Breadcrumb: Slashes moeten niet worden voorgelezen door een screenreader ([#1133](https://github.com/dso-toolkit/dso-toolkit/issues/1133))
 * **css + dso-toolkit + stories + styling** Storybook HTML - Footnotes ([#1110](https://github.com/dso-toolkit/dso-toolkit/issues/1110))
 * **css + dso-toolkit + stories + styling** Storybook HTML - Description ([#1109](https://github.com/dso-toolkit/dso-toolkit/issues/1109))
-
-* **dso-toolkit:** Navigations:aria-current='page' toevoegen ([#1131](https://github.com/dso-toolkit/dso-toolkit/issues/1131))
+* **dso-toolkit:** Navigations: aria-current="page" toevoegen ([#1131](https://github.com/dso-toolkit/dso-toolkit/issues/1131))
+* **dso-toolkit:** Navigations: aria-expanded en label hamburger knopje aanpassen ([#1134](https://github.com/dso-toolkit/dso-toolkit/issues/1134))
 
 ### Fixed
 * **dso-toolkit**: Recente `dso.css` is niet te bundlen met Angular v12 ([#1140](https://github.com/dso-toolkit/dso-toolkit/issues/1140))

--- a/packages/dso-toolkit/components/Componenten/navigations/navigations.njk
+++ b/packages/dso-toolkit/components/Componenten/navigations/navigations.njk
@@ -1,9 +1,9 @@
 <nav {{ className('dso-navbar', [open, 'dso-open']) }}>
   {% if modifier === 'main' %}
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" {{ attributes([open, 'aria-expanded', not(not(open)), true]) }}>
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
   {% endif %}

--- a/packages/dso-toolkit/reference/render/404pagina.html
+++ b/packages/dso-toolkit/reference/render/404pagina.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/beheer-basis.html
+++ b/packages/dso-toolkit/reference/render/beheer-basis.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/full-width.html
+++ b/packages/dso-toolkit/reference/render/full-width.html
@@ -1,9 +1,9 @@
 <header>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/header.html
+++ b/packages/dso-toolkit/reference/render/header.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/homepage.html
+++ b/packages/dso-toolkit/reference/render/homepage.html
@@ -24,9 +24,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/landingspagina.html
+++ b/packages/dso-toolkit/reference/render/landingspagina.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/navigations--default.html
+++ b/packages/dso-toolkit/reference/render/navigations--default.html
@@ -1,8 +1,8 @@
 <nav class="dso-navbar">
   <div class="dso-navbar-header">
-    <button type="button" class="dso-navbar-toggle btn btn-default">
+    <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
       <dso-icon icon="bars"></dso-icon>
-      <span class="sr-only">Ga naar menu</span>
+      <span class="sr-only">Menu</span>
     </button>
   </div>
   <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/overzicht-samenwerkingen.html
+++ b/packages/dso-toolkit/reference/render/overzicht-samenwerkingen.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/pagina-met-banner.html
+++ b/packages/dso-toolkit/reference/render/pagina-met-banner.html
@@ -28,9 +28,9 @@
     </div>
     <nav class="dso-navbar">
       <div class="dso-navbar-header">
-        <button type="button" class="dso-navbar-toggle btn btn-default">
+        <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
           <dso-icon icon="bars"></dso-icon>
-          <span class="sr-only">Ga naar menu</span>
+          <span class="sr-only">Menu</span>
         </button>
       </div>
       <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/row-equal-heights.html
+++ b/packages/dso-toolkit/reference/render/row-equal-heights.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/reference/render/zoeken-in-lijst-cards.html
+++ b/packages/dso-toolkit/reference/render/zoeken-in-lijst-cards.html
@@ -11,9 +11,9 @@
   </div>
   <nav class="dso-navbar">
     <div class="dso-navbar-header">
-      <button type="button" class="dso-navbar-toggle btn btn-default">
+      <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
         <dso-icon icon="bars"></dso-icon>
-        <span class="sr-only">Ga naar menu</span>
+        <span class="sr-only">Menu</span>
       </button>
     </div>
     <ul class="dso-nav dso-nav-main">

--- a/packages/dso-toolkit/src/styles/components/_modal.scss
+++ b/packages/dso-toolkit/src/styles/components/_modal.scss
@@ -14,6 +14,16 @@ $dso-modal-body-padding: $u4;
 $dso-modal-footer-padding: $u4;
 $dso-modal-footer-button-height: $u6;
 
+@keyframes slideInFromTop {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
 body.dso-modal-open {
   &:not(.dso-scripted-height) {
     .dso-modal {
@@ -125,16 +135,6 @@ body.dso-modal-open {
     right: 0;
     top: 0;
     z-index: $dso-modal-z-index;
-
-    @keyframes slideInFromTop {
-      0% {
-        opacity: 0;
-      }
-
-      100% {
-        opacity: 1;
-      }
-    }
 
     .dso-dialog {
       animation: 1s ease-out 0s 1 slideInFromTop;


### PR DESCRIPTION
**Implementatie informatie**

De `button` in de `dso-navbar-header` moet een `aria-expanded` attribuut krijgen gerelateerd aan de opened-state van het menu.

```
<nav class="dso-navbar">
    <div class="dso-navbar-header">
        <button type="button" class="dso-navbar-toggle btn btn-default" aria-expanded="false">
            <dso-icon icon="bars"></dso-icon>
            <span class="sr-only">Menu</span>
        </button>
    </div>

    <ul class="dso-nav dso-nav-main">
        <li class="dso-active">
            <a href="#">
                Home
            </a>
        </li>
        <li>
            <a href="#">
                Vergunningcheck
            </a>
        </li>
    </ul>
</nav>
```

-----

**Pull request informatie**

Het `aria-expanded` attribuut is in de huidige dso-toolkit niet te testen doormiddel van de checkbox "Open/sluit" die nu bij de navigations staat. Data driven werkt het wel goed, en is dit getest. Dit werkt zoals het ook bij het info-button component doet.

Oude situatie:
https://dso-toolkit.nl/24.0.0/components/detail/navigations.html

Nieuwe situatie:
https://dso-toolkit.nl/_1134.Navigations-aria-expanded-en-label-hamburger-knopje-aanpassen/components/detail/navigations.html