### PR TITLE
#1190 group button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Added
+* **dso-toolkit:** Buttons in form .group-static documentatie uitwerken ([#1190](https://github.com/dso-toolkit/dso-toolkit/issues/1190))
+
 ## 25.0.0
 
 ### Special release notes

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-static.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-static.njk
@@ -13,6 +13,9 @@
     {% if edit %}
       {% render '@button', {type: 'button', modifier: 'link', label: 'Link button', icon: 'pencil', iconOnly: 'true'} %}
     {% endif %}
+    {% if staticButton %}
+      {% render '@button', staticButton %}
+    {% endif %}
   </div>
   {% if infoOpen %}
     {% render '@info', {infoText: infoTextDeprecated} %}

--- a/packages/dso-toolkit/components/Componenten/form/form.njk
+++ b/packages/dso-toolkit/components/Componenten/form/form.njk
@@ -2,5 +2,14 @@
 
 <form {{ className(formModifier) }}>
   {% render '@form-fieldsets', {fieldsets: fieldsets, prefix: formPrefix} %}
+  <div class="row">
+    {% render '@button', {
+      type: 'button',
+      modifier: 'link',
+      label: 'Downloaden',
+      icon: 'download'
+    } %}
+  </div>
+  {% render '@form-fieldsets', {fieldsets: fieldsets, prefix: formPrefix} %}
   {% render '@form-buttons', {buttons: buttons, asideButtons: asideButtons} %}
 </form>

--- a/packages/dso-toolkit/components/Componenten/form/form.njk
+++ b/packages/dso-toolkit/components/Componenten/form/form.njk
@@ -2,14 +2,5 @@
 
 <form {{ className(formModifier) }}>
   {% render '@form-fieldsets', {fieldsets: fieldsets, prefix: formPrefix} %}
-  <div class="row">
-    {% render '@button', {
-      type: 'button',
-      modifier: 'link',
-      label: 'Downloaden',
-      icon: 'download'
-    } %}
-  </div>
-  {% render '@form-fieldsets', {fieldsets: fieldsets, prefix: formPrefix} %}
   {% render '@form-buttons', {buttons: buttons, asideButtons: asideButtons} %}
 </form>

--- a/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/10-Aanvragen/verzoeken-indienen.config.yml
+++ b/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/10-Aanvragen/verzoeken-indienen.config.yml
@@ -59,6 +59,15 @@ context:
       - id: confirm
         inputType: confirm
         label: Hierbij verklaar ik alle vragen naar waarheid te hebben ingevuld.
+    - modifier: form-vertical
+      groups:
+      - id: downloadBtn
+        inputType: static
+        staticButton:
+          modifier: link
+          type: button
+          label: Download verzoeken
+          icon: download
     asideButtons:
     - type: button
       modifier: link

--- a/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/10-Aanvragen/verzoeken-indienen.config.yml
+++ b/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/10-Aanvragen/verzoeken-indienen.config.yml
@@ -65,10 +65,6 @@ context:
       label: Vorige
       icon: chevron-left
     buttons:
-    - type: button
-      modifier: link
-      label: Downloaden
-      icon: download
     - type: submit
       modifier: primary
       label: Indienen

--- a/packages/dso-toolkit/reference/render/verzoeken-indienen.html
+++ b/packages/dso-toolkit/reference/render/verzoeken-indienen.html
@@ -123,15 +123,22 @@
           </div>
         </div>
       </div>
+      <div class="form-group dso-static">
+        <div class="dso-label-container">
+          <span class="control-label"></span>
+        </div>
+        <div class="dso-field-container">
+          <button type="button" class="btn btn-link">
+            <dso-icon icon="download"></dso-icon><span >Download verzoeken</span>
+          </button>
+        </div>
+      </div>
       <div class="dso-form-buttons">
         <div class="dso-aside">
           <button type="button" class="btn btn-link">
             <dso-icon icon="chevron-left"></dso-icon><span >Vorige</span>
           </button>
         </div>
-        <button type="button" class="btn btn-link">
-          <dso-icon icon="download"></dso-icon><span >Downloaden</span>
-        </button>
         <button type="submit" class="btn btn-primary"><span >Indienen</span></button>
       </div>
     </form>


### PR DESCRIPTION
### Implementatie informatie

Om het mogelijk te maken om knoppen tussendoor in formulieren te plaatsen is er een uitbreiding gedaan op `.form-group.dso-static`. Een valide stuk code kan er zo uit zien:

```
<div class="form-group dso-static">
  <div class="dso-label-container">
    <span class="control-label"></span>
  </div>
  <div class="dso-field-container">
    <button type="button" class="btn btn-link"><dso-icon icon="download" class="hydrated"></dso-icon><span>Download verzoeken</span></button>
  </div>
</div>
```

-----

### Pull request informatie

**Huidige situatie:**
https://dso-toolkit.nl/25.0.0/components/detail/verzoeken-indienen.html

**Nieuwe situatie:**
https://dso-toolkit.nl/_1190-Group-button-component/components/detail/verzoeken-indienen.html