### PR TITLE
#1281.Anchor link styling op gekleurde achtergrond niet gelijk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Fixed
+* **sources:** Anchor link styling op gekleurde achtergrond niet gelijk ([#1281](https://github.com/dso-toolkit/dso-toolkit/issues/1281))
+
 ### Documentation
 * **dso-toolkit:** Herschrijven navigatie en sub-navigatie documentatie ([#1284](https://github.com/dso-toolkit/dso-toolkit/issues/1284))
 

--- a/packages/sources/src/components/alert/alert.scss
+++ b/packages/sources/src/components/alert/alert.scss
@@ -61,8 +61,12 @@ $alert-danger-border: $state-danger-border;
 
     &:hover,
     &:focus,
-    &:active {
+    &:active,
+    &:visited {
       color: $text-color;
+    }
+
+    &:active {
       text-decoration: none;
     }
   }

--- a/packages/sources/src/components/banner/banner.scss
+++ b/packages/sources/src/components/banner/banner.scss
@@ -21,12 +21,13 @@ $banner-danger-border: $state-danger-border;
     text-decoration: underline;
 
     &,
+    &:hover,
+    &:focus,
+    &:active,
     &:visited {
       color: $text-color;
     }
 
-    &:hover,
-    &:focus,
     &:active {
       text-decoration: none;
     }

--- a/packages/sources/src/components/info/info.scss
+++ b/packages/sources/src/components/info/info.scss
@@ -31,14 +31,15 @@
     max-width: 100%;
   }
 
-  a,
-  a:visited {
-    &#{$not-dso-buttons} {
+  a {
+    &#{$not-dso-buttons},
+    &:hover,
+    &:focus,
+    &:active,
+    &:visited {
       color: $text-color;
     }
 
-    &:hover,
-    &:focus,
     &:active {
       text-decoration: none;
     }


### PR DESCRIPTION
**Implementatie informatie**

Geen

-----

**Pull request informatie**

**Anchor**
Oud: https://dso-toolkit.nl/30.0.0/components/detail/alert.html
Nieuw: https://dso-toolkit.nl/_1281.Anchor-link-styling-op-gekleurde-achtergrond-niet-gelijk/components/detail/alert.html

**Banner**
Oud: https://dso-toolkit.nl/30.0.0/components/detail/banner.html
Nieuw: https://dso-toolkit.nl/_1281.Anchor-link-styling-op-gekleurde-achtergrond-niet-gelijk/components/detail/banner.html

**Highlight box**
Oud: https://dso-toolkit.nl/30.0.0/components/detail/highlight-box.html
Nieuw: https://dso-toolkit.nl/_1281.Anchor-link-styling-op-gekleurde-achtergrond-niet-gelijk/components/detail/highlight-box.html

**Info**
Oud: https://dso-toolkit.nl/30.0.0/components/detail/info.html
Nieuw: https://dso-toolkit.nl/_1281.Anchor-link-styling-op-gekleurde-achtergrond-niet-gelijk/components/detail/info.html

**Footer**
Oud: https://dso-toolkit.nl/30.0.0/components/detail/footer.html
Nieuw: https://dso-toolkit.nl/_1281.Anchor-link-styling-op-gekleurde-achtergrond-niet-gelijk/components/detail/footer.html