### PR TITLE
#1274.Gedrag Context Component bij lange labels en/of grotere interactieve onderdelen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **sources:** Anchor link styling op gekleurde achtergrond niet gelijk ([#1281](https://github.com/dso-toolkit/dso-toolkit/issues/1281))
 * **dso-toolkit:** Toegankelijke helpteksten, toelichtingen en validatiefoutmeldingen ([#1238](https://github.com/dso-toolkit/dso-toolkit/issues/1238))
 * **core + sources:** AutoSuggest; Highlighter breekt op reguliere expressie ([#1332](https://github.com/dso-toolkit/dso-toolkit/issues/1332))
+* **css + dso-tookit:** Gedrag Context Component bij lange labels en/of grotere interactieve onderdelen ([#1274](https://github.com/dso-toolkit/dso-toolkit/issues/1274))
 
 ### Documentation
 * **dso-toolkit:** Herschrijven navigatie en sub-navigatie documentatie ([#1284](https://github.com/dso-toolkit/dso-toolkit/issues/1284))

--- a/packages/css/src/components/context/context.scss
+++ b/packages/css/src/components/context/context.scss
@@ -1,8 +1,12 @@
 .dso-context-wrapper {
-  .dso-context-label {
-    float: left;
-    width: auto;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-bottom: $dso-unit;
+  row-gap: $dso-unit * 2;
 
+  .dso-context-label {
     #{$headings} {
       margin-bottom: 0;
       margin-top: 0;
@@ -10,10 +14,6 @@
   }
 
   .dso-context-container {
-    float: right;
-
-    + * {
-      clear: both;
-    }
+    margin-left: auto;
   }
 }

--- a/packages/css/src/components/context/context.template.ts
+++ b/packages/css/src/components/context/context.template.ts
@@ -11,22 +11,27 @@ function contextLabelTemplate(label: TemplateResult, content: TemplateResult, ch
       <div class="dso-context-container">
         ${content}
       </div>
-      ${children}
     </div>
+    ${children}
   `;
 }
 
 function contextFieldsetTemplate(label: TemplateResult, content: TemplateResult, children: TemplateResult) {
   return html`
-    <fieldset class="dso-context-wrapper">
-      <legend class="dso-context-label">
+    <fieldset>
+      <legend class="sr-only">
         ${label}
       </legend>
-      <div class="dso-context-container">
-        ${content}
+      <div class="dso-context-wrapper">
+        <span class="dso-context-label" aria-hidden="true">
+          ${label}
+        </span>
+        <div class="dso-context-container">
+          ${content}
+        </div>
       </div>
       ${children}
-    </div>
+    </fieldset>
   `;
 }
 

--- a/packages/dso-toolkit/components/Voorbeelden/10-Patronen/filterblok.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/10-Patronen/filterblok.njk
@@ -1,10 +1,12 @@
 <section>
-  <div class="dso-highlight-box dso-context-wrapper">
-    <div class="dso-context-label">
-      <h3>Uw keuzes</h3>
-    </div>
-    <div class="dso-context-container">
-      {% render '@button', {type: 'button', modifier: 'dso-tertiary', label: 'Alle opties', icon: 'pencil'} %}
+  <div class="dso-highlight-box">
+    <div class="dso-context-wrapper">
+      <div class="dso-context-label">
+        <h3>Uw keuzes</h3>
+      </div>
+      <div class="dso-context-container">
+        {% render '@button', {type: 'button', modifier: 'dso-tertiary', label: 'Alle opties', icon: 'pencil'} %}
+      </div>
     </div>
     <p><b>Achterwillenseweg 9a, Gouda</b></p>
     {% render '@label-group', {labels: labels} %}

--- a/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/10-Aanvragen/activiteiten.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/10-Aanvragen/activiteiten.njk
@@ -13,12 +13,17 @@
         {% render '@form-fieldsets', {fieldsets: formFacets} %}
       </div>
       <div class="col-xs-12 col-sm-9">
-        <fieldset class="dso-context-wrapper">
-          <legend class="dso-context-label">
+        <fieldset>
+          <legend class="sr-only">
             <h4>5 activiteiten</h4>
           </legend>
-          <div class="dso-context-container">
-            {% render '@button', { type: 'button', modifier: 'dso-tertiary', label: 'Versies', icon: 'chevron-down' } %}
+          <div class="dso-context-wrapper">
+            <span class="dso-context-label" aria-hidden="true">
+              <h4>5 activiteiten</h4>
+            </span>
+            <div class="dso-context-container">
+              {% render '@button', { type: 'button', modifier: 'dso-tertiary', label: 'Versies', icon: 'chevron-down' } %}
+            </div>
           </div>
           <div class="row">
             <div class="col-xs-12">

--- a/packages/dso-toolkit/reference/render/activiteiten.html
+++ b/packages/dso-toolkit/reference/render/activiteiten.html
@@ -100,14 +100,19 @@
         </fieldset>
       </div>
       <div class="col-xs-12 col-sm-9">
-        <fieldset class="dso-context-wrapper">
-          <legend class="dso-context-label">
+        <fieldset>
+          <legend class="sr-only">
             <h4>5 activiteiten</h4>
           </legend>
-          <div class="dso-context-container">
-            <button type="button" class="dso-tertiary">
-              <dso-icon icon="chevron-down"></dso-icon><span >Versies</span>
-            </button>
+          <div class="dso-context-wrapper">
+            <span class="dso-context-label" aria-hidden="true">
+              <h4>5 activiteiten</h4>
+            </span>
+            <div class="dso-context-container">
+              <button type="button" class="dso-tertiary">
+                <dso-icon icon="chevron-down"></dso-icon><span >Versies</span>
+              </button>
+            </div>
           </div>
           <div class="row">
             <div class="col-xs-12">

--- a/packages/dso-toolkit/reference/render/filterblok.html
+++ b/packages/dso-toolkit/reference/render/filterblok.html
@@ -1,12 +1,14 @@
 <section>
-  <div class="dso-highlight-box dso-context-wrapper">
-    <div class="dso-context-label">
-      <h3>Uw keuzes</h3>
-    </div>
-    <div class="dso-context-container">
-      <button type="button" class="dso-tertiary">
-        <dso-icon icon="pencil"></dso-icon><span >Alle opties</span>
-      </button>
+  <div class="dso-highlight-box">
+    <div class="dso-context-wrapper">
+      <div class="dso-context-label">
+        <h3>Uw keuzes</h3>
+      </div>
+      <div class="dso-context-container">
+        <button type="button" class="dso-tertiary">
+          <dso-icon icon="pencil"></dso-icon><span >Alle opties</span>
+        </button>
+      </div>
     </div>
     <p><b>Achterwillenseweg 9a, Gouda</b></p>
     <div class="dso-label-group">


### PR DESCRIPTION
**Implementatie informatie**

Dit is een breaking change, de markup is gewijzigd voor het gebruik bij een fieldset. Het is niet langer de bedoeling dat de `.dso-context-wrapper` op een `fieldset` staat, en dat de `.dso-context-label` op de `legend` staat.

In plaats daarvan is het stukje `dso-context-wrapper` en de elementen die daar in horen; `dso-context-label` en `dso-context-container` een eigen eilandje geworden. Let wel op de `.sr-only` die op de `legend` gezet dient te worden, en de daarbij behorende `aria-hidden="true"` op de `dso-context-label`

Een geldige code ziet er nu zo uit:

```
<fieldset>
  <legend class="sr-only">
    ${label}
  </legend>
  <div class="dso-context-wrapper">
    <span class="dso-context-label" aria-hidden="true">
      ${label}
    </span>
    <div class="dso-context-container">
      ${content}
    </div>
  </div>
  ${children}
</fieldset>
 ```