### PR TITLE
#1386 Input-type number moet altijd gelabeled zijn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * **core:** Keydown en focusout events op Dropdown Menu en Toggletip Web Components in Safari ([#1379](https://github.com/dso-toolkit/dso-toolkit/issues/1379))
+* **css + dso-toolkit + sources:** Input-type number moet altijd gelabeled zijn ([#1386](https://github.com/dso-toolkit/dso-toolkit/issues/1386))
 
 ## 32.2.0
 

--- a/packages/css/src/components/input-number/input-number.template.ts
+++ b/packages/css/src/components/input-number/input-number.template.ts
@@ -21,7 +21,7 @@ export function inputNumberTemplate({ label, id, min, max, count, minusButtonIna
         min=${ifDefined(min)}
         max=${ifDefined(max)}
         class="dso-input-step-counter"
-        aria-label=${ifDefined(label === '' ? 'Aantal' : undefined)}
+        aria-label=${ifDefined(!label ? 'Aantal' : undefined)}
         value=${count}
       >
       ${buttonTemplate({ type: 'button', label: 'Aantal verhogen', variant: 'tertiary', disabled: plusButtonInactive, icon: { icon: 'plus-square' }, iconMode: 'only' })}

--- a/packages/css/src/components/input-number/input-number.template.ts
+++ b/packages/css/src/components/input-number/input-number.template.ts
@@ -1,5 +1,6 @@
 import { InputNumber } from '@dso-toolkit/sources';
 import { html } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined';
 
 import { buttonTemplate } from '../button/button.template';
 
@@ -17,9 +18,10 @@ export function inputNumberTemplate({ label, id, min, max, count, minusButtonIna
         id=${id}
         readonly
         tabindex="-1"
-        ?min=${min}
-        ?max=${max}
+        min=${ifDefined(min)}
+        max=${ifDefined(max)}
         class="dso-input-step-counter"
+        aria-label=${ifDefined(label === '' ? 'Aantal' : undefined)}
         value=${count}
       >
       ${buttonTemplate({ type: 'button', label: 'Aantal verhogen', variant: 'tertiary', disabled: plusButtonInactive, icon: { icon: 'plus-square' }, iconMode: 'only' })}

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-input-number.config.yml
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-input-number.config.yml
@@ -24,6 +24,7 @@ variants:
     label: Input number with minimum limit
     id: minimum-limit
     count: 0
+    min: 0
     minusButtonInactive: true
     minusButtonLabel: Aantal verlagen (disabled)
 - name: input-number-maximum-limit
@@ -31,6 +32,7 @@ variants:
     __title: Maximum limit (optional)
     label: Input number with maximum limit
     id: maximum-limit
+    max: 99
     plusButtonInactive: true
     plusButtonLabel: Aantal verhogen (disabled)
 - name: no-label

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-input-number.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-input-number.njk
@@ -14,7 +14,7 @@
       count: count,
       min: min,
       max: max,
-      labeledAlready: not not label,
+      label: null if label else '',
       minusButtonLabel: minusButtonLabel,
       minusButtonInactive: minusButtonInactive,
       plusButtonLabel: plusButtonLabel,

--- a/packages/dso-toolkit/components/Componenten/form-elements/group-input-number.njk
+++ b/packages/dso-toolkit/components/Componenten/form-elements/group-input-number.njk
@@ -2,14 +2,19 @@
 
 <div class="form-group dso-input-number">
   <div class="dso-label-container">
-    <label for="{{ localId }}" class="control-label">
-      {{ label }}
-    </label>
+    {% if label %}
+      <label for="{{ localId }}" class="control-label">
+        {{ label }}
+      </label>
+    {% endif %}
   </div>
   <div class="dso-field-container">
     {% render '@input-number', {
       id: localId,
       count: count,
+      min: min,
+      max: max,
+      labeledAlready: not not label,
       minusButtonLabel: minusButtonLabel,
       minusButtonInactive: minusButtonInactive,
       plusButtonLabel: plusButtonLabel,

--- a/packages/dso-toolkit/components/Componenten/input-number/input-number.config.yml
+++ b/packages/dso-toolkit/components/Componenten/input-number/input-number.config.yml
@@ -24,7 +24,7 @@ variants:
     label: Input number with minimum limit
     id: minimum-limit
     count: 0
-    min: '0'
+    min: 0
     minusButtonInactive: true
     minusButtonLabel: Aantal verlagen (disabled)
 - name: input-number-maximum-limit
@@ -33,7 +33,7 @@ variants:
     label: Input number with maximum limit
     id: maximum-limit
     count: 5
-    max: '99'
+    max: 99
     plusButtonInactive: true
     plusButtonLabel: Aantal verhogen (disabled)
 - name: no-label

--- a/packages/dso-toolkit/components/Componenten/input-number/input-number.config.yml
+++ b/packages/dso-toolkit/components/Componenten/input-number/input-number.config.yml
@@ -39,5 +39,5 @@ variants:
 - name: no-label
   context:
     __title: no label
-    label: null
+    label: ""
     id: no-label

--- a/packages/dso-toolkit/components/Componenten/input-number/input-number.njk
+++ b/packages/dso-toolkit/components/Componenten/input-number/input-number.njk
@@ -10,8 +10,8 @@
     readonly
     tabindex="-1"
     {% if min or min == 0 %} min="{{ min }}"{% endif %}
-    {% if max %} max="{{ max }}"{% endif %}
-    {% if not label and not labeledAlready %} aria-label="Aantal"{% endif %}
+    {% if max or max == 0 %} max="{{ max }}"{% endif %}
+    {% if not label and label != null %} aria-label="Aantal"{% endif %}
     class="dso-input-step-counter"
     value="{{ count }}">
   {% render '@button', {type: 'button', modifier: 'dso-tertiary', label: plusButtonLabel, icon: 'plus-square', iconOnly: 'true', disabled: plusButtonInactive} %}

--- a/packages/dso-toolkit/components/Componenten/input-number/input-number.njk
+++ b/packages/dso-toolkit/components/Componenten/input-number/input-number.njk
@@ -6,12 +6,13 @@
   {% endif %}
   {% render '@button', {type: 'button', modifier: 'dso-tertiary', label: minusButtonLabel, icon: 'minus-square', iconOnly: 'true', disabled: minusButtonInactive} %}
   <input type="number"
-          id="{{ id }}"
-          readonly
-          tabindex="-1"
-          {% if min %} min="{{ min }}"{% endif %}
-          {% if max %} max="{{ max }}"{% endif %}
-          class="dso-input-step-counter"
-          value="{{ count }}">
+    id="{{ id }}"
+    readonly
+    tabindex="-1"
+    {% if min or min == 0 %} min="{{ min }}"{% endif %}
+    {% if max %} max="{{ max }}"{% endif %}
+    {% if not label and not labeledAlready %} aria-label="Aantal"{% endif %}
+    class="dso-input-step-counter"
+    value="{{ count }}">
   {% render '@button', {type: 'button', modifier: 'dso-tertiary', label: plusButtonLabel, icon: 'plus-square', iconOnly: 'true', disabled: plusButtonInactive} %}
 </div>

--- a/packages/dso-toolkit/components/Componenten/list-button/list-button.njk
+++ b/packages/dso-toolkit/components/Componenten/list-button/list-button.njk
@@ -16,6 +16,6 @@
     {% endif %}
   </button>
   {% if inputNumber == true %}
-    {% render '@input-number', { id: localId, count: count, minusButtonLabel: minusButtonLabel, minusButtonInactive: minusButtonInactive, plusButtonLabel: plusButtonLabel, plusButtonInactive: plusButtonInactive } %}
-  </div> 
+    {% render '@input-number', { id: localId, count: count, label: '', minusButtonLabel: minusButtonLabel, minusButtonInactive: minusButtonInactive, plusButtonLabel: plusButtonLabel, plusButtonInactive: plusButtonInactive } %}
+  </div>
 {% endif %}

--- a/packages/dso-toolkit/reference/render/activiteiten.html
+++ b/packages/dso-toolkit/reference/render/activiteiten.html
@@ -207,7 +207,7 @@
                   <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
                     <dso-icon icon="minus-square"></dso-icon>
                   </button>
-                  <input type="number" id="in-stand-houden-van-bouwwerken" readonly tabindex="-1" class="dso-input-step-counter" value="0">
+                  <input type="number" id="in-stand-houden-van-bouwwerken" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="0">
                   <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
                     <dso-icon icon="plus-square"></dso-icon>
                   </button>

--- a/packages/dso-toolkit/reference/render/group-input-number--input-number-maximum-limit.html
+++ b/packages/dso-toolkit/reference/render/group-input-number--input-number-maximum-limit.html
@@ -9,7 +9,7 @@
       <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
         <dso-icon icon="minus-square"></dso-icon>
       </button>
-      <input type="number" id="maximum-limit" readonly tabindex="-1" class="dso-input-step-counter" value="99">
+      <input type="number" id="maximum-limit" readonly tabindex="-1" max="99" class="dso-input-step-counter" value="99">
       <button type="button" disabled class="dso-tertiary"><span class="sr-only">Aantal verhogen (disabled)</span>
         <dso-icon icon="plus-square"></dso-icon>
       </button>

--- a/packages/dso-toolkit/reference/render/group-input-number--input-number-minimum-limit.html
+++ b/packages/dso-toolkit/reference/render/group-input-number--input-number-minimum-limit.html
@@ -9,7 +9,7 @@
       <button type="button" disabled class="dso-tertiary"><span class="sr-only">Aantal verlagen (disabled)</span>
         <dso-icon icon="minus-square"></dso-icon>
       </button>
-      <input type="number" id="minimum-limit" readonly tabindex="-1" class="dso-input-step-counter" value="0">
+      <input type="number" id="minimum-limit" readonly tabindex="-1" min="0" class="dso-input-step-counter" value="0">
       <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
         <dso-icon icon="plus-square"></dso-icon>
       </button>

--- a/packages/dso-toolkit/reference/render/group-input-number--no-label.html
+++ b/packages/dso-toolkit/reference/render/group-input-number--no-label.html
@@ -1,14 +1,12 @@
 <div class="form-group dso-input-number">
   <div class="dso-label-container">
-    <label for="no-label" class="control-label">
-    </label>
   </div>
   <div class="dso-field-container">
     <div class="dso-input-number">
       <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
         <dso-icon icon="minus-square"></dso-icon>
       </button>
-      <input type="number" id="no-label" readonly tabindex="-1" class="dso-input-step-counter" value="99">
+      <input type="number" id="no-label" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="99">
       <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
         <dso-icon icon="plus-square"></dso-icon>
       </button>

--- a/packages/dso-toolkit/reference/render/input-number--no-label.html
+++ b/packages/dso-toolkit/reference/render/input-number--no-label.html
@@ -2,7 +2,7 @@
   <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
     <dso-icon icon="minus-square"></dso-icon>
   </button>
-  <input type="number" id="no-label" readonly tabindex="-1" class="dso-input-step-counter" value="99">
+  <input type="number" id="no-label" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="99">
   <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
     <dso-icon icon="plus-square"></dso-icon>
   </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-extra-label-en-input-number.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-extra-label-en-input-number.html
@@ -7,7 +7,7 @@
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-EL-with-input" readonly tabindex="-1" class="dso-input-step-counter" value="2">
+    <input type="number" id="list-button-EL-with-input" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="2">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-input-number-selected.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-input-number-selected.html
@@ -6,7 +6,7 @@
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-with-input-selected" readonly tabindex="-1" class="dso-input-step-counter" value="2">
+    <input type="number" id="list-button-with-input-selected" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="2">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-input-number.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-input-number.html
@@ -6,7 +6,7 @@
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-with-input" readonly tabindex="-1" class="dso-input-step-counter" value="0">
+    <input type="number" id="list-button-with-input" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="0">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-lange-optionele-tekst-en-input-number-en-extra-label.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-lange-optionele-tekst-en-input-number-en-extra-label.html
@@ -24,7 +24,7 @@ Opslaan <mark>van</mark> ontplofbare stoffen voor civiel gebruik
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-LOT-EL-with-input" readonly tabindex="-1" class="dso-input-step-counter" value="2">
+    <input type="number" id="list-button-LOT-EL-with-input" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="2">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-lange-optionele-tekst-en-input-number.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-lange-optionele-tekst-en-input-number.html
@@ -23,7 +23,7 @@ Opslaan <mark>van</mark> ontplofbare stoffen voor civiel gebruik
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-LOT-with-input" readonly tabindex="-1" class="dso-input-step-counter" value="2">
+    <input type="number" id="list-button-LOT-with-input" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="2">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-optionele-tekst-en-input-number-en-extra-label.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-optionele-tekst-en-input-number-en-extra-label.html
@@ -9,7 +9,7 @@
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-OT-EL-with-input" readonly tabindex="-1" class="dso-input-step-counter" value="2">
+    <input type="number" id="list-button-OT-EL-with-input" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="2">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/dso-toolkit/reference/render/list-button--button-met-optionele-tekst-en-input-number.html
+++ b/packages/dso-toolkit/reference/render/list-button--button-met-optionele-tekst-en-input-number.html
@@ -8,7 +8,7 @@
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verlagen</span>
       <dso-icon icon="minus-square"></dso-icon>
     </button>
-    <input type="number" id="list-button-OT-with-input" readonly tabindex="-1" class="dso-input-step-counter" value="2">
+    <input type="number" id="list-button-OT-with-input" readonly tabindex="-1" aria-label="Aantal" class="dso-input-step-counter" value="2">
     <button type="button" class="dso-tertiary"><span class="sr-only">Aantal verhogen</span>
       <dso-icon icon="plus-square"></dso-icon>
     </button>

--- a/packages/sources/src/components/input-number/input-number.stories.ts
+++ b/packages/sources/src/components/input-number/input-number.stories.ts
@@ -27,7 +27,7 @@ export function storiesOfInputNumber<TemplateFnReturnType>(
       },
       argTypes: inputNumberArgTypes,
       args: {
-        label: 'Default',
+        label: 'Input number',
         id: uuidv4(),
         count: 99
       }

--- a/packages/sources/src/components/input-number/input-number.stories.ts
+++ b/packages/sources/src/components/input-number/input-number.stories.ts
@@ -27,7 +27,7 @@ export function storiesOfInputNumber<TemplateFnReturnType>(
       },
       argTypes: inputNumberArgTypes,
       args: {
-        label: 'Input number',
+        label: 'Aantal onderdelen',
         id: uuidv4(),
         count: 99
       }


### PR DESCRIPTION
* css compontent: min en max zijn geen boolean attributes, en aria-label als geen label
* group input number: kan al zelf het label geven, en doorgeven min en max
* input-number min en max zijn ints, geen strings, en aria-label als niet zelf een label of reeds gelabeld (door bv. group input)