### PR TITLE
#1188.Storybook CSS Component - Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Changed
+* **sources:** CSS Component Image naar storybook - varianten `img-rounded` en `img-thumbnail` deprecated ([#1188](https://github.com/dso-toolkit/dso-toolkit/issues/1188))
+
 ## 33.3.0
 
 ### Changed

--- a/packages/css/src/components/image/readme.md
+++ b/packages/css/src/components/image/readme.md
@@ -1,1 +1,1 @@
-# `.img-responsive`, `.img-rounded`, `.img-circle`, `.img-thumbnail`
+# `.img-responsive`, `.img-circle`

--- a/packages/sources/src/components/image/image.args.ts
+++ b/packages/sources/src/components/image/image.args.ts
@@ -15,7 +15,7 @@ export const imageArgTypes: ArgTypes<ImageArgs> = {
     }
   },
   modifier: {
-    options: [undefined, 'img-responsive', 'img-rounded', 'img-circle', 'img-thumbnail'],
+    options: [undefined, 'img-responsive', 'img-circle'],
     control: {
       type: 'select'
     }

--- a/packages/sources/src/components/image/image.scss
+++ b/packages/sources/src/components/image/image.scss
@@ -9,8 +9,10 @@ $thumbnail-border-radius: $border-radius-base;
   height: auto;
 }
 
+// DEPRECATED
 @mixin img-rounded() {
   border-radius: $border-radius-large;
+  outline: 8px solid $dso-invalid-color;
 }
 
 @mixin img-thumbnail() {
@@ -18,10 +20,12 @@ $thumbnail-border-radius: $border-radius-base;
   border-radius: $thumbnail-border-radius;
   border: 1px solid $thumbnail-border;
   line-height: $line-height-base;
+  outline: 8px solid $dso-invalid-color;
   padding: $thumbnail-padding;
 
   @include img-responsive(inline-block);
 }
+// DEPRECATED
 
 @mixin img-circle() {
   border-radius: 50%;

--- a/packages/sources/src/components/image/image.stories.ts
+++ b/packages/sources/src/components/image/image.stories.ts
@@ -47,31 +47,11 @@ export function storiesOfImage<TemplateFnReturnType>(
   );
 
   stories.add(
-    'rounded',
-    template,
-    {
-      args: {
-        modifier: 'img-rounded'
-      }
-    }
-  );
-
-  stories.add(
     'circle',
     template,
     {
       args: {
         modifier: 'img-circle'
-      }
-    }
-  );
-
-  stories.add(
-    'thumbnail',
-    template,
-    {
-      args: {
-        modifier: 'img-thumbnail'
       }
     }
   );


### PR DESCRIPTION
Met deze change zijn de varianten `.img-rounded` en `.img-thumbnail` van het `image` HTML/CSS Component deprecated.