### PR TITLE
#1534.Badge Default Outline toevoegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 * **core:** `<dso-ozon-content inline>` en ondersteuning voor `<Opschrift>` ([#1530](https://github.com/dso-toolkit/dso-toolkit/issues/1530))
+* **sources + dso-toolkit + css + core:** Badge; `badge-outline` toevoegen ([#1534]https://github.com/dso-toolkit/dso-toolkit/issues/1534)
 
 ### Removed
 * **BREAKING: css:** .input-group verwijderen ([#1462](https://github.com/dso-toolkit/dso-toolkit/issues/1462))

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -40,7 +40,7 @@ export namespace Components {
         "suggestions": Suggestion[];
     }
     interface DsoBadge {
-        "status"?: 'primary' | 'success' | 'info' | 'warning' | 'danger';
+        "status"?: 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'outline';
     }
     interface DsoBanner {
         "status": 'warning' | 'danger';
@@ -471,7 +471,7 @@ declare namespace LocalJSX {
         "suggestions"?: Suggestion[];
     }
     interface DsoBadge {
-        "status"?: 'primary' | 'success' | 'info' | 'warning' | 'danger';
+        "status"?: 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'outline';
     }
     interface DsoBanner {
         "status": 'warning' | 'danger';

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -8,13 +8,14 @@ import clsx from 'clsx';
 })
 export class Badge {
   @Prop()
-  status?: 'primary' | 'success' | 'info' | 'warning' | 'danger';
+  status?: 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'outline';
 
   private static statusMap = new Map<string, string>([
     ['success', 'Gelukt'],
     ['info', 'Opmerking'],
     ['warning', 'Waarschuwing'],
-    ['danger', 'Fout']
+    ['danger', 'Fout'],
+    ['outline', 'Rand']
   ]);
 
   render() {

--- a/packages/core/src/components/badge/readme.md
+++ b/packages/core/src/components/badge/readme.md
@@ -7,9 +7,9 @@
 
 ## Properties
 
-| Property | Attribute | Description | Type                                                                     | Default     |
-| -------- | --------- | ----------- | ------------------------------------------------------------------------ | ----------- |
-| `status` | `status`  |             | `"danger" \| "info" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
+| Property | Attribute | Description | Type                                                                                  | Default     |
+| -------- | --------- | ----------- | ------------------------------------------------------------------------------------- | ----------- |
+| `status` | `status`  |             | `"danger" \| "info" \| "outline" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/css/src/components/badge/badge.template.ts
+++ b/packages/css/src/components/badge/badge.template.ts
@@ -7,7 +7,8 @@ const statusMap = new Map<string, string>([
   ['success', 'Gelukt'],
   ['info', 'Opmerking'],
   ['warning', 'Waarschuwing'],
-  ['danger', 'Fout']
+  ['danger', 'Fout'],
+  ['outline', 'Rand']
 ]);
 
 export function badgeTemplate({ status, message }: Badge) {

--- a/packages/dso-toolkit/components/Componenten/badge/badge.config.js
+++ b/packages/dso-toolkit/components/Componenten/badge/badge.config.js
@@ -68,6 +68,12 @@ module.exports = {
       context: {
         status: 'danger'
       }
+    },
+    {
+      name: 'badge-outline',
+      context: {
+        status: 'outline'
+      }
     }
   ]
 };

--- a/packages/dso-toolkit/reference/render/badge--badge-outline.html
+++ b/packages/dso-toolkit/reference/render/badge--badge-outline.html
@@ -1,0 +1,1 @@
+<dso-badge status="outline"><span class="dso-badge badge-outline"><span class="sr-only">Rand: </span>Badge tekst</span></dso-badge>

--- a/packages/sources/src/components/badge/badge.args.ts
+++ b/packages/sources/src/components/badge/badge.args.ts
@@ -9,7 +9,7 @@ export interface BadgeArgs {
 
 export const badgeArgTypes: ArgTypes<BadgeArgs> = {
   status: {
-    options: [undefined, 'primary', 'success', 'info', 'warning', 'danger'],
+    options: [undefined, 'primary', 'success', 'info', 'warning', 'danger', 'outline'],
     control: {
       type: 'select'
     }

--- a/packages/sources/src/components/badge/badge.scss
+++ b/packages/sources/src/components/badge/badge.scss
@@ -38,4 +38,10 @@ $dso-badge-danger-bg-color: $dso-danger-color;
     background-color: $dso-badge-danger-bg-color;
     color: $wit;
   }
+
+  &.badge-outline {
+    background-color: $wit;
+    border: 1px solid $grijs-90;
+    color: $grijs-90;
+  }
 }

--- a/packages/sources/src/components/badge/badge.stories.ts
+++ b/packages/sources/src/components/badge/badge.stories.ts
@@ -91,4 +91,15 @@ export function storiesOfBadge<TemplateFnReturnType>(
       }
     }
   );
+
+  stories.add(
+    'outline',
+    template,
+    {
+      args: {
+        status: 'outline',
+        message: 'Outline'
+      }
+    }
+  );
 }


### PR DESCRIPTION
Er is een nieuwe variant voor `Badge` geintroduceerd. Je kunt hiervoor de support-class `badge-outline` gebruiken.

Correcte markup ziet er zo uit:

```
<span class="dso-badge badge-outline">Badge tekst</span>
```