### PR TITLE
WCAG verbeteringen voor helpcenter-panel

### DIFF
--- a/packages/core/src/components/helpcenter-panel/helpcenter-panel.scss
+++ b/packages/core/src/components/helpcenter-panel/helpcenter-panel.scss
@@ -47,6 +47,7 @@
   font-family: $font-family-base;
   position: fixed;
   right: $u2;
+  box-shadow: 0 4px 8px 0 rgb(0 0 0 / 20%);
 
   &:hover {
     cursor: pointer;

--- a/packages/core/src/components/helpcenter-panel/helpcenter-panel.tsx
+++ b/packages/core/src/components/helpcenter-panel/helpcenter-panel.tsx
@@ -54,19 +54,22 @@ export class HelpcenterPanel {
           type="button"
           onClick={this.openClick}
           class={`open-button ${this.isOpen}`}
+          aria-expanded="false"
+          aria-haspopup="dialog"
         >
           <dso-icon icon="help"></dso-icon>
           <span>{this.label}</span>
         </button>
         <div class={`wrapper ${this.visibility}`}>
-          <div class="dimscreen" />
-          <div class={`iframe-container ${this.slideState}`}>
+          <div class="dimscreen" onClick={this.closeClick} />
+          <div class={`iframe-container ${this.slideState}`} aria-live="polite">
             {this.loadIframe ? <iframe src={this.url} /> : <div />}
           </div>
           <button
             type="button"
             class={`close-button ${this.isOpen}`}
             onClick={this.closeClick}
+            aria-expanded="true"
           >
             <span class="sr-only">sluiten</span>
           </button>


### PR DESCRIPTION
* Aria-attributen
    * Aria-expanded="true/false" op juiste moment toepassen + Aria-controls="(id van helpcentrum paneel) https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded
    * Aria-haspopup="dialog"  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup
    * Het Helpcenter paneel zelf wordt een aria-live region met setting polite. Zodat wanneer content verandert er een update aan screenreaders gegeven wordt. Inhoud en updates van aria-live meldingen zijn geen onderdeel van dit issue https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live
* Klik buiten helpframe sluit het helpframe
* Dropshadow toevoegen op de helpbutton: `box-shadow: rgb(0 0 0 / 20%) 0px 4px 8px 0px;`