### PR TITLE
#1565.definition list marge tussen dd + dts verkleinen naar 8px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **dso-toolkit + css:** Form: "Radios" verhuizen naar @dso-toolkit/css + Storybook ([#1560](https://github.com/dso-toolkit/dso-toolkit/issues/1560))
+* **dso-toolkit + sources:** Definition list marge tussen dd + dt's verkleinen naar 8px ([#1565](https://github.com/dso-toolkit/dso-toolkit/issues/1565))
 
 ## 38.1.0
 

--- a/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/50-Stelselcatalogus/Begrippen.njk
+++ b/packages/dso-toolkit/components/Voorbeelden/20-Toepassingen/50-Stelselcatalogus/Begrippen.njk
@@ -27,7 +27,9 @@
     <dd>{% render '@anchor', {label:'Aquo begrippenkader', url:'#', modifier:'extern') %}</dd>
   </dl>
 
-  {% render '@button', {type:'button', modifier:'dso-secondary', label:'Bekijk minder details', icon:'chevron-up', ariaExpanded: false} %}
+  <div class="dso-button-row">
+    {% render '@button', {type:'button', modifier:'dso-secondary', label:'Bekijk minder details', icon:'chevron-up', ariaExpanded: false} %}
+  </div>
 
   <h3>Unieke identificatie</h3>
   <dl class="dso-bordered">

--- a/packages/sources/src/styling/global/dl.scss
+++ b/packages/sources/src/styling/global/dl.scss
@@ -1,12 +1,12 @@
 $dso-definition-list-gutter: $u2;
-$dso-definition-list-vertical-space: $u2;
+$dso-definition-list-vertical-space: $u1;
 $dso-definition-list-term-width: 200px;
 $dso-definition-list-horizontal-breakpoint: $screen-sm-min;
 $dso-definition-list-highlight-color: $grasgroen;
 $dso-definition-list-border: 1px solid $grijs-20;
 
 dl {
-  margin-bottom: $u2;
+  margin-bottom: $dso-definition-list-vertical-space;
   margin-top: 0;
 
   + dl {
@@ -52,7 +52,6 @@ dl {
       break-inside: avoid;
       column-gap: $u2;
 
-
       dd:last-of-type {
         margin-bottom: 0;
       }
@@ -92,7 +91,7 @@ dl {
     }
 
     > div {
-      margin-bottom: $u2;
+      margin-bottom: $dso-definition-list-vertical-space;
     }
   }
 

--- a/packages/sources/src/styling/global/dl.scss
+++ b/packages/sources/src/styling/global/dl.scss
@@ -6,7 +6,7 @@ $dso-definition-list-highlight-color: $grasgroen;
 $dso-definition-list-border: 1px solid $grijs-20;
 
 dl {
-  margin-bottom: $dso-definition-list-vertical-space;
+  margin-bottom: $dso-definition-list-vertical-space * 2;
   margin-top: 0;
 
   + dl {
@@ -16,7 +16,7 @@ dl {
       display: block;
       float: left;
       height: $dso-definition-list-vertical-space;
-      margin-bottom: $dso-definition-list-vertical-space * 2;
+      margin-bottom: $dso-definition-list-vertical-space * 3;
       width: 100%;
     }
   }


### PR DESCRIPTION
In de voorbeeldpagina 'Begrippen' is om de `button` een `dso-button-row` geplaats voor verticale margin. 