### PR TITLE
#1573 Fixed: Map controls: onjuist toetsenbord gedrag keuzerondjes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * **dso-toolkit + core:** `dso-info` in `.formgroup.dso-radios, .form-group.dso-checkboxes` mist `aria-describedby` ([#1399](https://github.com/dso-toolkit/dso-toolkit/issues/1399))
+* **core:** Map controls: onjuist toetsenbord gedrag keuzerondjes ([#1573](https://github.com/dso-toolkit/dso-toolkit/issues/1573))
 
 ## 39.0.0
 

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -163,12 +163,14 @@ export namespace Components {
     }
     interface DsoMapBaseLayers {
         "baseLayers": BaseLayer[];
+        "group": string;
     }
     interface DsoMapControls {
         "disableZoom"?: 'in' | 'out' | 'both';
         "open": boolean;
     }
     interface DsoMapOverlays {
+        "group": string;
         "overlays": Overlay[];
     }
     interface DsoOzonContent {
@@ -630,6 +632,7 @@ declare namespace LocalJSX {
     }
     interface DsoMapBaseLayers {
         "baseLayers": BaseLayer[];
+        "group"?: string;
         "onBaseLayerChange"?: (event: CustomEvent<BaseLayerChangeEvent>) => void;
     }
     interface DsoMapControls {
@@ -639,6 +642,7 @@ declare namespace LocalJSX {
         "open"?: boolean;
     }
     interface DsoMapOverlays {
+        "group"?: string;
         "onToggleOverlay"?: (event: CustomEvent<OverlayChangeEvent>) => void;
         "overlays": Overlay[];
     }

--- a/packages/core/src/components/map-base-layers/map-base-layers.tsx
+++ b/packages/core/src/components/map-base-layers/map-base-layers.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop, Event, EventEmitter, ComponentInterface } from '@stencil/core';
+import { v4 as uuidv4 } from 'uuid';
 
 import { BaseLayer, BaseLayerChangeEvent } from './map-base-layers.interfaces';
 
@@ -13,6 +14,9 @@ export class MapBaseLayers implements ComponentInterface {
 
   @Event()
   baseLayerChange!: EventEmitter<BaseLayerChangeEvent>;
+
+  @Prop()
+  group = uuidv4();
 
   @Prop()
   baseLayers!: BaseLayer[];
@@ -52,6 +56,7 @@ export class MapBaseLayers implements ComponentInterface {
               value={baseLayer.name}
               checked={baseLayer.checked}
               disabled={baseLayer.disabled}
+              name={this.group}
               ref={ref => this.selectableRefs[baseLayer.id] = ref!}
               onDsoChange={() => this.baseLayerChangeHandler(baseLayer)}
             >

--- a/packages/core/src/components/map-base-layers/readme.md
+++ b/packages/core/src/components/map-base-layers/readme.md
@@ -10,6 +10,7 @@ Private component, do not use.
 | Property                  | Attribute | Description | Type          | Default     |
 | ------------------------- | --------- | ----------- | ------------- | ----------- |
 | `baseLayers` _(required)_ | --        |             | `BaseLayer[]` | `undefined` |
+| `group`                   | `group`   |             | `string`      | `uuidv4()`  |
 
 
 ## Events

--- a/packages/core/src/components/map-overlays/map-overlays.tsx
+++ b/packages/core/src/components/map-overlays/map-overlays.tsx
@@ -1,4 +1,5 @@
 import { Component, Event, EventEmitter, Prop, h, ComponentInterface } from '@stencil/core';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Overlay, OverlayChangeEvent } from './map-overlays.interfaces';
 
@@ -12,6 +13,9 @@ import { SelectableChangeEvent } from '../selectable/selectable';
 export class MapOverlays implements ComponentInterface {
   previousOverlays: Overlay[] | undefined;
   selectableRefs: { [id: number]: HTMLDsoSelectableElement } = {};
+
+  @Prop()
+  group = uuidv4();
 
   @Prop()
   overlays!: Overlay[];
@@ -56,6 +60,7 @@ export class MapOverlays implements ComponentInterface {
               value={overlay.name}
               checked={overlay.checked}
               disabled={overlay.disabled}
+              name={this.group}
               ref={ref => this.selectableRefs[overlay.id] = ref!}
               onDsoChange={e => this.overlayChangeHandler(overlay, e)}
             >

--- a/packages/core/src/components/map-overlays/readme.md
+++ b/packages/core/src/components/map-overlays/readme.md
@@ -9,6 +9,7 @@ Private component, do not use.
 
 | Property                | Attribute | Description | Type        | Default     |
 | ----------------------- | --------- | ----------- | ----------- | ----------- |
+| `group`                 | `group`   |             | `string`    | `uuidv4()`  |
 | `overlays` _(required)_ | --        |             | `Overlay[]` | `undefined` |
 
 

--- a/packages/core/src/components/selectable/selectable.tsx
+++ b/packages/core/src/components/selectable/selectable.tsx
@@ -7,7 +7,7 @@ import { createIdentifier } from '../../utils/create-identifier';
 @Component({
   tag: 'dso-selectable',
   styleUrl: 'selectable.scss',
-  shadow: true
+  scoped: true
 })
 export class Selectable {
   @Prop()


### PR DESCRIPTION
Vanuit `@dso-toolkit/leaflet` worden `<dso-map-controls />`, `<dso-map-overlays />` en `<dso-map-baselayers />` aangeroepen. Baselayer en Overlays (samen de "Map Layer componenten") roepen vervolgens `<dso-selectable />` aan.

Een "Map Layer component" wordt geinstantieerd. Dit component accepteert een `@Prop() group: string`. Als er geen `group` wordt gegeven, wordt er een GUID gegenereerd.

De `group` wordt als `name` voor de selectables van een groep layers gebruikt. Hiermee worden de selectables gekoppeld.

Is dit OK of is het belangrijk dat `name` een herkenbare/toegankelijke value krijgt? Zo ja: Dan zal er ook een change in `@dso-toolkit/leaflet` en `@dso-toolkit/react-leaflet` moeten komen. ~De "group identifier" moet immers worden meegegeven door de afnemer.~ edit: Niet waar, de name is in eigen beheer, wordt gezet vanuit `@dso-toolkit/leaflet`: "Achtergrond" en "Kaartlagen".