### PR TITLE
#1667 Pagination: previous en next page selecteren geeft de verkeerde pagina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **BREAKING: css + sources:** Form Group: Search Bar naar @dso-toolkit/css: ([#1614](https://github.com/dso-toolkit/dso-toolkit/issues/1614)) **Class `dso-filter` is hernoemd naar `dso-form-group-search-bar` ([#1642](https://github.com/dso-toolkit/dso-toolkit/pull/1642))**
-* **BREAKING: core + react:** Pagination: Het navigeren (anchor) wordt niet meer door het component met event.preventDefault() ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
+* **BREAKING: core + react:** Pagination: bugfix: Vorige en volgende pagina emitten altijd de eerste en laatge pagina. Changed: Het navigeren (anchor) wordt niet meer door het component met event.preventDefault(). Added: selectPage event emit nu `isModifiedEvent` wanneer een pagina is geselecteerd met een modifier key (Ctrl/Alt/Shift/Meta) ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
 * **dso-toolkit + sources + css:** `.dso-justify-form-groups` onderbrengen in @dso-toolkit/css ([#1646](https://github.com/dso-toolkit/dso-toolkit/issues/1646))
-
-### Added
-* **core + react:** Pagination: selectPage event emit nu `isModifiedEvent` wanneer een pagina is geselecteerd met een modifier key (Ctrl/Alt/Shift/Meta). ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
-
-### Fixed
-* **core + react:** Pagination bug: Vorige en Volgende pagina emitten altijd de eerste en laatste pagina ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
 
 ## 40.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **BREAKING: css + sources:** Form Group: Search Bar naar @dso-toolkit/css: ([#1614](https://github.com/dso-toolkit/dso-toolkit/issues/1614)) **Class `dso-filter` is hernoemd naar `dso-form-group-search-bar` ([#1642](https://github.com/dso-toolkit/dso-toolkit/pull/1642))**
+* **BREAKING: core + react:** Pagination: Het navigeren (anchor) wordt niet meer door het component met event.preventDefault() ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
 * **dso-toolkit + sources + css:** `.dso-justify-form-groups` onderbrengen in @dso-toolkit/css ([#1646](https://github.com/dso-toolkit/dso-toolkit/issues/1646))
+
+### Added
+* **core + react:** Pagination: selectPage event emit nu `isModifiedEvent` wanneer een pagina is geselecteerd met een modifier key (Ctrl/Alt/Shift/Meta). ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
+
+### Fixed
+* **core + react:** Pagination bug: Vorige en Volgende pagina emitten altijd de eerste en laatste pagina ([#1667](https://github.com/dso-toolkit/dso-toolkit/issues/1667))
 
 ## 40.1.0
 

--- a/cypress/integration/core/pagination.spec.ts
+++ b/cypress/integration/core/pagination.spec.ts
@@ -1,0 +1,144 @@
+describe('Alert', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:56106/iframe.html?id=pagination--pagination');
+  });
+
+  /** Configure the component and set an eventListener as @selectPageListener */
+  function prepareComponent(currentPage: number, totalPages: number) {
+    cy.get('dso-pagination')
+      .invoke('attr', 'current-page', currentPage)
+      .invoke('attr', 'total-pages', totalPages)
+      .then($pagination => {
+        $pagination.on('selectPage', event => event.detail.originalEvent.preventDefault());
+        $pagination.on('selectPage', cy.stub().as('selectPageListener'));
+      });
+  }
+
+  it('should show 5 pages and previous/next buttons', () => {
+    prepareComponent(3, 5);
+
+    cy
+      .get('dso-pagination')
+      .shadow()
+      .as('dsoPagination')
+      .find('.pagination > li')
+      .should('have.length', 7)
+      .get('@dsoPagination')
+      .find('a[aria-label="Vorige"]')
+      .get('@dsoPagination')
+      .find('a[aria-label="Volgende"]');
+  });
+
+  it('should emit page on page select', () => {
+    prepareComponent(3, 5);
+
+    cy
+      .get('dso-pagination')
+      .shadow()
+      .as('dsoPagination')
+      .find('.pagination > li')
+      .eq(2)
+      .find('a')
+      .click()
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.page')
+      .should('equal', 2);
+  });
+
+  it('should show emit correct page on previous and next page select', () => {
+    const currentPage = 3;
+    prepareComponent(currentPage, 5);
+
+    cy
+      .get('dso-pagination')
+      .shadow()
+      .as('dsoPagination')
+      .find('a[aria-label="Vorige"]')
+      .click()
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.page')
+      .should('equal', currentPage - 1)
+      .get('@dsoPagination')
+      .find('a[aria-label="Volgende"]')
+      .click()
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.page')
+      .should('equal', currentPage + 1);
+  });
+
+  it('should not emit event on current page click', () => {
+    prepareComponent(3, 5);
+
+    cy
+      .get('dso-pagination')
+      .shadow()
+      .as('dsoPagination')
+      .find('.pagination > .active span[aria-current="page"]')
+      .click()
+      .get('@selectPageListener')
+      .should('not.have.been.called');
+  });
+
+  it('should emit event with isModifiedEvent true on clicks with modifier keys pressed', () => {
+    prepareComponent(3, 5);
+
+    cy
+      .get('dso-pagination')
+      .shadow()
+      .as('dsoPagination')
+      .find('a[aria-label="Vorige"]')
+      .as('dsoPage')
+      .click()
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.isModifiedEvent')
+      .should('equal', false)
+      // Ctrl
+      .get('@dsoPage')
+      .click({ ctrlKey: true })
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.isModifiedEvent')
+      .should('equal', true)
+      // Shift
+      .get('@dsoPage')
+      .click({ shiftKey: true })
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.isModifiedEvent')
+      .should('equal', true)
+      // Alt
+      .get('@dsoPage')
+      .click({ altKey: true })
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.isModifiedEvent')
+      .should('equal', true)
+      // Meta
+      .get('@dsoPage')
+      .click({ commandKey: true })
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.isModifiedEvent')
+      .should('equal', true)
+      // Right click
+      .get('@dsoPage')
+      .rightclick()
+      .get('@selectPageListener')
+      .invoke('getCalls')
+      .invoke('at', -1)
+      .its('args.0.detail.isModifiedEvent')
+      .should('equal', true);
+  });
+});

--- a/cypress/integration/core/pagination.spec.ts
+++ b/cypress/integration/core/pagination.spec.ts
@@ -9,7 +9,7 @@ describe('Alert', () => {
       .invoke('attr', 'current-page', currentPage)
       .invoke('attr', 'total-pages', totalPages)
       .then($pagination => {
-        $pagination.on('selectPage', event => event.detail.originalEvent.preventDefault());
+        $pagination.on('selectPage', $event => $event.detail.originalEvent.preventDefault());
         $pagination.on('selectPage', cy.stub().as('selectPageListener'));
       });
   }
@@ -25,8 +25,10 @@ describe('Alert', () => {
       .should('have.length', 7)
       .get('@dsoPagination')
       .find('a[aria-label="Vorige"]')
+      .should('be.visible')
       .get('@dsoPagination')
-      .find('a[aria-label="Volgende"]');
+      .find('a[aria-label="Volgende"]')
+      .should('be.visible');
   });
 
   it('should emit page on page select', () => {
@@ -41,8 +43,10 @@ describe('Alert', () => {
       .find('a')
       .click()
       .get('@selectPageListener')
-      .invoke('getCalls')
-      .invoke('at', -1)
+      .its('callCount')
+      .should('equal', 1)
+      .get('@selectPageListener')
+      .invoke('getCall', 0)
       .its('args.0.detail.page')
       .should('equal', 2);
   });
@@ -58,16 +62,20 @@ describe('Alert', () => {
       .find('a[aria-label="Vorige"]')
       .click()
       .get('@selectPageListener')
-      .invoke('getCalls')
-      .invoke('at', -1)
+      .its('callCount')
+      .should('equal', 1)
+      .get('@selectPageListener')
+      .invoke('getCall', 0)
       .its('args.0.detail.page')
       .should('equal', currentPage - 1)
       .get('@dsoPagination')
       .find('a[aria-label="Volgende"]')
       .click()
       .get('@selectPageListener')
-      .invoke('getCalls')
-      .invoke('at', -1)
+      .its('callCount')
+      .should('equal', 2)
+      .get('@selectPageListener')
+      .invoke('getCall', 1)
       .its('args.0.detail.page')
       .should('equal', currentPage + 1);
   });

--- a/packages/core/src/components/pagination/pagination.interfaces.ts
+++ b/packages/core/src/components/pagination/pagination.interfaces.ts
@@ -3,4 +3,6 @@ export interface PaginationSelectPageEvent {
   page: number;
   /** The original pointer event */
   originalEvent: MouseEvent;
+  /** True when user selected the page holding Ctrl, Alt or other modifiers. Can be used to determine navigation. */
+  isModifiedEvent: boolean;
 }

--- a/packages/core/src/components/pagination/pagination.tsx
+++ b/packages/core/src/components/pagination/pagination.tsx
@@ -33,13 +33,11 @@ export class Pagination implements ComponentInterface {
   selectPage!: EventEmitter<PaginationSelectPageEvent>;
 
   clickHandler(e: MouseEvent, page: number) {
-    if (e.button !== 0 || e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) {
-      return;
-    }
-
-    e.preventDefault();
-
-    this.selectPage.emit({ originalEvent: e, page });
+    this.selectPage.emit({
+      originalEvent: e,
+      page,
+      isModifiedEvent: e.button !== 0 || e.ctrlKey || e.shiftKey || e.altKey || e.metaKey,
+    });
   };
 
   render() {
@@ -52,7 +50,7 @@ export class Pagination implements ComponentInterface {
     return (
       <ul class="pagination">
         <li class={this.currentPage === pages[0] ? 'dso-page-hidden' : undefined}>
-          <a href={this.formatHref(pages[0])} aria-label="Vorige" onClick={e => this.clickHandler(e, pages[0])}>
+          <a href={this.formatHref(pages[0])} aria-label="Vorige" onClick={e => this.currentPage && this.clickHandler(e, pages[this.currentPage - 2])}>
             <dso-icon icon="chevron-left"></dso-icon>
           </a>
         </li>
@@ -68,7 +66,7 @@ export class Pagination implements ComponentInterface {
           </li>
         ))}
         <li class={this.currentPage === pages[pages.length - 1] ? 'dso-page-hidden' : undefined}>
-          <a href={this.formatHref(pages[pages.length - 1])} aria-label="Volgende" onClick={e => this.clickHandler(e, pages[pages.length - 1])}>
+          <a href={this.formatHref(pages[pages.length - 1])} aria-label="Volgende" onClick={e => this.currentPage && this.clickHandler(e, pages[this.currentPage])}>
             <dso-icon icon="chevron-right"></dso-icon>
           </a>
         </li>

--- a/packages/sources/src/components/pagination/pagination.args.ts
+++ b/packages/sources/src/components/pagination/pagination.args.ts
@@ -29,7 +29,10 @@ export function paginationArgsMapper(a: PaginationArgs): Pagination {
   return {
     totalPages: a.totalPages,
     currentPage: a.currentPage,
-    onSelectPage: a.onSelectPage,
+    onSelectPage: (event) => {
+      event.detail.originalEvent.preventDefault();
+      a.onSelectPage(event);
+    },
     formatHref: page => '#' + page,
   };
 }

--- a/packages/sources/src/components/pagination/pagination.models.ts
+++ b/packages/sources/src/components/pagination/pagination.models.ts
@@ -3,6 +3,8 @@ export interface PaginationSelectPageEvent {
   page: number;
   /** The original pointer event */
   originalEvent: MouseEvent;
+  /** True when user selected the page holding Ctrl, Alt or other modifiers. Can be used to determine navigation. */
+  isModifiedEvent: boolean;
 }
 
 export interface Pagination {


### PR DESCRIPTION
* tests aangemaakt.
* anchor klik-navigatie wordt niet meer afgevangen door het component.
* isModifiedEvent meegeven aan selectPage event.