### PR TITLE
#1657.Document-Item-uitbreiden-met-container-voor-regels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * **dso-toolkit** Helpcentrum voorbeeldpagina's ([#1455](https://github.com/dso-toolkit/dso-toolkit/issues/1455))
 * **core + css + dso-toolkit + sources:** List component uitbreiden met `img-list` variant ([#1622](https://github.com/dso-toolkit/dso-toolkit/issues/1622))
-* **BREAKING: css:** Document Item uitbreiden met container voor regels ([#1657](https://github.com/dso-toolkit/dso-toolkit/issues/1657)) **`.dso-document-list-item` is de wrapper geworden. Toevoeging van `.dso-document-list-item-heading` waar nu de oorspronkelijke vulling in staat ([#1687](https://github.com/dso-toolkit/dso-toolkit/pull/1687))**
+* **BREAKING: css:** Document Item uitbreiden met container voor regels ([#1657](https://github.com/dso-toolkit/dso-toolkit/issues/1657))\
+**het component `.dso-document-list-item` omvat het hele item (heading + content). Plaats de huidige content in `.dso-document-list-item-heading` (dit is het grijze vlak). `.dso-document-list-item-content` kan gebruikt worden om content onder de heading te tonen. ([#1687](https://github.com/dso-toolkit/dso-toolkit/pull/1687))**
 
 ## 42.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * **dso-toolkit** Helpcentrum voorbeeldpagina's ([#1455](https://github.com/dso-toolkit/dso-toolkit/issues/1455))
 * **core + css + dso-toolkit + sources:** List component uitbreiden met `img-list` variant ([#1622](https://github.com/dso-toolkit/dso-toolkit/issues/1622))
+* **BREAKING: css:** Document Item uitbreiden met container voor regels ([#1657](https://github.com/dso-toolkit/dso-toolkit/issues/1657)) **`.dso-document-list-item` is de wrapper geworden. Toevoeging van `.dso-document-list-item-heading` waar nu de oorspronkelijke vulling in staat ([#1687](https://github.com/dso-toolkit/dso-toolkit/pull/1687))**
 
 ## 42.0.0
 

--- a/packages/css/src/components/document-list/document-list.scss
+++ b/packages/css/src/components/document-list/document-list.scss
@@ -5,34 +5,41 @@
 }
 
 .dso-document-list-item {
-  background-color: $grijs-5;
-  padding: $grid-gutter-width * 0.5;
+  .dso-document-list-item-heading {
+    background-color: $grijs-5;
+    padding: $grid-gutter-width * 0.5;
 
-  a {
-    color: $zwart;
-  }
+    a {
+      color: $zwart;
+    }
 
-  > :first-child {
-    margin: 0;
-  }
+    > :first-child {
+      margin: 0;
+    }
 
-  .dso-document-list-item-container {
-    position: relative;
-  }
+    .dso-document-list-item-container {
+      position: relative;
+    }
 
-  .dso-document-list-item-type,
-  .dso-document-list-item-owner {
-    margin: 0 0 $u1 0;
-    display: inline-block;
-  }
+    .dso-document-list-item-type,
+    .dso-document-list-item-owner {
+      margin: 0 0 $u1 0;
+      display: inline-block;
+    }
 
-  .dso-document-list-item-status {
-    dso-badge,
-    .dso-badge {
-      margin-right: $u1;
+    .dso-document-list-item-status {
+      dso-badge,
+      .dso-badge {
+        margin-right: $u1;
+      }
     }
   }
+
+  .dso-document-list-item-content {
+    padding: $grid-gutter-width * 0.5;
+  }
 }
+
 
 dso-responsive-element[small] > .dso-document-list {
   .dso-document-list-item-container {

--- a/packages/css/src/components/document-list/document-list.template.ts
+++ b/packages/css/src/components/document-list/document-list.template.ts
@@ -34,55 +34,8 @@ function documentListItemTemplate({
         </div>
       </div>
       <div class="dso-document-list-item-content">
-        <p>Er zijn regels gemaakt die in de toekomst geldig worden op deze locatie:</p>
-        ${anchorTemplate({
-          url: "#",
-          label: "Toekomstige regels tonen",
-        })}
-        <hr />
-        <small>Gevonden in: Hoofdstuk 2 Functietoedeling / Afdeling wonen</small>
-        <ul class="dso-link-list">
-          <li>
-            ${anchorTemplate({
-              url: "#",
-              label: "22.1 Functieomschrijving",
-            })}
-          </li>
-          <li>
-            ${anchorTemplate({
-              url: "#",
-              label: "22.2 Bouwregels",
-            })}
-          </li>
-          <li>
-            ${anchorTemplate({
-              url: "#",
-              label: "22.3 Nadere eisen",
-            })}
-          </li>
-          <li>
-            ${anchorTemplate({
-              url: "#",
-              label: "22.4 Ontheffing van de bouwregels",
-            })}
-          </li>
-        </ul>
-        <hr />
-        <small>Gevonden in: Hoofdstuk 2 Functietoedeling / Artikel 23 Watergang</small>
-        <ul class="dso-link-list">
-          <li>
-            ${anchorTemplate({
-              url: "#",
-              label: "23.1 Functieomschrijving",
-            })}
-          </li>
-          <li>
-            ${anchorTemplate({
-              url: "#",
-              label: "23.2 Regels voor doorgangbeperking",
-            })}
-          </li>
-        </ul>
+        <p>Hier komt vulling</p>
+        <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui.</p>
       </div>
     </div>
   `;

--- a/packages/css/src/components/document-list/document-list.template.ts
+++ b/packages/css/src/components/document-list/document-list.template.ts
@@ -20,16 +20,69 @@ function documentListItemTemplate({
 }: DocumentListItem<TemplateResult>) {
   return html`
     <div class="dso-document-list-item">
-      <h2>${title}</h2>
-      <div class="dso-document-list-item-container">
-        <p class="dso-document-list-item-type">${type}</p>
-        <p class="dso-document-list-item-owner">${owner}</p>
-        <p class="dso-document-list-item-status">${status}</p>
+      <div class="dso-document-list-item-heading">
+        <h2>${title}</h2>
+        <div class="dso-document-list-item-container">
+          <p class="dso-document-list-item-type">${type}</p>
+          <p class="dso-document-list-item-owner">${owner}</p>
+          <p class="dso-document-list-item-status">${status}</p>
+          ${anchorTemplate({
+            url: "#",
+            label: "Hele document bekijken",
+            modifier: "dso-document-list-item-open-document",
+          })}
+        </div>
+      </div>
+      <div class="dso-document-list-item-content">
+        <p>Er zijn regels gemaakt die in de toekomst geldig worden op deze locatie:</p>
         ${anchorTemplate({
           url: "#",
-          label: "Hele document bekijken",
-          modifier: "dso-document-list-item-open-document",
+          label: "Toekomstige regels tonen",
         })}
+        <hr />
+        <small>Gevonden in: Hoofdstuk 2 Functietoedeling / Afdeling wonen</small>
+        <ul class="dso-link-list">
+          <li>
+            ${anchorTemplate({
+              url: "#",
+              label: "22.1 Functieomschrijving",
+            })}
+          </li>
+          <li>
+            ${anchorTemplate({
+              url: "#",
+              label: "22.2 Bouwregels",
+            })}
+          </li>
+          <li>
+            ${anchorTemplate({
+              url: "#",
+              label: "22.3 Nadere eisen",
+            })}
+          </li>
+          <li>
+            ${anchorTemplate({
+              url: "#",
+              label: "22.4 Ontheffing van de bouwregels",
+            })}
+          </li>
+        </ul>
+        <hr />
+        <small>Gevonden in: Hoofdstuk 2 Functietoedeling / Artikel 23 Watergang</small>
+        <ul class="dso-link-list">
+          <li>
+            ${anchorTemplate({
+              url: "#",
+              label: "23.1 Functieomschrijving",
+            })}
+          </li>
+          <li>
+            ${anchorTemplate({
+              url: "#",
+              label: "23.2 Regels voor doorgangbeperking",
+            })}
+          </li>
+        </ul>
       </div>
     </div>
   `;


### PR DESCRIPTION
De markup is aangepast zodat `.dso-document-list-item` nu de wrapper is van `.dso-document-list-item-heading` en (de toegevoegde nieuwe) `.dso-document-list-item-content`. De vulling die oorspronkelijk in `.dso-document-list-item` stond, staat nu in `.dso-document-list-item-heading`.

Geldige markup ziet er bijvoorbeeld zo uit:

```
<div class="dso-document-list-item">
  <div class="dso-document-list-item-heading">
    <h2>
      Omgevingsplan gemeente Gouda
    </h2>
    <div class="dso-document-list-item-container">
      <p class="dso-document-list-item-type">
        Omgevingsplan
      </p>
      <p class="dso-document-list-item-owner">
        Gemeente Gouda
      </p>
      <p class="dso-document-list-item-status">
        <span class="dso-badge badge-warning">
          Ontwerp
        </span>
        Bekendgemaakt 01-03-2021
      </p>
      <a href="#" class="dso-document-list-item-open-document">
        Hele document bekijken
      </a>
    </div>
  </div>
  <div class="dso-document-list-item-content">
  #REGELS#
  </div>
</div>
```