### PR TITLE
#1714.progress bar indicator wcag verbeteringen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 Het sluitknopje is verplaatst, zie PR voor geldige markup ([#1765](https://github.com/dso-toolkit/dso-toolkit/pull/1765))
 * **core + css + dso-toolkit:** Verhuizen van global stijling naar `@dso-toolkit/css/` ([#1751](https://github.com/dso-toolkit/dso-toolkit/issues/1751))
 * **dso-toolkit + css:** Verhuizen van dso-toolkit/libs/bootstrap ([#1771](https://github.com/dso-toolkit/dso-toolkit/issues/1771))
+* **BREAKING: core:** Progress bar / indicator: WCAG verbeteringen ([#1714](https://github.com/dso-toolkit/dso-toolkit/issues/1714))\
+`Progress Bar` en `Progress Indicator` labels staan nu als eerste element en worden gevolgd door het visuele `progress` kenmerk ([#1748](https://github.com/dso-toolkit/dso-toolkit/pull/1748))
 
 ## 44.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 Het sluitknopje is verplaatst, zie PR voor geldige markup ([#1765](https://github.com/dso-toolkit/dso-toolkit/pull/1765))
 * **core + css + dso-toolkit:** Verhuizen van global stijling naar `@dso-toolkit/css/` ([#1751](https://github.com/dso-toolkit/dso-toolkit/issues/1751))
 * **dso-toolkit + css:** Verhuizen van dso-toolkit/libs/bootstrap ([#1771](https://github.com/dso-toolkit/dso-toolkit/issues/1771))
+* **core:** `dso-map-controls`: naam sluitknopje ([#1722](https://github.com/dso-toolkit/dso-toolkit/issues/1722))
 * **BREAKING: core:** Progress bar / indicator: WCAG verbeteringen ([#1714](https://github.com/dso-toolkit/dso-toolkit/issues/1714))\
 `Progress Bar` en `Progress Indicator` labels staan nu als eerste element en worden gevolgd door het visuele `progress` kenmerk ([#1748](https://github.com/dso-toolkit/dso-toolkit/pull/1748))
 
 ## 44.0.0
-
-### Changed
-* **core:** `dso-map-controls`: naam sluitknopje ([#1722](https://github.com/dso-toolkit/dso-toolkit/issues/1722))
 
 ### Fixed
 * **core + sources:** `ExtIoRef`: href ontbreekt ([#1728](https://github.com/dso-toolkit/dso-toolkit/issues/1728))

--- a/packages/core/src/components/progress-bar/progress-bar.tsx
+++ b/packages/core/src/components/progress-bar/progress-bar.tsx
@@ -21,19 +21,19 @@ export class ProgressBar {
 
     return (
       <div class="progress">
-        <div
+        <span
           class="progress-bar"
           role="progressbar"
           aria-labelledby="progress-bar-label"
           aria-valuenow={progressNumber}
           aria-valuemin={this.min}
           aria-valuemax={this.max}
-          style={{ width: `${progressPercentage}` }}
         >
-          <span id="progress-bar-label">
-            <slot></slot>
-          </span>
-        </div>
+          <span style={{ width: `${progressPercentage}` }}></span>
+        </span>
+        <span id="progress-bar-label">
+          <slot></slot>
+        </span>
       </div>
     );
   }

--- a/packages/core/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/core/src/components/progress-indicator/progress-indicator.scss
@@ -7,10 +7,6 @@
 @include box-sizing();
 @include progress-indicator_root();
 
-:host {
-  display: block;
-}
-
 :host([block]) {
   @include progress-indicator_block();
 }

--- a/packages/core/src/components/progress-indicator/progress-indicator.tsx
+++ b/packages/core/src/components/progress-indicator/progress-indicator.tsx
@@ -20,7 +20,7 @@ export class Progressindicator {
 
     return (
       <Host>
-        <div class="dso-progress-indicator-spinner" role="progressbar" aria-labelledby="progress-indicator-label">
+        <span class="dso-progress-indicator-spinner" role="progressbar" aria-labelledby="progress-indicator-label">
           {/* Keep in sync with /packages/css/src/components/progress-indicator/progress-indicator.scss */}
           <svg class="spinner" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
             <style>
@@ -33,7 +33,7 @@ export class Progressindicator {
             </style>
             <circle class="path" fill="none" stroke-width="10" stroke-linecap="butt" cx="50" cy="50" r="45"></circle>
           </svg>
-        </div>
+        </span>
         <span id="progress-indicator-label" class="dso-progress-indicator-label">{label}</span>
       </Host>
     );

--- a/packages/css/src/components/progress-bar/progress-bar.template.ts
+++ b/packages/css/src/components/progress-bar/progress-bar.template.ts
@@ -4,19 +4,19 @@ import { html } from 'lit-html';
 export function progressBarTemplate({ progress, label, min, max }: ProgressBar) {
   return html`
     <div class="progress">
-      <div
+      <span
         class="progress-bar"
         role="progressbar"
         aria-labelledby="progress-bar-label"
         aria-valuenow="${Math.round(progress)}"
         aria-valuemin="${min || 0}"
         aria-valuemax="${max || 100}"
-        style="width: ${Math.round(progress / (max || 100) * 100)}%"
       >
-        <span id="progress-bar-label">
-          ${label}
-        </span>
-      </div>
+        <span style="width: ${Math.round(progress / (max || 100) * 100)}%"></span>
+      </span>
+      <span id="progress-bar-label">
+        ${label}
+      </span>
     </div>
   `;
 }

--- a/packages/css/src/components/progress-indicator/progress-indicator.template.ts
+++ b/packages/css/src/components/progress-indicator/progress-indicator.template.ts
@@ -11,10 +11,9 @@ export function progressIndicatorTemplate({ label, size, block }: ProgressIndica
         [`dso-${size}`]: !!size,
         'dso-block': !!block,
       })}"
-      role="progressbar"
-      aria-labelledby="progress-indicator-label"
     >
-      <div class="dso-progress-indicator-spinner"></div><span id="progress-indicator-label" class="dso-progress-indicator-label">${label}</span>
+      <span class="dso-progress-indicator-spinner" role="progressbar" aria-labelledby="progress-indicator-label"></span>
+      <span id="progress-indicator-label" class="dso-progress-indicator-label">${label}</span>
     </div>
   `;
 }

--- a/packages/dso-toolkit/reference/render/progress-bar--default.html
+++ b/packages/dso-toolkit/reference/render/progress-bar--default.html
@@ -1,7 +1,12 @@
 <dso-progress-bar progress="60">
   <div class="progress">
-    <div class="progress-bar" role="progressbar" aria-labelledby="progress-bar-label" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-      <span id="progress-bar-label">Genereren export: Nog ongeveer 4 minuten.</span>
-    </div>
+    <span
+      class="progress-bar"
+      role="progressbar"
+      aria-labelledby="progress-bar-label"
+      aria-valuenow="60"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      ><span style="width: 60%"></span></span><span id="progress-bar-label">Genereren export: Nog ongeveer 4 minuten.</span>
   </div>
 </dso-progress-bar>

--- a/packages/dso-toolkit/reference/render/progress-bar--non-default-values.html
+++ b/packages/dso-toolkit/reference/render/progress-bar--non-default-values.html
@@ -1,7 +1,12 @@
 <dso-progress-bar progress="3" max="12">
   <div class="progress">
-    <div class="progress-bar" role="progressbar" aria-labelledby="progress-bar-label" aria-valuenow="3" aria-valuemin="0" aria-valuemax="12" style="width: 3%">
-      <span id="progress-bar-label">Bestanden comprimeren: 12 stuks.</span>
-    </div>
+    <span
+      class="progress-bar"
+      role="progressbar"
+      aria-labelledby="progress-bar-label"
+      aria-valuenow="3"
+      aria-valuemin="0"
+      aria-valuemax="12"
+      ><span style="width: 3%"></span></span><span id="progress-bar-label">Bestanden comprimeren: 12 stuks.</span>
   </div>
 </dso-progress-bar>

--- a/packages/sources/src/components/progress-bar/progress-bar.scss
+++ b/packages/sources/src/components/progress-bar/progress-bar.scss
@@ -7,27 +7,24 @@ $dso-progress-bar-bg: $wit;
 $dso-progress-bar-color: $grasgroen;
 
 @mixin progress-bar_root() {
-  background-color: $dso-progress-bar-bg;
-  border: 1px solid  $dso-progress-bar-color;
-  height: $dso-progress-bar-height;
-  margin-bottom: calc(#{$dso-progress-bar-margin * 2} + 1em);
-  position: relative;
+  margin-bottom: $u1;
+
+  #progress-bar-label {
+    font-size: $dso-font-size-small;
+    margin-top: $u1;
+  }
 
   .progress-bar {
-    background-color: $progress-bar-bg;
-    color: $progress-bar-color;
-    float: left;
-    font-size: $dso-font-size-small;
-    height: 100%;
-    line-height: $dso-progress-bar-height;
-    text-align: center;
-    width: 0%;
+    background-color: $dso-progress-bar-bg;
+    border: 1px solid  $dso-progress-bar-color;
+    display: block;
+    height: $dso-progress-bar-height;
 
-    > span:not(.sr-only) {
-      color: $text-color;
-      left: 0;
-      position: absolute;
-      top: calc(100% + #{$dso-progress-bar-margin});
+    > span {
+      background-color: $progress-bar-bg;
+      float: left;
+      height: 100%;
+      width: 0%;
     }
   }
 }


### PR DESCRIPTION
Een aantal elementen zijn aangepast naar `<span>` elementen.

Geldige markup progressbar:
```
<div class="progress">
  <span class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100">
    <span style="width: 60%"></span>
  </span>
  <span id="progress-bar-label">
    Genereren export: nog ongeveer 4 minuten.
  </span>
</div>
```

Geldige markup progress-indicator:
```
<div class="dso-progress-indicator dso-small ">
  <span class="dso-progress-indicator-spinner" role="progressbar" aria-labelledby="progress-indicator-label"></span>
  <span id="progress-indicator-label" class="dso-progress-indicator-label">
    Resultaten laden: een moment geduld alstublieft.
  </span>
</div>
```