### PR TITLE
#1707 - Info: sluitknopje in DOM onderaan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Changed
+* **BREAKING: core + css:** Info: sluitknopje in DOM onderaan ([#1707](https://github.com/dso-toolkit/dso-toolkit/issues/1707))\
+Het sluitknopje is verplaatst, zie PR voor geldige markup ([#1765](https://github.com/dso-toolkit/dso-toolkit/pull/1765))
+
 ## 44.0.0
 
 ### Fixed

--- a/packages/core/src/components/info/info.tsx
+++ b/packages/core/src/components/info/info.tsx
@@ -18,12 +18,12 @@ export class Info {
   render() {
     return (
       <Fragment>
+        <slot></slot>
         {!this.fixed && (
           <button type="button" onClick={e => this.close.emit(e)}>
             <span class="sr-only">Sluiten</span>
           </button>
         )}
-        <slot></slot>
       </Fragment>
     );
   }

--- a/packages/css/src/components/info/info.template.ts
+++ b/packages/css/src/components/info/info.template.ts
@@ -8,13 +8,13 @@ import { buttonTemplate } from '../button/button.template';
 export function infoTemplate({ fixed, richContent, onClose, id }: Info<TemplateResult>) {
   return html`
     <div class="dso-info" id=${ifDefined(id)}>
-      ${!fixed
-        ? buttonTemplate({ label: 'Sluiten', variant: null, onClick: onClose, iconMode: 'only' })
-        : nothing
-      }
       ${typeof richContent === 'string'
         ? html`${unsafeHTML(richContent)}`
         : richContent
+      }
+      ${!fixed
+        ? buttonTemplate({ label: 'Sluiten', variant: null, onClick: onClose, iconMode: 'only' })
+        : nothing
       }
     </div>
   `;


### PR DESCRIPTION
Het sluitknopje is nu onderaan in de DOM van het component verplaatst.

Geldige markup ziet er zo uit:

```
<div class="dso-info">
    <div class="dso-rich-content">
      ##CONTENT##
    </div>
    <button type="button">
      <span class="sr-only">Sluiten</span>
    </button>
</div>
```