### PR TITLE
#1763 Header styling verbeteringen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **core:** Helpcenterpanel - Responsive maken ([#1781](https://github.com/dso-toolkit/dso-toolkit/issues/1781))
+* **core + css:** Header styling verbeteringen ([#1763](https://github.com/dso-toolkit/dso-toolkit/issues/1763))
 
 ## 45.1.0
 

--- a/packages/core/src/components/header/header.scss
+++ b/packages/core/src/components/header/header.scss
@@ -29,7 +29,6 @@ $dso-dropdown-link-color: $grijs-90;
   border-bottom: 1px solid $grijs-20;
   display: flex;
   flex-wrap: wrap;
-  padding: 0 $u2;
   position: relative;
 
   @media screen and (min-width: $screen-sm-min) {
@@ -50,7 +49,7 @@ $dso-dropdown-link-color: $grijs-90;
   padding-top: $u2;
 
   @media screen and (max-width: $screen-xs-max) {
-    max-width: 200px;
+    max-height: 40px;
   }
 }
 
@@ -66,8 +65,6 @@ $dso-dropdown-link-color: $grijs-90;
 
 .login,
 .logout {
-  margin-right: $u2;
-
   .dso-tertiary {
     cursor: pointer;
     font-family: $font-family-base;

--- a/packages/core/src/components/header/header.template.ts
+++ b/packages/core/src/components/header/header.template.ts
@@ -26,7 +26,7 @@ export function headerTemplate({
     user-home-url=${ifDefined(userHomeUrl)}
     @dsoHeaderClick=${dsoHeaderClick}
   >
-    <div slot="logo"><img height="40" alt="Omgevingsloket" src="${logo}" /></div>
+    <div slot="logo"><img alt="Omgevingsloket" src="${logo}" /></div>
     ${subLogo ? html`<div slot="sub-logo"><img alt="Regels op de kaart" src="${subLogo}" /></div>` : undefined}
   </dso-header>`;
 }

--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -1,3 +1,27 @@
 header {
   display: block;
 }
+
+dso-header {
+  .dso-header:not(.has-sub-logo) {
+    div[slot="logo"] {
+      img {
+        @media screen and (min-width: $screen-sm-min) {
+          max-height: 48px;
+        }
+
+        @media screen and (max-width: $screen-xs-max) {
+          max-height: 40px;
+        }
+      }
+    }
+  }
+
+  .dso-header.has-sub-logo {
+    div[slot="logo"] {
+      img {
+        max-height: 40px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Voorheen werd er een `height="40"` op de `img` in de `slot="logo"` gezet. Deze is nu weggehaald, de maat wordt dmv stijling bepaald.