### PR TITLE
#1826 Webcomponent Accordion: Algemene verbeteringen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## NEXT
 
 ### Changed
+* **core + css + react + storybook:** Webcomponent Accordion: Algemene verbeteringen ([#1826](https://github.com/dso-toolkit/dso-toolkit/issues/1826))
 * **core + css + sources:** Aanpassing chevrons in accordion component ([#1827](https://github.com/dso-toolkit/dso-toolkit/issues/1827))
 
 ## 45.2.0

--- a/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
@@ -1,13 +1,18 @@
 @use "~@dso-toolkit/sources/src/variables/colors";
+@use "~@dso-toolkit/sources/src/variables/units";
 @use "~@dso-toolkit/sources/src/components/accordion";
 
 @mixin dso-web-component-accordion-compact() {
   .dso-section-handle {
     border: 1px solid transparent;
+    border-top-width: 0;
 
     a,
     button {
       color: accordion.$compact-color;
+      padding-bottom: accordion.$vertical-padding - accordion.$compact-border-width;
+      padding-left: 0;
+      padding-top: accordion.$vertical-padding - accordion.$compact-border-width;
 
       &:hover,
       &:active,
@@ -21,18 +26,16 @@
   .dso-section-body {
     border: 0;
     border-top: 1px solid accordion.$compact-border-color;
+    padding-top: 0;
   }
 
   &:last-child {
     border-bottom: 1px solid accordion.$compact-border-color;
   }
 
-  + dso-accordion-section {
-    margin-top: 0;
-  }
-
   .dso-section-body {
     margin-top: 0;
+    padding-bottom: units.$u1 * 1.5;
   }
 }
 
@@ -55,6 +58,10 @@
         --dso-icon: var(--di-paperclip-grijs);
       }
     }
+  }
+
+  > .dso-section-body {
+    border-top: 0;
   }
 }
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-conclusion.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-conclusion.scss
@@ -42,5 +42,4 @@
 
 @mixin dso-web-component-accordion-conclusion-open-nested() {
   background-color: accordion.$conclusion-nested-body-bgcolor;
-  border: 2px solid accordion.$conclusion-border-color;
 }

--- a/packages/core/src/components/accordion/components/accordion-section-theme-default.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-default.scss
@@ -28,7 +28,10 @@
 @mixin dso-web-component-accordion-default-open {
   > .dso-section-handle {
     background-color: accordion.$default-nested-handle-bgcolor;
-    border-radius: accordion.$border-radius;
+    border-radius: 0;
+    border-top-left-radius: accordion.$border-radius;
+    border-top-right-radius: accordion.$border-radius;
+
 
     a,
     button {

--- a/packages/core/src/components/accordion/components/accordion-section.scss
+++ b/packages/core/src/components/accordion/components/accordion-section.scss
@@ -53,6 +53,7 @@
     line-height: accordion.$handle-line-height;
     margin: 0;
     padding: accordion.$vertical-padding accordion.$horizontal-padding accordion.$vertical-padding;
+    text-align: start;
     width: 100%;
     word-break: break-word;
 

--- a/packages/core/src/components/accordion/components/accordion-section.scss
+++ b/packages/core/src/components/accordion/components/accordion-section.scss
@@ -98,7 +98,7 @@
   @include accordion-section-theme-default.dso-web-component-accordion-default();
 }
 
-:host(.dso-accordion-default[open]:not(.dso-nested-accordion)) {
+:host(.dso-accordion-default[open]) {
   @include accordion-section-theme-default.dso-web-component-accordion-default-open();
 }
 

--- a/packages/core/src/components/accordion/components/accordion-section.tsx
+++ b/packages/core/src/components/accordion/components/accordion-section.tsx
@@ -78,7 +78,7 @@ export class AccordionSection implements ComponentInterface {
     }
 
     const { variant, reverseAlign } = this.accordionState;
-    const hasAddons = this.status || this.state || this.icon || this.attachmentCount;
+    const hasAddons = !!this.status || !!this.state || !!this.icon || !!this.attachmentCount;
 
     return (
       <Host

--- a/packages/css/src/components/accordion/accordion-theme-compact.scss
+++ b/packages/css/src/components/accordion/accordion-theme-compact.scss
@@ -80,35 +80,33 @@
     }
 
     &.dso-open {
-      &:not(.dso-nested-accordion) {
-        > .dso-section-handle {
-          background-color: transparent;
+      > .dso-section-handle {
+        background-color: transparent;
 
-          a,
-          button {
+        a,
+        button {
+          color: accordion.$compact-color;
+
+          &:hover,
+          &:active,
+          &.active {
             color: accordion.$compact-color;
+          }
 
-            &:hover,
-            &:active,
-            &.active {
-              color: accordion.$compact-color;
-            }
+          &::before {
+            @include di.variant("chevron-up-grasgroen");
+          }
 
-            &::before {
-              @include di.base("chevron-up-grasgroen");
-            }
+          dso-attachments-counter {
+            --dso-attachments-counter-color: #{colors.$grijs-60};
+            --dso-icon: var(--di-paperclip-grijs);
+          }
 
-            dso-attachments-counter {
-              --dso-attachments-counter-color: #{colors.$grijs-60};
-              --dso-icon: var(--di-paperclip-grijs);
-            }
+          .dso-attachments {
+            color: colors.$grijs-60;
 
-            .dso-attachments {
-              color: colors.$grijs-60;
-
-              &::after {
-                @include di.variant("paperclip-grijs");
-              }
+            &::after {
+              @include di.variant("paperclip-grijs");
             }
           }
         }

--- a/packages/css/src/components/accordion/accordion-theme-compact.scss
+++ b/packages/css/src/components/accordion/accordion-theme-compact.scss
@@ -1,4 +1,5 @@
 @use "@dso-toolkit/sources/src/variables/colors";
+@use "@dso-toolkit/sources/src/variables/units";
 @use "@dso-toolkit/sources/src/components/accordion";
 
 @use "../../di";
@@ -8,8 +9,12 @@
     .dso-section-handle {
       a,
       button {
+        padding-left: units.$u2;
+
         &::before {
           @include di.base("chevron-down-grasgroen");
+
+          left: auto;
         }
       }
     }
@@ -43,13 +48,17 @@
 
   .dso-section-handle {
     border: 1px solid transparent;
+    border-top-width: 0;
 
     a,
     button {
       color: accordion.$compact-color;
+      padding-left: units.$u4;
 
       &::before {
         @include di.base("chevron-down-grasgroen");
+
+        left: 0;
       }
 
       &:hover,
@@ -65,6 +74,7 @@
     .dso-section-body {
       border: 0;
       border-top: 1px solid accordion.$compact-border-color;
+      padding-top: 0;
     }
 
     &:last-child {
@@ -77,6 +87,7 @@
 
     .dso-section-body {
       margin-top: 0;
+      padding-bottom: units.$u1 * 1.5;
     }
 
     &.dso-open {
@@ -110,6 +121,10 @@
             }
           }
         }
+      }
+
+      > .dso-section-body {
+        border-top: 0;
       }
 
       &.dso-nested-accordion {

--- a/packages/css/src/components/accordion/accordion-theme-conclusion.scss
+++ b/packages/css/src/components/accordion/accordion-theme-conclusion.scss
@@ -94,7 +94,6 @@
 
       &.dso-nested-accordion {
         background-color: accordion.$conclusion-nested-body-bgcolor;
-        border: 2px solid accordion.$conclusion-border-color;
 
         > .dso-section-handle {
           a,

--- a/packages/css/src/components/accordion/accordion-theme-default.scss
+++ b/packages/css/src/components/accordion/accordion-theme-default.scss
@@ -64,32 +64,30 @@
 
   .dso-accordion-section {
     &.dso-open {
-      &:not(.dso-nested-accordion) {
-        > .dso-section-handle {
-          background-color: accordion.$default-nested-handle-bgcolor;
-          border-radius: 0;
-          border-top-left-radius: accordion.$border-radius;
-          border-top-right-radius: accordion.$border-radius;
+      > .dso-section-handle {
+        background-color: accordion.$default-nested-handle-bgcolor;
+        border-radius: 0;
+        border-top-left-radius: accordion.$border-radius;
+        border-top-right-radius: accordion.$border-radius;
 
-          a,
-          button {
+        a,
+        button {
+          color: colors.$wit;
+
+          &::before {
+            @include di.variant("chevron-up-wit");
+          }
+
+          dso-attachments-counter {
+            --dso-attachments-counter-color: #{colors.$wit};
+            --dso-icon: var(--di-paperclip-wit);
+          }
+
+          .dso-attachments {
             color: colors.$wit;
 
-            &::before {
-              @include di.variant("chevron-down-wit");
-            }
-
-            dso-attachments-counter {
-              --dso-attachments-counter-color: #{colors.$wit};
-              --dso-icon: var(--di-paperclip-wit);
-            }
-
-            .dso-attachments {
-              color: colors.$wit;
-
-              &::after {
-                @include di.variant("paperclip-wit");
-              }
+            &::after {
+              @include di.variant("paperclip-wit");
             }
           }
         }
@@ -97,15 +95,6 @@
 
       &.dso-nested-accordion {
         background-color: accordion.$default-nested-body-bgcolor;
-
-        > .dso-section-handle {
-          a,
-          button {
-            &::before {
-              @include di.variant("chevron-right-mauve");
-            }
-          }
-        }
       }
     }
   }

--- a/packages/css/src/components/accordion/accordion-theme-default.scss
+++ b/packages/css/src/components/accordion/accordion-theme-default.scss
@@ -67,7 +67,9 @@
       &:not(.dso-nested-accordion) {
         > .dso-section-handle {
           background-color: accordion.$default-nested-handle-bgcolor;
-          border-radius: accordion.$border-radius;
+          border-radius: 0;
+          border-top-left-radius: accordion.$border-radius;
+          border-top-right-radius: accordion.$border-radius;
 
           a,
           button {

--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -160,7 +160,7 @@
     }
   }
 
-  + .dso-accordion-section {
+  &:not(.dso-accordion-compact) + .dso-accordion-section {
     margin-top: units.$u1 * 0.5;
   }
 

--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -214,11 +214,9 @@
 
   &.dso-open {
     &.dso-nested-accordion {
-      border: 0;
       border-radius: 0 0 accordion.$border-radius accordion.$border-radius;
 
       > .dso-section-body {
-        border: 0;
         padding: (units.$u2 + accordion.$border-radius - 1) (units.$u2 + 1) units.$u2; // corrections for missing borders in nested accordion
       }
 

--- a/packages/react/src/components/accordion/accordion.react-template.tsx
+++ b/packages/react/src/components/accordion/accordion.react-template.tsx
@@ -19,26 +19,26 @@ export const reactAccordion: ComponentImplementation<Accordion> = {
   ) {
     class DemoHtml extends React.PureComponent<{ html?: string; }> {
       divRef: React.RefObject<HTMLDivElement>;
-    
+
       constructor(props: { html?: string; }) {
         super(props);
-    
+
         this.divRef = React.createRef();
       }
-    
+
       componentDidMount() {
         const parent = this.divRef.current?.parentElement;
-    
+
         if (parent instanceof HTMLElement) {
           this.divRef.current?.childNodes.forEach(node => parent.appendChild(node));
         }
       }
-    
+
       render() {
         if (!this.props.html) {
           return;
         }
-    
+
         return <div style={{ display: 'none' }} ref={this.divRef} dangerouslySetInnerHTML={{ __html: this.props.html }}></div>;
       }
     }
@@ -55,6 +55,7 @@ export const reactAccordion: ComponentImplementation<Accordion> = {
             key={`dsoAccordionSection-${i}`}
             open={section.open}
             handleTitle={section.handleTitle}
+            heading={section.heading}
             handleUrl={section.handleUrl}
             state={section.state}
             status={section.status}

--- a/packages/sources/src/components/accordion/accordion.variables.scss
+++ b/packages/sources/src/components/accordion/accordion.variables.scss
@@ -4,7 +4,7 @@
 $default-border-color: colors.$mauve;
 $default-color: colors.$mauve;
 $default-nested-handle-bgcolor: colors.$mauve;
-$default-nested-body-bgcolor: colors.$mauve-40;
+$default-nested-body-bgcolor: colors.$grijs-10;
 
 $conclusion-bgcolor: colors.$grijs-5;
 $conclusion-hover-bgcolor: colors.$grijs-10;

--- a/packages/sources/src/components/accordion/accordion.variables.scss
+++ b/packages/sources/src/components/accordion/accordion.variables.scss
@@ -15,6 +15,7 @@ $conclusion-nested-body-bgcolor: colors.$wit;
 
 $compact-color: colors.$grasgroen;
 $compact-border-color: colors.$grijs-20;
+$compact-border-width: 1px;
 
 $border-radius: units.$u1 * 0.5;
 $horizontal-padding: units.$u2;

--- a/packages/storybook/src/components/accordion/accordion.core-template.ts
+++ b/packages/storybook/src/components/accordion/accordion.core-template.ts
@@ -25,6 +25,7 @@ export const coreAccordion: ComponentImplementation<Accordion> = {
           <dso-accordion-section
             ?open=${ifDefined(section.open)}
             handle-title=${section.handleTitle}
+            heading=${section.heading}
             handle-url=${ifDefined(section.handleUrl)}
             state=${ifDefined(section.state)}
             status=${ifDefined(section.status)}

--- a/packages/storybook/src/components/accordion/accordion.css-template.ts
+++ b/packages/storybook/src/components/accordion/accordion.css-template.ts
@@ -84,6 +84,10 @@ export const cssAccordion: ComponentImplementation<Accordion> = {
     function accordionSectionTemplate(accordion: Accordion, section: AccordionSection): TemplateResult {
       const hasNestedAccordion = section.content?.includes('<dso-accordion') ?? false;
 
+      if(!section.heading) {
+        section.heading = 'h2';
+      }
+
       return html`
         <div class="dso-accordion-section ${classMap({
           [`dso-${section.state}`]: !!section.state,
@@ -106,7 +110,7 @@ export const cssAccordion: ComponentImplementation<Accordion> = {
 
     return html`
       <div class="dso-accordion ${classMap({
-        [`${accordion.variant}`]: !!accordion.variant,
+        [`dso-accordion-${accordion.variant}`]: !!accordion.variant,
         'dso-accordion-reverse-align': !!accordion.reverseAlign
       })}">
         ${accordion.sections.map(section => accordionSectionTemplate(accordion, section))}


### PR DESCRIPTION
* Als de attachmentcount van 1 naar 0 gaat dan verschijnt een 0 achter de heading.
* Styling: de onderste corners moeten radius 0 krijgen in uitgeklapte toestand
* De heading control lijkt geen effect te hebben, mogelijk de property ook niet.
* Wanneer de titel multi-line is centreert de tekst ongewenst.
* css variants
* css section heading undefined
* Stijling nested accordion
* Stijling compact accordion