### PR TITLE
#1881 Fixed: dso-ozon-content kan lege titels/bijschrift div renderen bij image-overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **core:** Accordion compact: inspring klopt niet ([#1883](https://github.com/dso-toolkit/dso-toolkit/issues/1883))
 * TemplateContainer valt onterecht terug op CSS implementatie ([#1890](https://github.com/dso-toolkit/dso-toolkit/issues/1890))
 * **core + css:** Header: smalle viewport: Menu toont niet bij dropdownmenu never, en sub-logo valt buiten de header ([#1889](https://github.com/dso-toolkit/dso-toolkit/issues/1889))
+* **core:** `<dso-ozon-content>` kan lege titels/bijschrift div renderen bij image-overlay ([#1881](https://github.com/dso-toolkit/dso-toolkit/issues/1881))
 
 ## 46.0.0
 

--- a/packages/core/src/components/ozon-content/nodes/figuur.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/figuur.node.tsx
@@ -73,17 +73,21 @@ export class OzonContentFiguurNode implements OzonContentNode {
             <Bijschrift bijschrift={bijschrift} bron={bron} mapNodeToJsx={mapNodeToJsx} />
           )}
           <dso-image-overlay>
-            <div slot="titel">
-              <span>{titel}</span>
-            </div>
+            {titel && (
+              <div slot="titel">
+                <span>{titel}</span>
+              </div>
+            )}
             <img
               src={illustratie.naam ?? undefined}
               alt={illustratie.alt ?? titel ?? illustratie.naam ?? undefined}
               onLoad={(event: Event) => this.onImageLoad(event, Number(illustratie.schaal))}
             />
-            <div slot="bijschrift">
-              <Bijschrift bijschrift={bijschrift} bron={bron} mapNodeToJsx={mapNodeToJsx} />
-            </div>
+            {(bijschrift || bron) && (
+              <div slot="bijschrift">
+                <Bijschrift bijschrift={bijschrift} bron={bron} mapNodeToJsx={mapNodeToJsx} />
+              </div>
+            )}
           </dso-image-overlay>
           {(bijschrift?.locatie === "onder" || (!bijschrift && bron)) && (
             <Bijschrift bijschrift={bijschrift} bron={bron} mapNodeToJsx={mapNodeToJsx} />


### PR DESCRIPTION
bij de <Figuur> node treedt dit op