### PR TITLE
#1989 Fixed: Modal body niet bereikbaar met toetsenbord bij scrollbaar gebied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Angular componenten missen Intellisense voor events ([#1961](https://github.com/dso-toolkit/dso-toolkit/issues/1961)).
 * SVG fix voor nieuwe iconen ([#1969](https://github.com/dso-toolkit/dso-toolkit/issues/1969))
 * dso-toolkit.nl: Storybook opent altijd in master ([#1973](https://github.com/dso-toolkit/dso-toolkit/issues/1973))
+* **BREAKING** Modal body niet bereikbaar met toetsenbord bij scrollbaar gebied. ([#1989](https://github.com/dso-toolkit/dso-toolkit/issues/1989))
 
 ### Changed
 * Webcomponent header - verbeteringen ([#1904](https://github.com/dso-toolkit/dso-toolkit/issues/1904)).

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -85,7 +85,7 @@ export class Modal implements ComponentInterface {
               </span>
             )}
 
-            <div class="dso-body">
+            <div class="dso-body" tabIndex={0}>
               <slot name="body"></slot>
             </div>
 

--- a/storybook/cypress/e2e/modal.cy.ts
+++ b/storybook/cypress/e2e/modal.cy.ts
@@ -38,6 +38,11 @@ describe("Modal", () => {
       .should("have.focus")
       .realPress("Tab")
       .get("dso-modal")
+      .shadow()
+      .find(".dso-body")
+      .should("have.focus")
+      .realPress("Tab")
+      .get("dso-modal")
       .find('div[slot="body"] > p > a')
       .should("have.focus")
       .realPress("Tab")
@@ -107,5 +112,23 @@ describe("Modal", () => {
     cy.get("dso-modal").invoke("remove").should("not.exist");
 
     cy.get("@close").should("not.have.been.called");
+  });
+
+  it("should have keyboard accessible body container", () => {
+    cy.visit("http://localhost:45000/iframe.html?id=core-modal--passive");
+
+    cy.get("dso-modal").shadow().find(".dso-body").as("modalBody");
+
+    cy.get("dso-modal").shadow().find(".dso-close").should("have.focus");
+    cy.get("@modalBody").should("have.attr", "tabindex", 0);
+    cy.get("@modalBody").invoke("scrollTop").should("eq", 0);
+
+    cy.realPress("Tab");
+
+    cy.get("@modalBody").should("have.focus");
+
+    cy.realPress("{downarrow}");
+
+    cy.get("@modalBody").invoke("scrollTop").should("be.greaterThan", 0);
   });
 });

--- a/storybook/src/components/modal/modal.css-template.ts
+++ b/storybook/src/components/modal/modal.css-template.ts
@@ -37,7 +37,7 @@ export const cssModal: ComponentImplementation<Modal<TemplateResult>> = {
                   </div>
                 `
               : nothing}
-            <div class="dso-body">${body}</div>
+            <div class="dso-body" tabindex="0">${body}</div>
             ${footer && html`<div class="dso-footer">${footer}</div>`}
           </div>
         </div>

--- a/website/blog/2023-01-18-dso-toolkit-51.0.0.mdx
+++ b/website/blog/2023-01-18-dso-toolkit-51.0.0.mdx
@@ -1,0 +1,12 @@
+---
+authors: [tfrijsewijk]
+---
+
+# DSO Toolkit v51.0.0
+
+## Modal
+
+In deze release is [#1989](https://github.com/dso-toolkit/dso-toolkit/issues/1989) opgelost.
+
+- Voor het HTML/CSS component zijn de markup voorschriften gewijzigd: Het element `.dso-modal .dso-body` moet een attribuut `tabindex="0"` krijgen.
+- Voor het Web Component zijn geen wijzigingen voor afnemers.


### PR DESCRIPTION
Ik vraag mij nu af of dit niet voorwaardelijk moet?

Als de content wel past en er geen scrollbare content is, zit die `tabindex="0"` dan in de weg?

Voor het Web Component kunnen we dat best wel oplossen. Met 'n MutationObserver kunnen we de slotted content observen en alleen als nodig het attribuut `tabindex="0"` zetten.

Voor het HTML/CSS component zal het bij voorschriften blijven.

@timveld wat denk jij?