### PR TITLE
#1985.status danger deprecaten en vervangen door status error van 3 componenten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Added
+* Toevoeging `error` status bij `badge`, `banner` en `label` ([#1985](https://github.com/dso-toolkit/dso-toolkit/issues/1985))
+
+### Deprecated
+* Deprecation van `danger` status bij `badge`, `banner` en `label`. Gebruik voortaan de `error` status ([#1985](https://github.com/dso-toolkit/dso-toolkit/issues/1985))
+
 ## 51.1.0
 
 ### Added

--- a/angular-workspace/components/banner/banner.content.ts
+++ b/angular-workspace/components/banner/banner.content.ts
@@ -18,6 +18,15 @@ export const dangerRichContent = {
   `,
 };
 
+export const errorRichContent = {
+  template: `
+    <div class="dso-rich-content">
+      <h2>Storingsmelding:</h2>
+      <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
+    </div>
+  `,
+};
+
 export const richWarningRichContent = {
   template: `
     <div class="dso-rich-content">

--- a/angular-workspace/components/banner/banner.stories.ts
+++ b/angular-workspace/components/banner/banner.stories.ts
@@ -6,6 +6,7 @@ import { templateContainer } from "../../templates";
 import {
   dangerRichContent,
   dangerWithHeadingsRichContent,
+  errorRichContent,
   richWarningRichContent,
   warningRichContent,
 } from "./banner.content";
@@ -32,5 +33,6 @@ storiesOfBanner({
     dangerWithHeadingsRichContent,
     richWarningRichContent,
     warningRichContent,
+    errorRichContent,
   }),
 });

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -8,7 +8,13 @@
         "command": "stencil build",
         "cwd": "packages/core"
       },
-      "outputs": ["{projectRoot}/dist", "{projectRoot}/loader"]
+      "outputs": [
+        "{projectRoot}/dist",
+        "{projectRoot}/loader",
+        "{projectRoot}/../react/src/components.ts",
+        "{projectRoot}/../react/src/react-component-lib",
+        "{projectRoot}/../../angular-workspace/projects/component-library/src/lib/stencil-generated"
+      ]
     }
   }
 }

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -115,7 +115,7 @@ export namespace Components {
         "suggestions": Suggestion[] | null;
     }
     interface DsoBadge {
-        "status"?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
+        "status"?: "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline";
     }
     interface DsoBanner {
         "status": "warning" | "danger" | "error";
@@ -860,7 +860,7 @@ declare namespace LocalJSX {
         "suggestions"?: Suggestion[] | null;
     }
     interface DsoBadge {
-        "status"?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
+        "status"?: "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline";
     }
     interface DsoBanner {
         "status": "warning" | "danger" | "error";

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -240,7 +240,7 @@ export namespace Components {
     interface DsoLabel {
         "compact"?: boolean;
         "removable"?: boolean;
-        "status"?: "primary" | "info" | "success" | "warning" | "danger" | "bright";
+        "status"?: "primary" | "info" | "success" | "warning" | "danger" | "error" | "bright";
         "truncate"?: boolean;
     }
     interface DsoListButton {
@@ -1000,7 +1000,7 @@ declare namespace LocalJSX {
         "compact"?: boolean;
         "onDsoRemoveClick"?: (event: DsoLabelCustomEvent<MouseEvent>) => void;
         "removable"?: boolean;
-        "status"?: "primary" | "info" | "success" | "warning" | "danger" | "bright";
+        "status"?: "primary" | "info" | "success" | "warning" | "danger" | "error" | "bright";
         "truncate"?: boolean;
     }
     interface DsoListButton {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -118,7 +118,7 @@ export namespace Components {
         "status"?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
     }
     interface DsoBanner {
-        "status": "warning" | "danger";
+        "status": "warning" | "danger" | "error";
     }
     interface DsoCard {
         "hasImage": boolean;
@@ -863,7 +863,7 @@ declare namespace LocalJSX {
         "status"?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
     }
     interface DsoBanner {
-        "status": "warning" | "danger";
+        "status": "warning" | "danger" | "error";
     }
     interface DsoCard {
         "hasImage"?: boolean;

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 })
 export class Badge {
   @Prop()
-  status?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
+  status?: "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline";
 
   render() {
     return (

--- a/packages/core/src/components/badge/readme.md
+++ b/packages/core/src/components/badge/readme.md
@@ -5,9 +5,9 @@
 
 ## Properties
 
-| Property | Attribute | Description | Type                                                                                  | Default     |
-| -------- | --------- | ----------- | ------------------------------------------------------------------------------------- | ----------- |
-| `status` | `status`  |             | `"danger" \| "info" \| "outline" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
+| Property | Attribute | Description | Type                                                                                             | Default     |
+| -------- | --------- | ----------- | ------------------------------------------------------------------------------------------------ | ----------- |
+| `status` | `status`  |             | `"danger" \| "error" \| "info" \| "outline" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/banner/banner.tsx
+++ b/packages/core/src/components/banner/banner.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 })
 export class Banner {
   @Prop({ reflect: true })
-  status!: "warning" | "danger";
+  status!: "warning" | "danger" | "error";
 
   render() {
     return (

--- a/packages/core/src/components/banner/readme.md
+++ b/packages/core/src/components/banner/readme.md
@@ -5,9 +5,9 @@
 
 ## Properties
 
-| Property              | Attribute | Description | Type                    | Default     |
-| --------------------- | --------- | ----------- | ----------------------- | ----------- |
-| `status` _(required)_ | `status`  |             | `"danger" \| "warning"` | `undefined` |
+| Property              | Attribute | Description | Type                               | Default     |
+| --------------------- | --------- | ----------- | ---------------------------------- | ----------- |
+| `status` _(required)_ | `status`  |             | `"danger" \| "error" \| "warning"` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/label/label.tsx
+++ b/packages/core/src/components/label/label.tsx
@@ -46,7 +46,7 @@ export class Label implements ComponentInterface {
   removable?: boolean;
 
   @Prop()
-  status?: "primary" | "info" | "success" | "warning" | "danger" | "bright";
+  status?: "primary" | "info" | "success" | "warning" | "danger" | "error" | "bright";
 
   @State()
   removeHover?: boolean;

--- a/packages/core/src/components/label/readme.md
+++ b/packages/core/src/components/label/readme.md
@@ -5,12 +5,12 @@
 
 ## Properties
 
-| Property    | Attribute   | Description | Type                                                                                 | Default     |
-| ----------- | ----------- | ----------- | ------------------------------------------------------------------------------------ | ----------- |
-| `compact`   | `compact`   |             | `boolean \| undefined`                                                               | `undefined` |
-| `removable` | `removable` |             | `boolean \| undefined`                                                               | `undefined` |
-| `status`    | `status`    |             | `"bright" \| "danger" \| "info" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
-| `truncate`  | `truncate`  |             | `boolean \| undefined`                                                               | `undefined` |
+| Property    | Attribute   | Description | Type                                                                                            | Default     |
+| ----------- | ----------- | ----------- | ----------------------------------------------------------------------------------------------- | ----------- |
+| `compact`   | `compact`   |             | `boolean \| undefined`                                                                          | `undefined` |
+| `removable` | `removable` |             | `boolean \| undefined`                                                                          | `undefined` |
+| `status`    | `status`    |             | `"bright" \| "danger" \| "error" \| "info" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
+| `truncate`  | `truncate`  |             | `boolean \| undefined`                                                                          | `undefined` |
 
 
 ## Events

--- a/packages/dso-toolkit/src/components/badge/badge.args.ts
+++ b/packages/dso-toolkit/src/components/badge/badge.args.ts
@@ -3,13 +3,13 @@ import { ArgTypes } from "../../storybook/index.js";
 import { Badge } from "./badge.models.js";
 
 export interface BadgeArgs {
-  status?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
+  status?: "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline";
   message: string;
 }
 
 export const badgeArgTypes: ArgTypes<BadgeArgs> = {
   status: {
-    options: [undefined, "primary", "success", "info", "warning", "danger", "outline"],
+    options: [undefined, "primary", "success", "info", "warning", "danger", "error", "outline"],
     control: {
       type: "select",
     },

--- a/packages/dso-toolkit/src/components/badge/badge.mixins.scss
+++ b/packages/dso-toolkit/src/components/badge/badge.mixins.scss
@@ -45,6 +45,12 @@
     color: colors.$wit;
   }
 
+  &.badge-error {
+    background-color: badge-variables.$error-bg-color;
+    border-color: badge-variables.$error-bg-color;
+    color: colors.$wit;
+  }
+
   &.badge-outline {
     background-color: colors.$wit;
     border-color: colors.$grijs-90;

--- a/packages/dso-toolkit/src/components/badge/badge.models.ts
+++ b/packages/dso-toolkit/src/components/badge/badge.models.ts
@@ -1,4 +1,4 @@
 export interface Badge {
-  status?: "primary" | "success" | "info" | "warning" | "danger" | "outline";
+  status?: "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline";
   message: string;
 }

--- a/packages/dso-toolkit/src/components/badge/badge.stories-of.ts
+++ b/packages/dso-toolkit/src/components/badge/badge.stories-of.ts
@@ -63,6 +63,13 @@ export function storiesOfBadge<Implementation, Templates, TemplateFnReturnType>(
       },
     });
 
+    stories.add("error", template, {
+      args: {
+        status: "error",
+        message: "Error",
+      },
+    });
+
     stories.add("outline", template, {
       args: {
         status: "outline",

--- a/packages/dso-toolkit/src/components/badge/badge.variables.scss
+++ b/packages/dso-toolkit/src/components/badge/badge.variables.scss
@@ -6,5 +6,6 @@ $primary-bg-color: colors.$bosgroen;
 $success-bg-color: colors.$success-color;
 $warning-bg-color: colors.$warning-color;
 $danger-bg-color: colors.$danger-color;
+$error-bg-color: colors.$error-color;
 
 $line-height: 1;

--- a/packages/dso-toolkit/src/components/banner/banner.args.ts
+++ b/packages/dso-toolkit/src/components/banner/banner.args.ts
@@ -11,7 +11,7 @@ export interface BannerArgs {
 
 export const bannerArgTypes: ArgTypes<BannerArgs> = {
   status: {
-    options: ["warning", "danger"],
+    options: ["warning", "danger", "error"],
     control: {
       type: "select",
     },

--- a/packages/dso-toolkit/src/components/banner/banner.mixins.scss
+++ b/packages/dso-toolkit/src/components/banner/banner.mixins.scss
@@ -101,6 +101,10 @@
   @include _variant(banner-variables.$danger-bg, banner-variables.$danger-border, banner-variables.$danger-text);
 }
 
+@mixin error() {
+  @include _variant(banner-variables.$error-bg, banner-variables.$error-border, banner-variables.$error-text);
+}
+
 @mixin warning() {
   @include _variant(banner-variables.$warning-bg, banner-variables.$warning-border, banner-variables.$warning-text);
 }

--- a/packages/dso-toolkit/src/components/banner/banner.models.ts
+++ b/packages/dso-toolkit/src/components/banner/banner.models.ts
@@ -1,5 +1,5 @@
 export interface Banner<TemplateFnReturnType> {
-  status: "warning" | "danger";
+  status: "warning" | "danger" | "error";
   content: TemplateFnReturnType;
   onClick?: (e: Event) => void;
 }

--- a/packages/dso-toolkit/src/components/banner/banner.scss
+++ b/packages/dso-toolkit/src/components/banner/banner.scss
@@ -31,6 +31,14 @@
     }
   }
 
+  &.alert-error {
+    @include banner.error();
+
+    .row > div::before {
+      @include di.base("status-error");
+    }
+  }
+
   &.alert-warning {
     @include banner.warning();
 
@@ -71,6 +79,14 @@ dso-banner {
 
     .row > div::before {
       @include di.base("status-danger");
+    }
+  }
+
+  &[status="error"] {
+    @include banner.error();
+
+    .row > div::before {
+      @include di.base("status-error");
     }
   }
 

--- a/packages/dso-toolkit/src/components/banner/banner.stories-of.ts
+++ b/packages/dso-toolkit/src/components/banner/banner.stories-of.ts
@@ -6,6 +6,7 @@ import { Banner } from "./banner.models.js";
 export interface BannerTemplates<TemplateFnReturnType> {
   bannerTemplate: (bannerProperties: Banner<TemplateFnReturnType>) => TemplateFnReturnType;
   dangerRichContent: TemplateFnReturnType;
+  errorRichContent: TemplateFnReturnType;
   warningRichContent: TemplateFnReturnType;
   richWarningRichContent: TemplateFnReturnType;
   dangerWithHeadingsRichContent: TemplateFnReturnType;
@@ -32,6 +33,18 @@ export function storiesOfBanner<Implementation, Templates, TemplateFnReturnType>
       {
         args: {
           status: "danger",
+        },
+      }
+    );
+
+    stories.add(
+      "error",
+      templateMapper<BannerArgs>((args, { bannerTemplate, errorRichContent }) =>
+        bannerTemplate(bannerArgsMapper(args, errorRichContent))
+      ),
+      {
+        args: {
+          status: "error",
         },
       }
     );

--- a/packages/dso-toolkit/src/components/banner/banner.variables.scss
+++ b/packages/dso-toolkit/src/components/banner/banner.variables.scss
@@ -12,3 +12,7 @@ $warning-border: states.$warning-border;
 $danger-bg: states.$danger-bg;
 $danger-text: states.$danger-text;
 $danger-border: states.$danger-border;
+
+$error-bg: states.$error-bg;
+$error-text: states.$error-text;
+$error-border: states.$error-border;

--- a/packages/dso-toolkit/src/components/label/label.args.ts
+++ b/packages/dso-toolkit/src/components/label/label.args.ts
@@ -5,7 +5,7 @@ import { Label } from "./label.models.js";
 import { ArgTypes } from "../../storybook/index.js";
 
 export interface LabelArgs {
-  status: "primary" | "info" | "success" | "warning" | "danger" | "bright";
+  status: "primary" | "info" | "success" | "warning" | "danger" | "error" | "bright";
   compact: boolean;
   truncate: boolean;
   label: string;
@@ -16,7 +16,7 @@ export interface LabelArgs {
 
 export const labelArgTypes: ArgTypes<LabelArgs> = {
   status: {
-    options: ["primary", "success", "info", "warning", "danger", "bright"],
+    options: ["primary", "success", "info", "warning", "danger", "error", "bright"],
     control: {
       type: "select",
     },

--- a/packages/dso-toolkit/src/components/label/label.mixins.scss
+++ b/packages/dso-toolkit/src/components/label/label.mixins.scss
@@ -73,6 +73,11 @@
     color: label-variables.$danger-color;
   }
 
+  &.dso-label-error {
+    background-color: label-variables.$error-bg-color;
+    color: label-variables.$error-color;
+  }
+
   &.dso-label-bright {
     background-color: label-variables.$bright-bg-color;
     color: label-variables.$bright-color;

--- a/packages/dso-toolkit/src/components/label/label.models.ts
+++ b/packages/dso-toolkit/src/components/label/label.models.ts
@@ -1,5 +1,5 @@
 export interface Label {
-  status?: "primary" | "info" | "success" | "warning" | "danger" | "bright";
+  status?: "primary" | "info" | "success" | "warning" | "danger" | "error" | "bright";
   compact?: boolean;
   truncate?: boolean;
   label: string;

--- a/packages/dso-toolkit/src/components/label/label.variables.scss
+++ b/packages/dso-toolkit/src/components/label/label.variables.scss
@@ -20,6 +20,9 @@ $warning-color: colors.$grijs-90;
 $danger-bg-color: colors.$danger-color;
 $danger-color: colors.$wit;
 
+$error-bg-color: colors.$error-color;
+$error-color: colors.$wit;
+
 $bright-bg-color: colors.$wit;
 $bright-color: colors.$grijs-90;
 $bright-border-color: colors.$grijs-20;

--- a/packages/dso-toolkit/src/variables/colors.scss
+++ b/packages/dso-toolkit/src/variables/colors.scss
@@ -50,12 +50,14 @@ $success-color: $grasgroen;
 $info-color: $lichtblauw;
 $warning-color: $geel;
 $danger-color: $rood;
+$error-color: $rood;
 $invalid-color: $rood-110;
 
 $success-bg-color: $lime-20;
 $info-bg-color: $lichtblauw-20;
 $warning-bg-color: $geel-20;
 $danger-bg-color: $rood-20;
+$error-bg-color: $rood-20;
 
 $input-color-placeholder: $grijs-60;
 $input-bg: $wit;

--- a/packages/dso-toolkit/src/variables/states.scss
+++ b/packages/dso-toolkit/src/variables/states.scss
@@ -15,3 +15,7 @@ $warning-border: colors.$warning-bg-color;
 $danger-text: colors.$grijs-90;
 $danger-bg: colors.$danger-bg-color;
 $danger-border: colors.$danger-bg-color;
+
+$error-text: colors.$grijs-90;
+$error-bg: colors.$error-bg-color;
+$error-border: colors.$error-bg-color;

--- a/packages/react/src/components/banner/banner.content.tsx
+++ b/packages/react/src/components/banner/banner.content.tsx
@@ -17,6 +17,13 @@ export const dangerRichContent = (
   </div>
 );
 
+export const errorRichContent = (
+  <div className="dso-rich-content">
+    <h2>Storingsmelding:</h2>
+    <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
+  </div>
+);
+
 export const richWarningRichContent = (
   <div className="dso-rich-content">
     <h2>Onderhoudsmelding:</h2>

--- a/packages/react/src/components/banner/banner.stories.tsx
+++ b/packages/react/src/components/banner/banner.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from "@storybook/react";
 import { templateContainer } from "../../templates";
 import {
   dangerRichContent,
+  errorRichContent,
   dangerWithHeadingsRichContent,
   richWarningRichContent,
   warningRichContent,
@@ -21,6 +22,7 @@ storiesOfBanner({
   storyTemplates: ({ bannerTemplate }) => ({
     bannerTemplate,
     dangerRichContent,
+    errorRichContent,
     dangerWithHeadingsRichContent,
     richWarningRichContent,
     warningRichContent,

--- a/storybook/src/components/banner/banner.content.ts
+++ b/storybook/src/components/banner/banner.content.ts
@@ -20,6 +20,13 @@ export const dangerRichContent = html`
   </div>
 `;
 
+export const errorRichContent = html`
+  <div class="dso-rich-content">
+    <h2>Storingsmelding:</h2>
+    <p>Op dit moment ervaren wij een storing in de Vergunningcheck. U kunt wel een aanvraag of melding indienen.</p>
+  </div>
+`;
+
 export const richWarningRichContent = html`
   <div class="dso-rich-content">
     <h2>Onderhoudsmelding:</h2>

--- a/storybook/src/components/banner/banner.stories.ts
+++ b/storybook/src/components/banner/banner.stories.ts
@@ -7,6 +7,7 @@ import coreReadme from "@dso-toolkit/core/src/components/banner/readme.md";
 import { templateContainer } from "../../templates";
 import {
   dangerRichContent,
+  errorRichContent,
   dangerWithHeadingsRichContent,
   richWarningRichContent,
   warningRichContent,
@@ -23,6 +24,7 @@ storiesOfBanner({
   storyTemplates: ({ bannerTemplate }, templates) => ({
     bannerTemplate,
     dangerRichContent,
+    errorRichContent,
     dangerWithHeadingsRichContent: dangerWithHeadingsRichContent(templates),
     richWarningRichContent,
     warningRichContent: warningRichContent(templates),
@@ -40,6 +42,7 @@ storiesOfBanner({
   storyTemplates: ({ bannerTemplate }, templates) => ({
     bannerTemplate,
     dangerRichContent,
+    errorRichContent,
     dangerWithHeadingsRichContent: dangerWithHeadingsRichContent(templates),
     richWarningRichContent,
     warningRichContent: warningRichContent(templates),


### PR DESCRIPTION
De `danger` status wordt in dit pull request deprecated bij `badge`, `banner` en `label`. Gebruik voortaan de `error` status.