### PR TITLE
#2209 action list en form buttons hebben geen verticaal ritme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## NEXT
 
+### Fixed
+* Action List en Form Buttons hebben geen verticaal ritme ([#2209](https://github.com/dso-toolkit/dso-toolkit/issues/2209))
+
 ## 55.0.0 - 10-07-2023
 
 ### Added

--- a/packages/dso-toolkit/src/components/form/form-buttons/form-buttons.scss
+++ b/packages/dso-toolkit/src/components/form/form-buttons/form-buttons.scss
@@ -28,12 +28,6 @@
   }
 }
 
-// Create space between action list and form buttons.
-// To Do: add to/integrate with general vertical rhythm styles (to be built).
-dso-action-list + .dso-form-buttons {
-  margin-block-start: units.$vertical-spacing-xlarge;
-}
-
 .dso-single-page {
   &.dso-form-buttons,
   .dso-form-buttons {

--- a/packages/dso-toolkit/src/components/form/form-buttons/form-buttons.scss
+++ b/packages/dso-toolkit/src/components/form/form-buttons/form-buttons.scss
@@ -28,6 +28,12 @@
   }
 }
 
+// Create space between action list and form buttons.
+// To Do: add to/integrate with general vertical rhythm styles (to be built).
+dso-action-list + .dso-form-buttons {
+  margin-block-start: units.$u4;
+}
+
 .dso-single-page {
   &.dso-form-buttons,
   .dso-form-buttons {

--- a/packages/dso-toolkit/src/components/form/form-buttons/form-buttons.scss
+++ b/packages/dso-toolkit/src/components/form/form-buttons/form-buttons.scss
@@ -31,7 +31,7 @@
 // Create space between action list and form buttons.
 // To Do: add to/integrate with general vertical rhythm styles (to be built).
 dso-action-list + .dso-form-buttons {
-  margin-block-start: units.$u4;
+  margin-block-start: units.$vertical-spacing-xlarge;
 }
 
 .dso-single-page {

--- a/packages/dso-toolkit/src/dso.scss
+++ b/packages/dso-toolkit/src/dso.scss
@@ -1,5 +1,6 @@
 // Global
 @use "global/font-faces";
+@use "global/spacing";
 @use "global/utilities";
 
 // Components

--- a/packages/dso-toolkit/src/global/spacing.scss
+++ b/packages/dso-toolkit/src/global/spacing.scss
@@ -5,4 +5,3 @@
 :where(dso-action-list) + :where(.dso-form-buttons) {
   margin-block-start: units.$vertical-spacing-xlarge;
 }
-

--- a/packages/dso-toolkit/src/global/spacing.scss
+++ b/packages/dso-toolkit/src/global/spacing.scss
@@ -1,0 +1,8 @@
+@use "../variables/units.scss";
+
+// Create space between action list and form buttons
+// To Do: integrate this with things to come within this file.
+:where(dso-action-list) + :where(.dso-form-buttons) {
+  margin-block-start: units.$vertical-spacing-xlarge;
+}
+


### PR DESCRIPTION
Fix for a situation not present within the toolkit. tested with browser inspector to check if this code works.
Added `margin-block-start` of 32px to separate `<dso-action-list>` and `.dso-form-buttons`.