### PR TITLE
#2237 [fixed] viewer grid: sr-only tekst bedieningsknoppen inconsistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Tabs: Tabindex op inhoud tabs ([#2117](https://github.com/dso-toolkit/dso-toolkit/issues/2117))
+* Viewer grid: sr-only tekst bedieningsknoppen inconsistent ([#2237](https://github.com/dso-toolkit/dso-toolkit/issues/2237))
 
 ### Changed
 * Headings: Line-height aanpassen van de H1, H2 en H3. ([#2153](https://github.com/dso-toolkit/dso-toolkit/issues/2153))

--- a/packages/core/src/components/viewer-grid/viewer-grid.tsx
+++ b/packages/core/src/components/viewer-grid/viewer-grid.tsx
@@ -205,14 +205,14 @@ export class ViewerGrid {
         <div class="dso-map-panel" ref={(element) => (this.mapPanel = element)}>
           <div class="sizing-buttons">
             <span class="sr-only" aria-live="polite" aria-atomic="true">
-              breedte tekstpaneel: {this.sizeLabelMap[this.mainSize]}
+              Breedte tekstpaneel: {this.sizeLabelMap[this.mainSize]}
             </span>
             <button type="button" class="shrink" disabled={this.mainSize === "small"} onClick={this.shrinkMain}>
-              <span class="sr-only">Kaartpaneel smaller maken</span>
+              <span class="sr-only">Tekstpaneel smaller maken</span>
               <dso-icon icon="chevron-left"></dso-icon>
             </button>
             <button type="button" class="expand" disabled={this.mainSize === "large"} onClick={this.expandMain}>
-              <span class="sr-only">Kaartpaneel breder maken</span>
+              <span class="sr-only">Tekstpaneel breder maken</span>
               <dso-icon icon="chevron-right"></dso-icon>
             </button>
           </div>


### PR DESCRIPTION
sr-only text on buttons changed, changelog updated