### PR TITLE
#2245 Accordion animatie verspringt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Tabs: Tabindex op inhoud tabs ([#2117](https://github.com/dso-toolkit/dso-toolkit/issues/2117))
 * Viewer Grid: Bedieningsknoppen hebben de verkeerde labels ([#2237](https://github.com/dso-toolkit/dso-toolkit/issues/2237))
 * Accordion: [open="false"] moet geen open stijling tonen ([#2242](https://github.com/dso-toolkit/dso-toolkit/issues/2242))
+* Accordion: Animatie verspringt ([#2245](https://github.com/dso-toolkit/dso-toolkit/issues/2245))
 
 ### Changed
 * Headings: Line-height aanpassen van de H1, H2 en H3. ([#2153](https://github.com/dso-toolkit/dso-toolkit/issues/2153))

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -5,8 +5,8 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AccordionInternalState, AccordionSectionAnimationEndEvent, AccordionSectionToggleClickEvent, AccordionVariant } from "./components/accordion/accordion.interfaces";
-import { AccordionHeading, AccordionSectionState } from "./components/accordion/components/accordion-section.interfaces";
+import { AccordionInternalState, AccordionVariant } from "./components/accordion/accordion.interfaces";
+import { AccordionHeading, AccordionSectionAnimationEndEvent, AccordionSectionState, AccordionSectionToggleClickEvent } from "./components/accordion/components/accordion-section.interfaces";
 import { AnnotationButtonClickEvent } from "./components/annotation-button/annotation-button";
 import { AnnotationOutputCloseEvent } from "./components/annotation-output/annotation-output";
 import { Suggestion } from "./components/autosuggest/autosuggest.interfaces";
@@ -31,8 +31,8 @@ import { SelectableChangeEvent } from "./components/selectable/selectable.interf
 import { SlideToggleActiveEvent } from "./components/slide-toggle/slide-toggle.interfaces";
 import { TreeViewItem, TreeViewPointerEvent } from "./components/tree-view/tree-view.interfaces";
 import { FilterpanelEvent, MainSize, ViewerGridChangeSizeEvent } from "./components/viewer-grid/viewer-grid.interfaces";
-export { AccordionInternalState, AccordionSectionAnimationEndEvent, AccordionSectionToggleClickEvent, AccordionVariant } from "./components/accordion/accordion.interfaces";
-export { AccordionHeading, AccordionSectionState } from "./components/accordion/components/accordion-section.interfaces";
+export { AccordionInternalState, AccordionVariant } from "./components/accordion/accordion.interfaces";
+export { AccordionHeading, AccordionSectionAnimationEndEvent, AccordionSectionState, AccordionSectionToggleClickEvent } from "./components/accordion/components/accordion-section.interfaces";
 export { AnnotationButtonClickEvent } from "./components/annotation-button/annotation-button";
 export { AnnotationOutputCloseEvent } from "./components/annotation-output/annotation-output";
 export { Suggestion } from "./components/autosuggest/autosuggest.interfaces";

--- a/packages/core/src/components/accordion/accordion.interfaces.ts
+++ b/packages/core/src/components/accordion/accordion.interfaces.ts
@@ -4,29 +4,3 @@ export interface AccordionInternalState {
   variant?: AccordionVariant;
   reverseAlign?: boolean;
 }
-
-export interface AccordionSectionToggleClickEvent {
-  /**
-   * The original MouseEvent that triggered the click.
-   *
-   * In case the Section Handle is an <a> this event can be used to preventDefault() so the framework router is reponsible for navigating the user.
-   */
-  originalEvent?: MouseEvent;
-
-  /**
-   * The requested state. If the Accordion Section is closed, `open = true`.
-   */
-  open: boolean;
-}
-
-export interface AccordionSectionAnimationEndEvent {
-  /**
-   * Helper function to scroll the Accordion Section into view.
-   */
-  scrollIntoView(): void;
-
-  /**
-   * The state of the Accordion Section after animation.
-   */
-  open: boolean;
-}

--- a/packages/core/src/components/accordion/components/accordion-section.interfaces.ts
+++ b/packages/core/src/components/accordion/components/accordion-section.interfaces.ts
@@ -9,3 +9,29 @@ export const stateMap: Record<AccordionSectionState, string> = {
   danger: "fout:",
   error: "fout:",
 };
+
+export interface AccordionSectionToggleClickEvent {
+  /**
+   * The original MouseEvent that triggered the click.
+   *
+   * In case the Section Handle is an <a> this event can be used to preventDefault() so the framework router is reponsible for navigating the user.
+   */
+  originalEvent?: MouseEvent;
+
+  /**
+   * The requested state. If the Accordion Section is closed, `open = true`.
+   */
+  open: boolean;
+}
+
+export interface AccordionSectionAnimationEndEvent {
+  /**
+   * Helper function to scroll the Accordion Section into view.
+   */
+  scrollIntoView(): void;
+
+  /**
+   * The state of the Accordion Section after animation.
+   */
+  open: boolean;
+}

--- a/packages/core/src/components/accordion/components/accordion-section.tsx
+++ b/packages/core/src/components/accordion/components/accordion-section.tsx
@@ -12,12 +12,14 @@ import {
   EventEmitter,
 } from "@stencil/core";
 
+import { AccordionInternalState } from "../accordion.interfaces";
 import {
-  AccordionInternalState,
+  AccordionHeading,
   AccordionSectionAnimationEndEvent,
+  AccordionSectionState,
   AccordionSectionToggleClickEvent,
-} from "../accordion.interfaces";
-import { AccordionHeading, AccordionSectionState, stateMap } from "./accordion-section.interfaces";
+  stateMap,
+} from "./accordion-section.interfaces";
 import { Handle, HandleElement, HandleIcon } from "./handles";
 import { ExpandableAnimationEndEvent } from "../../expandable/expandable";
 

--- a/packages/core/src/components/expandable/expandable.tsx
+++ b/packages/core/src/components/expandable/expandable.tsx
@@ -122,10 +122,10 @@ export class Expandable implements ComponentInterface {
         if (this.bodyHeight !== height) {
           this.bodyHeight = height;
         }
+
+        this.instantiateAnimation();
       }, 150)
     );
-
-    this.instantiateAnimation();
   }
 
   private instantiateAnimation(): void {

--- a/packages/dso-toolkit/src/components/accordion/accordion.models.ts
+++ b/packages/dso-toolkit/src/components/accordion/accordion.models.ts
@@ -13,8 +13,6 @@ export interface Accordion<TemplateFnReturnType> {
 }
 
 export interface AccordionSection<TemplateFnReturnType> {
-  dsoToggleClick?: (e: CustomEvent<AccordionSectionToggleClickEvent>) => void;
-  dsoAnimationEnd?: (e: CustomEvent<AccordionSectionAnimationEndEvent>) => void;
   open?: boolean;
   handleTitle: string;
   heading: AccordionHeading;
@@ -24,6 +22,8 @@ export interface AccordionSection<TemplateFnReturnType> {
   icon?: string;
   attachmentCount?: number;
   content?: TemplateFnReturnType;
+  dsoToggleClick?: (e: CustomEvent<AccordionSectionToggleClickEvent>) => void;
+  dsoAnimationEnd?: (e: CustomEvent<AccordionSectionAnimationEndEvent>) => void;
 }
 
 export interface AccordionSectionToggleClickEvent {

--- a/packages/react/src/components/accordion/accordion.react-template.tsx
+++ b/packages/react/src/components/accordion/accordion.react-template.tsx
@@ -1,7 +1,7 @@
 import {
   AccordionSectionAnimationEndEvent,
   AccordionSectionToggleClickEvent,
-} from "@dso-toolkit/core/dist/types/components/accordion/accordion.interfaces";
+} from "@dso-toolkit/core/dist/types/components/accordion/components/accordion-section.interfaces";
 import { Accordion } from "dso-toolkit";
 
 import * as React from "react";

--- a/storybook/cypress/e2e/accordion.cy.ts
+++ b/storybook/cypress/e2e/accordion.cy.ts
@@ -33,6 +33,10 @@ describe("Accordion", () => {
       .invoke("prop", "open")
       .should("equal", false)
       .get("@accordionSection")
+      .shadow()
+      .find("dso-expandable")
+      .should("have.class", "dso-animate-ready")
+      .get("@accordionSection")
       .then(($accordionSection) => {
         $accordionSection.on("dsoAnimationEnd", cy.stub().as("dsoAnimationEnd"));
       })


### PR DESCRIPTION
Na lang zoeken naar de oorzaak, bleek het de verplaatsing van `this.instantiateAnimation();` buiten de `debounce` te zijn. Maar het was belangrijk dat het zetten van `this.bodyheight` binnen de `debounce` eerst werd afgerond voordat deze call werd gedaan.