### PR TITLE
#2318 Selectable: Label in Web Component gaat stuk in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Selectable: Label in Web Component gaat stuk in Firefox ([#2318](https://github.com/dso-toolkit/dso-toolkit/issues/2318))
+
 ## 58.2.0 - 07-09-2023
 
 ### Added

--- a/packages/core/src/components/selectable/selectable.scss
+++ b/packages/core/src/components/selectable/selectable.scss
@@ -28,7 +28,7 @@
   }
 
   .dso-selectable-input-wrapper {
-    display: inline;
+    display: inline-block;
     margin-inline: -#{units.$u4};
     min-height: units.$u3;
     padding-inline: units.$u4;


### PR DESCRIPTION
De `dso-selectable-input-wrapper` had een `inline` context maar dit zou volgens het altijd strenge Firefox `inline-block` moeten zijn (er staat ook een min-height waarde op dit element, maar Firefox geeft ook aan dat deze op een `inline` element geen waarde heeft).

Resultaat:
<img width="436" alt="Scherm­afbeelding 2023-09-12 om 16 50 28" src="https://github.com/dso-toolkit/dso-toolkit/assets/7202272/d06863fb-b732-4ea9-9a56-68dbb29b0c88">
