### PR TITLE
#2486 [Fixed] Document Component: Scrollen in tabel na vergroten werkt niet meer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Document Component: Scrollen in tabel na vergroten werkt niet meer ([#2486](https://github.com/dso-toolkit/dso-toolkit/issues/2486))
+
 ## ⛷️ 62.12.0 - 15-02-2024
 
 ### Added

--- a/packages/core/src/components/table/table.scss
+++ b/packages/core/src/components/table/table.scss
@@ -61,7 +61,7 @@
   .dso-table-body {
     border: 1px solid table.$border-color;
     margin-bottom: 0;
-    overflow-y: hidden;
+    overflow-y: auto;
     width: 100%;
 
     &.dso-body {


### PR DESCRIPTION
Wanneer je binnen een tabel horizontaal kan scrollen kon je niet meer verticaal scrollen. Tabellen kunnen nog wel lang genoeg zijn dat je verticaal wilt scrollen. Bij deze heb ik de `overflow-y` op `auto` gezet zodat je nog wel verticaal kan scrollen wanneer de tabel lang genoeg is.