### PR TITLE
#2541 [Fixed] Pagination: Long numbers overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Map Layers: Scroll overlay stacking ([#2526](https://github.com/dso-toolkit/dso-toolkit/issues/2526))
 * Document Component: Scrollen in tabel na vergroten werkt niet meer ([#2486](https://github.com/dso-toolkit/dso-toolkit/issues/2486))
 * Styling: Version number in dso.css undefined ([#2520](https://github.com/dso-toolkit/dso-toolkit/issues/2520))
+* Pagination: Long numbers overlap ([#2541](https://github.com/dso-toolkit/dso-toolkit/issues/2541))
 
 ### Docs
 * Card: Link selecteren met href werkt niet ([#2506](https://github.com/dso-toolkit/dso-toolkit/issues/2506))

--- a/packages/dso-toolkit/src/components/pagination/pagination.mixins.scss
+++ b/packages/dso-toolkit/src/components/pagination/pagination.mixins.scss
@@ -22,7 +22,8 @@
       height: pagination-variables.$item-size;
       justify-content: center;
       position: relative;
-      width: pagination-variables.$item-size;
+      min-inline-size: pagination-variables.$item-size;
+      padding: units.$u1 * 0.25;
 
       &:active {
         background-color: colors.$grasgroen-10;
@@ -31,7 +32,7 @@
 
     > span {
       border: pagination-variables.$border-size solid transparent;
-      border-radius: 50%;
+      border-radius: pagination-variables.$item-size * 0.5;
     }
 
     a {


### PR DESCRIPTION
min-inline-size i/o width, small padding added to keep characters away from edge
50% border-radius set to explicit 1rem to facilitate pill-shape with 4+ characters