### PR TITLE
#2423 Ozon Content: Tabel toevoegingen STOP implementeren inOzon documentweergave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * Ozon Content: Ondersteuning voor `<Inhoud wijzigactie="voegtoe|verwijder">` ([#2528](https://github.com/dso-toolkit/dso-toolkit/issues/2528))
 * Ozon Content: Afbeeldingen in renvooi kunnen weergeven ([#2433](https://github.com/dso-toolkit/dso-toolkit/issues/2433))
+* Ozon Content: Tabel toevoegingen STOP implementeren in Ozon documentweergave ([#2423](https://github.com/dso-toolkit/dso-toolkit/issues/2423))
 
 ### Changed
 * Viewer Grid: Align sizing buttons to bottom ([#2552](https://github.com/dso-toolkit/dso-toolkit/issues/2552))

--- a/packages/core/src/components/ozon-content/nodes/table.node/colspec/colspec-mapper.ts
+++ b/packages/core/src/components/ozon-content/nodes/table.node/colspec/colspec-mapper.ts
@@ -1,4 +1,4 @@
-import { Colspecs } from "./colspec.interface";
+import { Colspec, Colspecs } from "./colspec.interface";
 
 export function mapColspecs(count: number, nodeList: NodeListOf<Element>): Colspecs {
   const elements = Array.from(nodeList);
@@ -7,12 +7,14 @@ export function mapColspecs(count: number, nodeList: NodeListOf<Element>): Colsp
   return {
     totalWidth,
     count,
-    columns: elements.map((element, index) => {
+    columns: elements.map((element, index): Colspec => {
       const colNumber = element.getAttribute("colnum");
 
       return {
+        colsep: element.getAttribute("colsep"),
         name: element.getAttribute("colname") ?? "",
         number: colNumber ? parseInt(colNumber, 10) : index + 1,
+        rowsep: element.getAttribute("rowsep"),
         width: getWidth(totalWidth, element),
       };
     }),

--- a/packages/core/src/components/ozon-content/nodes/table.node/colspec/colspec.interface.ts
+++ b/packages/core/src/components/ozon-content/nodes/table.node/colspec/colspec.interface.ts
@@ -5,7 +5,9 @@ export interface Colspecs {
 }
 
 export interface Colspec {
+  colsep: string | null;
   name: string;
   number: number;
+  rowsep: string | null;
   width: string | undefined;
 }

--- a/packages/core/src/components/ozon-content/nodes/table.node/table-cell.tsx
+++ b/packages/core/src/components/ozon-content/nodes/table.node/table-cell.tsx
@@ -1,14 +1,45 @@
 import { FunctionalComponent } from "@stencil/core";
-import { h, JSXBase } from "@stencil/core/internal";
+import { h } from "@stencil/core/internal";
+import clsx from "clsx";
 
 import { OzonContentNodeContext } from "../../ozon-content-node-context.interface";
 import { Colspecs } from "./colspec/colspec.interface";
 
-function getData(cell: Element) {
+function getColspecStartColsep({ columns }: Colspecs, nameStart: string): string | null {
+  const colspecStart = columns.find((c) => c.name === nameStart);
+
+  return colspecStart ? colspecStart.colsep : null;
+}
+
+function getColspecStartRowsep({ columns }: Colspecs, nameStart: string): string | null {
+  const colspecStart = columns.find((c) => c.name === nameStart);
+
+  return colspecStart ? colspecStart.rowsep : null;
+}
+
+function getData(cell: Element, colspecs?: Colspecs) {
+  const nameStart = cell.getAttribute("namest");
+  const row = cell.parentElement;
+  const tgroup = row?.parentElement?.parentElement;
+  const table = tgroup?.parentElement;
+  const colsep =
+    cell.getAttribute("colsep") ||
+    (colspecs && nameStart ? getColspecStartColsep(colspecs, nameStart) : null) ||
+    (tgroup && tgroup.getAttribute("colsep")) ||
+    (table && table.getAttribute("colsep"));
+  const rowsep =
+    cell.getAttribute("rowsep") ||
+    (row && row.getAttribute("rowsep")) ||
+    (colspecs && nameStart ? getColspecStartRowsep(colspecs, nameStart) : null) ||
+    (tgroup && tgroup.getAttribute("rowsep")) ||
+    (table && table.getAttribute("rowsep"));
+
   return {
     moreRows: cell.getAttribute("morerows"),
-    nameStart: cell.getAttribute("namest"),
+    nameStart,
     nameEnd: cell.getAttribute("nameend"),
+    colsep,
+    rowsep,
   };
 }
 
@@ -29,12 +60,15 @@ export const Cell: FunctionalComponent<{
   colspecs: Colspecs | undefined;
   cell: Element;
 }> = ({ context: { mapNodeToJsx }, colspecs, cell }) => {
-  const { moreRows, nameStart, nameEnd } = getData(cell);
+  const { moreRows, nameStart, nameEnd, colsep, rowsep } = getData(cell, colspecs);
 
-  const td: JSXBase.TdHTMLAttributes<HTMLTableCellElement> = {
-    rowSpan: moreRows ? parseInt(moreRows, 10) + 1 : undefined,
-    colSpan: colspecs && nameStart && nameEnd ? getColspan(colspecs, nameStart, nameEnd) : undefined,
-  };
-
-  return <td {...td}>{mapNodeToJsx(cell.childNodes)}</td>;
+  return (
+    <td
+      class={clsx({ "dso-horizontal-line": rowsep !== "0" }, { "dso-vertical-line": colsep !== "0" })}
+      rowSpan={moreRows ? parseInt(moreRows, 10) + 1 : undefined}
+      colSpan={colspecs && nameStart && nameEnd ? getColspan(colspecs, nameStart, nameEnd) : undefined}
+    >
+      {mapNodeToJsx(cell.childNodes)}
+    </td>
+  );
 };

--- a/packages/core/src/components/ozon-content/nodes/table.node/table.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/table.node/table.node.tsx
@@ -21,6 +21,7 @@ function mapData(node: Element) {
     headRows: Array.from(node.querySelectorAll(":scope > tgroup > thead > row")),
     bodyRows: Array.from(node.querySelectorAll(":scope > tgroup > tbody > row")),
     wijzigactie: node.getAttribute("wijzigactie"),
+    frame: node.getAttribute("frame") ? node.getAttribute("frame") : "all",
   };
 }
 
@@ -32,16 +33,17 @@ export class OzonContentTableNode implements OzonContentNode {
   id = uuidv4();
 
   render(node: Element, context: OzonContentNodeContext) {
-    const { caption, colspecs, headRows, bodyRows, wijzigactie } = mapData(node);
+    const { caption, colspecs, headRows, bodyRows, wijzigactie, frame } = mapData(node);
 
     const bron = Array.from(node.childNodes).find((n) => getNodeName(n) === "Bron");
 
     return (
       <dso-table>
         <table
-          class={clsx("table dso-table-vertical-lines", {
+          class={clsx("table", {
             "editaction-add": wijzigactie === "voegtoe",
             "editaction-remove": wijzigactie === "verwijder",
+            [`dso-table-outside-lines-${frame}`]: frame,
           })}
           {...(bron ? { "aria-describedby": this.id } : {})}
         >

--- a/packages/dso-toolkit/src/components/ozon-content/ozon-content.content.ts
+++ b/packages/dso-toolkit/src/components/ozon-content/ozon-content.content.ts
@@ -1162,6 +1162,192 @@ export const content = [
       </Inhoud>`,
   },
   {
+    title: "Table zonder colsep en met rowsep",
+    content: `
+      <table
+        colsep='0'
+        eId='chp_3__subchp_3.5__subsec_3.5.4__subsec_3.5.4.2__art_3.34__para_1__list_o_1__item_b__table_o_1'
+        frame='topbot'
+        pgwide='0'
+        rowsep='0'
+        tabstyle='xml2'
+        wId='mnre1034_1-0__chp_3__subchp_3.5__subsec_3.5.4__subsec_3.5.4.2__art_3.34__para_1__list_o_1__item_b__table_o_1'
+      >
+        <title>Tabel 3.34: Standaardwaarde geluid op een geluidgevoelig gebouw per geluidbronsoort</title>
+        <tgroup align='left' cols='2'>
+          <colspec colname='col1' colnum='1' colwidth='50*'/>
+          <colspec colname='col2' colnum='2' colwidth='50*'/>
+          <thead valign='bottom'>
+            <row rowsep='1'>
+            <entry align='left' colname='col1' colsep='1' rotate='0' valign='top'>
+              <Al>
+                <b>Geluidbronsoort</b>
+              </Al>
+            </entry>
+            <entry align='left' colname='col2' colsep='1' rotate='0' valign='top'>
+              <Al>
+                <b>Standaardwaarde</b>
+              </Al>
+            </entry>
+          </row>
+          </thead>
+          <tbody valign='top'>
+            <row rowsep='1'>
+              <entry align='left' colname='col1' colsep='1' rotate='0' valign='middle'>
+                <Al>Provinciale wegen</Al>
+                <Al>Rijkswegen</Al>
+              </entry>
+              <entry align='left' colname='col2' colsep='1' rotate='0' valign='middle'>
+                <Al>50 L
+                  <sub>den</sub>
+                </Al>
+              </entry>
+            </row>
+            <row rowsep='1'>
+              <entry align='left' colname='col1' colsep='1' rotate='0' valign='middle'>
+                <Al>Gemeentewegen</Al>
+                <Al>Waterschapswegen</Al>
+              </entry>
+              <entry align='left' colname='col2' colsep='1' rotate='0' valign='middle'>
+                <Al>53 L
+                  <sub>den</sub>
+                </Al>
+              </entry>
+            </row>
+            <row rowsep='1'>
+              <entry align='left' colname='col1' colsep='1' rotate='0' valign='middle'>
+                <Al>Lokale spoorwegen</Al>
+                <Al>Hoofdspoorwegen</Al>
+              </entry>
+              <entry align='left' colname='col2' colsep='1' rotate='0' valign='middle'>
+                <Al>55 L
+                  <sub>den</sub>
+                </Al>
+              </entry>
+            </row>
+            <row rowsep='0'>
+              <entry align='left' colname='col1' colsep='1' morerows='1' rotate='0' valign='middle'>
+                <Al>Industrieterreinen</Al>
+              </entry>
+              <entry align='left' colname='col2' colsep='1' rotate='0' rowsep='1' valign='middle'>
+                <Al>50 L
+                  <sub>den</sub>
+                </Al>
+              </entry>
+            </row>
+            <row rowsep='0'>
+            <entry align='left' colname='col2' colsep='1' rotate='0' valign='middle'>
+              <Al>40 L
+                <sub>night</sub>
+              </Al>
+            </entry>
+          </row>
+          </tbody>
+        </tgroup>
+      </table>
+    `,
+  },
+  {
+    title: "Complexe Table zonder colsep en met rowsep",
+    content: `
+      <table
+        colsep='0'
+        eId='chp_3__subchp_3.5__subsec_3.5.5__art_3.53__para_1__table_o_1'
+        frame='topbot'
+        pgwide='0'
+        rowsep='0'
+        tabstyle='xml2'
+        wId='mnre1034_1-0__chp_3__subchp_3.5__subsec_3.5.5__art_3.53__para_1__table_o_1'
+      >
+        <title>Tabel 3.53: Grenswaarde in geluidgevoelige ruimten (binnenwaarde)</title>
+        <tgroup align='left' cols='3' colsep='1' rowsep='1'>
+          <colspec align='center' colname='col1' colnum='1' colsep='0' colwidth='37.1*'/>
+          <colspec colname='col2' colnum='2' colsep='0' colwidth='44.9*'/>
+          <colspec align='center' colname='col3' colnum='3' colwidth='17.9*'/>
+          <thead valign='bottom'>
+            <row rowsep='1' valign='top'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='1' valign='top'>
+                    <Al>
+                        <b>Gebouw in het geluidaandachtsgebied van rijkswegen of hoofdspoorwegen</b>
+                    </Al>
+                </entry>
+                <entry align='left' colname='col2' colsep='0' rotate='0' rowsep='1' valign='top'>
+                    <Al>
+                        <b>Gebouw in het geluidaandachtsgebied van gemeentewegen, waterschapswegen, provinciale wegen, lokale spoorwegen of industrieterreinen</b>
+                    </Al>
+                </entry>
+                <entry align='center' colname='col3' colsep='1' rotate='0' rowsep='1' valign='top'>
+                    <Al>
+                        <b>Binnenwaarde in L
+                            <sub>den</sub>
+                        </b>
+                    </Al>
+                </entry>
+            </row>
+          </thead>
+          <tbody valign='top'>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='0' valign='middle'/>
+                <entry align='center' colname='col2' colsep='0' rotate='0' rowsep='0' valign='middle'>
+                    <Al>Geluidgevoelig gebouw waarvoor de bouwvergunning is afgegeven voor 1 januari 1982 waarvoor <IntRef ref='chp_12__subchp_12.1__subsec_12.1.6'>paragraaf 12.1.6</IntRef> wordt of is uitgevoerd
+                    </Al>
+                </entry>
+                <entry align='center' colname='col3' morerows='6' rotate='0' rowsep='1' valign='middle'>
+                    <Al>41</Al>
+                </entry>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='0' valign='middle'/>
+                <entry align='center' colname='col2' colsep='0' rotate='0' rowsep='0' valign='middle'>
+                    <Al>of</Al>
+                </entry>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='0' valign='middle'>
+                    <Al>Geluidgevoelig gebouw waarvoor de bouwvergunning is afgegeven voor 1 januari 1982 en dat ligt langs een weg die in gebruik is genomen voor 1 januari 1982 of langs een spoorweg die in gebruik is genomen voor 1 juli 1987</Al>
+                </entry>
+                <entry align='center' colname='col2' colsep='0' rotate='0' rowsep='0' valign='middle'>
+                    <Al>geluidgevoelig gebouw dat eerder op grond van de <ExtRef xmlns='' ref='http://wetten.overheid.nl/jci1.3:c:BWBR0003227'>Wet geluidhinder</ExtRef> vanwege het geluid door wegen of spoorwegen op kosten van het Rijk is gesaneerd
+                    </Al>
+                </entry>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='0' valign='middle'/>
+                <entry align='center' colname='col2' colsep='0' rotate='0' rowsep='0' valign='middle'>
+                    <Al>of</Al>
+                </entry>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='0' valign='middle'/>
+                <entry align='center' colname='col2' colsep='0' rotate='0' rowsep='0' valign='middle'/>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' rotate='0' rowsep='1' valign='middle'/>
+                <entry align='center' colname='col2' colsep='0' rotate='0' rowsep='1' valign='middle'>
+                    <Al>woning als bedoeld in <ExtRef xmlns='' ref='http://wetten.overheid.nl/jci1.3:c:BWBR0003227&amp;artikel=111b'>artikel 111b, eerste lid, aanhef en onder a, van de Wet geluidhinder</ExtRef>, en ander geluidsgevoelig gebouw als bedoeld in <ExtRef xmlns='' ref='http://wetten.overheid.nl/jci1.3:c:BWBR0020445&amp;artikel=2.5'>artikel 2.5, aanhef en onder b, van het Besluit geluidhinder</ExtRef>, zoals die artikelen luidden voor inwerkingtreding van dit besluit
+                    </Al>
+                </entry>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' nameend='col2' namest='col1' rotate='0' rowsep='1' valign='middle'>
+                    <Al>Geluidgevoelig gebouw dat door wijziging van de gebruiksfunctie geluidgevoelig is geworden en waarvoor <ExtRef xmlns='' ref='http://wetten.overheid.nl/jci1.3:c:BWBR0041297&amp;artikel=5.23a'>artikel 5.23a, aanhef en onder b, van het Besluit bouwwerken leefomgeving</ExtRef> is toegepast
+                    </Al>
+                </entry>
+            </row>
+            <row rowsep='0'>
+                <entry align='center' colname='col1' colsep='0' nameend='col2' namest='col1' rotate='0' rowsep='1' valign='middle'>
+                    <Al>Ander geluidgevoelig gebouw</Al>
+                </entry>
+                <entry align='center' colname='col3' colsep='1' rotate='0' rowsep='1' valign='middle'>
+                    <Al>36</Al>
+                </entry>
+            </row>
+        </tbody>
+        </tgroup>
+      </table>
+    `,
+  },
+  {
     title: "Renvooi-weergave",
     content: `
       <Artikel eId="chp_3__subchp_3.4__subsec_3.4.4__subsec_3.3.4.1__art_3.60" wId="gm1979_2__chp_3__subchp_3.4__subsec_3.4.4__subsec_3.3.4.1__art_3.60">

--- a/packages/dso-toolkit/src/components/table/table.mixins.scss
+++ b/packages/dso-toolkit/src/components/table/table.mixins.scss
@@ -2,6 +2,22 @@
 
 @use "../table";
 
+@mixin outside-lines-sides() {
+  thead {
+    border-inline-start: 1px solid table.$th-border-color;
+    border-inline-end: 1px solid table.$th-border-color;
+  }
+  tbody {
+    border-inline-start: 1px solid table.$border-color;
+    border-inline-end: 1px solid table.$border-color;
+  }
+}
+
+@mixin outside-lines-topbot() {
+  border-block-start: 1px solid table.$th-border-color;
+  border-block-end: 1px solid table.$border-color;
+}
+
 @mixin row-variant($state, $background) {
   // Exact selectors below required to override `.table-striped` and prevent
   // inheritance to nested tables.

--- a/packages/dso-toolkit/src/components/table/table.scss
+++ b/packages/dso-toolkit/src/components/table/table.scss
@@ -96,6 +96,67 @@ table.table,
     }
   }
 
+  &.dso-table-outside-lines-top {
+    border-block-start: 1px solid table.$th-border-color;
+  }
+
+  &.dso-table-outside-lines-bottom {
+    border-block-end: 1px solid table.$border-color;
+  }
+
+  &.dso-table-outside-lines-topbot {
+    @include css-table-mixins.outside-lines-topbot;
+  }
+
+  &.dso-table-outside-lines-all {
+    @include css-table-mixins.outside-lines-topbot;
+    @include css-table-mixins.outside-lines-sides;
+  }
+
+  &.dso-table-outside-lines-sides {
+    @include css-table-mixins.outside-lines-sides;
+  }
+
+  > thead {
+    > tr {
+      > td,
+      > th {
+        &.dso-horizontal-line {
+          border-block-end: 1px solid table.$th-border-color;
+        }
+
+        &:not(:last-child) {
+          &.dso-vertical-line {
+            border-inline-end: 1px solid table.$th-border-color;
+          }
+        }
+      }
+    }
+  }
+
+  > tbody,
+  > tfoot {
+    > tr {
+      > td,
+      > th {
+        &:not(:last-child) {
+          &.dso-vertical-line {
+            border-inline-end: 1px solid table.$border-color;
+          }
+        }
+      }
+    }
+
+    > tr:not(:last-child) {
+      > td,
+      > th {
+        &.dso-horizontal-line {
+          border-block-end: 1px solid table.$border-color;
+        }
+      }
+    }
+  }
+
   th,
   td {
     &.dso-text-left {
@@ -128,21 +189,23 @@ table.table,
     }
   }
 
-  > thead {
-    > tr {
-      > td,
-      > th {
-        border-bottom: 1px solid table.$th-border-color;
+  &:not([class*="dso-table-outside-lines"]) {
+    > thead {
+      > tr {
+        > td,
+        > th {
+          border-bottom: 1px solid table.$th-border-color;
+        }
       }
     }
-  }
 
-  > tbody,
-  > tfoot {
-    > tr {
-      > td,
-      > th {
-        border-bottom: 1px solid table.$border-color;
+    > tbody,
+    > tfoot {
+      > tr {
+        > td,
+        > th {
+          border-bottom: 1px solid table.$border-color;
+        }
       }
     }
   }


### PR DESCRIPTION
In deze PR zijn geïmplementeerd 3 van de 6 attributen beschreven in het issue #2423. Te weten rowsep, colsep en frame. Mbt. tot de attributen tabstyle en orient zijn er geen voorbeelden gevonden, waarop dit van toepassing is.
Mbt. attribuut pgwide: deze lijkt geen betekenis te hebben binnen de context van DSO.
