### PR TITLE
#2480 Document Component: titel knop mist aria expanded en sluit voor titel tekst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * Form Group: Rich content overflow ([#2600](https://github.com/dso-toolkit/dso-toolkit/issues/2600))
 * Alert: Achtergrondkleur wordt op verkeerde niveau gezet ([#2614](https://github.com/dso-toolkit/dso-toolkit/issues/2614))
+* Document Component: Titel knop mist aria-expanded en sluit voor titel tekst ([#2480](https://github.com/dso-toolkit/dso-toolkit/issues/2480))
 
 ### Tasks
 * Packages: Dependencies updates ([#2483](https://github.com/dso-toolkit/dso-toolkit/issues/2483))

--- a/packages/core/src/components/annotation-button/annotation-button.scss
+++ b/packages/core/src/components/annotation-button/annotation-button.scss
@@ -1,10 +1,5 @@
-@use "~dso-toolkit/src/utilities";
 @use "~dso-toolkit/src/components/button/button";
 
 dso-annotation-button {
   display: block;
-}
-
-.sr-only {
-  @include utilities.sr-only();
 }

--- a/packages/core/src/components/annotation-output/annotation-output.scss
+++ b/packages/core/src/components/annotation-output/annotation-output.scss
@@ -1,16 +1,9 @@
-@use "~dso-toolkit/src/utilities";
 @use "~dso-toolkit/src/variables/units";
 @use "~dso-toolkit/src/variables/colors";
 @use "~dso-toolkit/src/global/mixins/set-colors.mixin" as set-colors;
 
-@include utilities.box-sizing();
-
 dso-annotation-output {
   display: block;
-}
-
-.sr-only {
-  @include utilities.sr-only();
 }
 
 .dso-annotation-header {

--- a/packages/core/src/components/document-component/document-component.scss
+++ b/packages/core/src/components/document-component/document-component.scss
@@ -17,6 +17,10 @@
   display: block;
 
   --depth: var(--a, 0);
+
+  .sr-only {
+    @include utilities.sr-only();
+  }
 }
 
 :host([not-collapsible]:where([wijzigactie="verwijder"], [wijzigactie="voegtoe"])) {

--- a/packages/core/src/components/document-component/document-component.scss
+++ b/packages/core/src/components/document-component/document-component.scss
@@ -9,7 +9,7 @@
 @use "~dso-toolkit/src/components/delete";
 @use "~dso-toolkit/src/components/insert";
 
-.not-applicable {
+.sr-only {
   @include utilities.sr-only();
 }
 
@@ -17,10 +17,6 @@
   display: block;
 
   --depth: var(--a, 0);
-
-  .sr-only {
-    @include utilities.sr-only();
-  }
 }
 
 :host([not-collapsible]:where([wijzigactie="verwijder"], [wijzigactie="voegtoe"])) {

--- a/packages/core/src/components/document-component/document-component.tsx
+++ b/packages/core/src/components/document-component/document-component.tsx
@@ -248,7 +248,7 @@ export class DocumentComponent implements ComponentInterface {
                   </button>
                 )}
                 <div id="heading-title">
-                  {this.notApplicable && <span class="not-applicable">Niet van toepassing:</span>}
+                  {this.notApplicable && <span class="sr-only">Niet van toepassing:</span>}
                   {this.label || this.nummer || this.opschrift ? (
                     <>
                       {this.label && (

--- a/packages/core/src/components/document-component/document-component.tsx
+++ b/packages/core/src/components/document-component/document-component.tsx
@@ -208,7 +208,7 @@ export class DocumentComponent implements ComponentInterface {
     this.dsoRecursiveToggle.emit({
       originalEvent: e,
       current: this.recursiveToggle,
-      next: this.recursiveToggle === true ? false : true,
+      next: this.recursiveToggle !== true,
     });
   };
 
@@ -237,11 +237,17 @@ export class DocumentComponent implements ComponentInterface {
             <div class="heading">
               <Heading heading={this.heading} class="heading-element" onClick={this.handleHeadingClick}>
                 {collapsible && (
-                  <button type="button" class="toggle-button">
+                  <button
+                    type="button"
+                    class="toggle-button"
+                    aria-describedby="heading-title"
+                    aria-expanded={this.open.toString()}
+                  >
                     <dso-icon icon={this.open ? "chevron-down" : "chevron-right"}></dso-icon>
+                    <span class="sr-only">{this.open ? "Invouwen" : "Uitvouwen"}</span>
                   </button>
                 )}
-                <div class="title">
+                <div id="heading-title">
                   {this.notApplicable && <span class="not-applicable">Niet van toepassing:</span>}
                   {this.label || this.nummer || this.opschrift ? (
                     <>


### PR DESCRIPTION
In de storybook Document Component Demo en IMRO loop ik tegen het issue aan dat de class .sr-only niet werkt, dus is of "Invouwen" of "Uitvouwen" in beeld. Ik begrijp niet waarom die niet werkt.