### PR TITLE
#2587 Advanced Select: Placeholder toevoegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Next
+* Advanced Select: Placeholder optie toegevoegd ([#2587](https://github.com/dso-toolkit/dso-toolkit/issues/2587))
 
 ## 🎏 62.16.0 - 18-03-2024
 

--- a/packages/core/src/components/advanced-select/advanced-select.models.ts
+++ b/packages/core/src/components/advanced-select/advanced-select.models.ts
@@ -14,12 +14,20 @@ export interface AdvancedSelectGroup<T> {
   label: string;
   summaryCounter?: boolean;
   redirect?: AdvancedSelectGroupRedirect;
-  placeholder?: string;
-  options?: AdvancedSelectOption<T>[];
+  options: AdvancedSelectOption<T>[];
   variant?: AdvancedSelectVariant;
 }
 
-export type AdvancedSelectOptionOrGroup<T> = AdvancedSelectOption<T> | AdvancedSelectGroup<T>;
+export interface AdvancedSelectPlaceholder {
+  label: string;
+  redirect?: AdvancedSelectGroupRedirect;
+  placeholder: string;
+}
+
+export type AdvancedSelectOptionOrGroup<T> =
+  | AdvancedSelectOption<T>
+  | AdvancedSelectGroup<T>
+  | AdvancedSelectPlaceholder;
 
 export interface AdvancedSelectChangeEvent<T> {
   originalEvent: MouseEvent;

--- a/packages/core/src/components/advanced-select/advanced-select.models.ts
+++ b/packages/core/src/components/advanced-select/advanced-select.models.ts
@@ -14,7 +14,8 @@ export interface AdvancedSelectGroup<T> {
   label: string;
   summaryCounter?: boolean;
   redirect?: AdvancedSelectGroupRedirect;
-  options: AdvancedSelectOption<T>[];
+  placeholder?: string;
+  options?: AdvancedSelectOption<T>[];
   variant?: AdvancedSelectVariant;
 }
 

--- a/packages/core/src/components/advanced-select/advanced-select.scss
+++ b/packages/core/src/components/advanced-select/advanced-select.scss
@@ -85,7 +85,7 @@
     border-bottom: none;
   }
 
-  .option:not(.option-placeholder) {
+  .option {
     padding-left: advanced-select.$horizontal-padding * 2 + advanced-select.$option-dot-size * 0.5;
   }
 
@@ -163,6 +163,7 @@
   display: block;
   inline-size: 100%;
   padding: advanced-select.$vertical-padding * 2 advanced-select.$horizontal-padding;
+  cursor: pointer;
   line-height: inherit;
   font-family: inherit;
   font-size: inherit;
@@ -170,16 +171,12 @@
   text-align: left;
   background-color: advanced-select.$bg-color;
 
-  &:not(.option-placeholder) {
-    cursor: pointer;
+  &:hover {
+    background-color: advanced-select.$option-hover-bg-color;
 
-    &:hover {
-      background-color: advanced-select.$option-hover-bg-color;
-
-      .option-label {
-        color: advanced-select.$option-hover-color;
-        font-weight: advanced-select.$option-hover-font-weight;
-      }
+    .option-label {
+      color: advanced-select.$option-hover-color;
+      font-weight: advanced-select.$option-hover-font-weight;
     }
   }
 }
@@ -204,10 +201,8 @@
   font-weight: advanced-select.$option-active-font-weight;
 }
 
-.option-placeholder .option-label {
+.placeholder {
+  margin: 0;
+  padding: advanced-select.$vertical-padding * 2 advanced-select.$horizontal-padding;
   color: advanced-select.$option-placeholder-color;
-
-  &::before {
-    display: none;
-  }
 }

--- a/packages/core/src/components/advanced-select/advanced-select.scss
+++ b/packages/core/src/components/advanced-select/advanced-select.scss
@@ -85,7 +85,7 @@
     border-bottom: none;
   }
 
-  .option {
+  .option:not(.option-placeholder) {
     padding-left: advanced-select.$horizontal-padding * 2 + advanced-select.$option-dot-size * 0.5;
   }
 
@@ -163,7 +163,6 @@
   display: block;
   inline-size: 100%;
   padding: advanced-select.$vertical-padding * 2 advanced-select.$horizontal-padding;
-  cursor: pointer;
   line-height: inherit;
   font-family: inherit;
   font-size: inherit;
@@ -171,12 +170,16 @@
   text-align: left;
   background-color: advanced-select.$bg-color;
 
-  &:hover {
-    background-color: advanced-select.$option-hover-bg-color;
+  &:not(.option-placeholder) {
+    cursor: pointer;
 
-    .option-label {
-      color: advanced-select.$option-hover-color;
-      font-weight: advanced-select.$option-hover-font-weight;
+    &:hover {
+      background-color: advanced-select.$option-hover-bg-color;
+
+      .option-label {
+        color: advanced-select.$option-hover-color;
+        font-weight: advanced-select.$option-hover-font-weight;
+      }
     }
   }
 }
@@ -199,4 +202,12 @@
   color: advanced-select.$option-active-color;
   font-size: advanced-select.$option-font-size;
   font-weight: advanced-select.$option-active-font-weight;
+}
+
+.option-placeholder .option-label {
+  color: advanced-select.$option-placeholder-color;
+
+  &::before {
+    display: none;
+  }
 }

--- a/packages/core/src/components/advanced-select/advanced-select.tsx
+++ b/packages/core/src/components/advanced-select/advanced-select.tsx
@@ -161,7 +161,12 @@ export class AdvancedSelect implements ComponentInterface {
                       "options" in option && "summaryCounter" in option && !!option?.summaryCounter,
                   )
                   .map((group) => {
-                    return <dso-badge status={group.variant ?? "outline"}>{group.options.length}</dso-badge>;
+                    return (
+                      group.options &&
+                      group.options.length && (
+                        <dso-badge status={group.variant ?? "outline"}>{group.options.length}</dso-badge>
+                      )
+                    );
                   })}
               </span>
             )}
@@ -172,39 +177,42 @@ export class AdvancedSelect implements ComponentInterface {
           <div class="groups-container">
             <ul class="groups">
               {this.options.map((optionOrGroup) =>
-                "options" in optionOrGroup ? (
+                "options" in optionOrGroup || "placeholder" in optionOrGroup ? (
                   <li class={clsx(["group", { [`group-${optionOrGroup.variant}`]: !!optionOrGroup.variant }])}>
                     {optionOrGroup.label && <p class="group-label">{optionOrGroup.label}</p>}
-                    <ul class="options">
-                      {optionOrGroup.options.map((option) => (
-                        <OptionElement
-                          option={option}
-                          active={this.active}
-                          activeHint={this.activeHint}
-                          isPlaceholder={!option.value}
-                          callback={this.handleOptionClick}
-                        />
-                      ))}
-                    </ul>
+                    {optionOrGroup.options && optionOrGroup.options.length && (
+                      <ul class="options">
+                        {optionOrGroup.options.map((option) => (
+                          <li>
+                            <OptionElement
+                              option={option}
+                              active={this.active}
+                              activeHint={this.activeHint}
+                              callback={this.handleOptionClick}
+                            />
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {optionOrGroup.placeholder && (
+                      <PlaceholderElement placeholder={optionOrGroup.placeholder}></PlaceholderElement>
+                    )}
                     {optionOrGroup.redirect && (
-                      <a
-                        class="group-link"
-                        href={optionOrGroup.redirect.href}
-                        onClick={(e) => optionOrGroup.redirect && this.handleRedirectClick(e, optionOrGroup.redirect)}
-                      >
-                        {optionOrGroup.redirect.label}
-                        <dso-icon icon="chevron-right"></dso-icon>
-                      </a>
+                      <RedirectElement
+                        redirect={optionOrGroup.redirect}
+                        callback={this.handleRedirectClick}
+                      ></RedirectElement>
                     )}
                   </li>
                 ) : (
-                  <OptionElement
-                    option={optionOrGroup}
-                    active={this.active}
-                    activeHint={this.activeHint}
-                    isPlaceholder={!optionOrGroup.value}
-                    callback={this.handleOptionClick}
-                  />
+                  <li>
+                    <OptionElement
+                      option={optionOrGroup}
+                      active={this.active}
+                      activeHint={this.activeHint}
+                      callback={this.handleOptionClick}
+                    />
+                  </li>
                 ),
               )}
             </ul>
@@ -215,22 +223,32 @@ export class AdvancedSelect implements ComponentInterface {
   }
 }
 
+const PlaceholderElement: FunctionalComponent<{
+  placeholder: string;
+}> = ({ placeholder }) => <p class="placeholder">{placeholder}</p>;
+
 const OptionElement: FunctionalComponent<{
   option: AdvancedSelectOption<never>;
   active: AdvancedSelectOption<never> | undefined;
   activeHint: string | undefined;
-  isPlaceholder: boolean;
   callback: (event: MouseEvent, value: AdvancedSelectOption<never>) => void;
-}> = ({ option, active, activeHint, isPlaceholder, callback }) => (
-  <li>
-    <button
-      class={clsx(["option", { "option-active": active === option, "option-placeholder": isPlaceholder }])}
-      type="button"
-      tabindex={isPlaceholder ? -1 : 0}
-      onClick={(e) => !isPlaceholder && callback(e, option)}
-    >
-      <span class="option-label">{option.label}</span>
-      {!!activeHint && active === option && <span class="option-hint">({activeHint})</span>}
-    </button>
-  </li>
+}> = ({ option, active, activeHint, callback }) => (
+  <button
+    class={clsx(["option", { "option-active": active === option }])}
+    type="button"
+    onClick={(e) => callback(e, option)}
+  >
+    <span class="option-label">{option.label}</span>
+    {!!activeHint && active === option && <span class="option-hint">({activeHint})</span>}
+  </button>
+);
+
+const RedirectElement: FunctionalComponent<{
+  redirect: AdvancedSelectGroupRedirect;
+  callback: (event: MouseEvent, value: AdvancedSelectGroupRedirect) => void;
+}> = ({ redirect, callback }) => (
+  <a class="group-link" href={redirect.href} onClick={(e) => callback(e, redirect)}>
+    {redirect.label}
+    <dso-icon icon="chevron-right"></dso-icon>
+  </a>
 );

--- a/packages/core/src/components/advanced-select/advanced-select.tsx
+++ b/packages/core/src/components/advanced-select/advanced-select.tsx
@@ -160,14 +160,9 @@ export class AdvancedSelect implements ComponentInterface {
                     (option): option is AdvancedSelectGroup<never> =>
                       "options" in option && "summaryCounter" in option && !!option?.summaryCounter,
                   )
-                  .map((group) => {
-                    return (
-                      group.options &&
-                      group.options.length && (
-                        <dso-badge status={group.variant ?? "outline"}>{group.options.length}</dso-badge>
-                      )
-                    );
-                  })}
+                  .map((group) => (
+                    <dso-badge status={group.variant ?? "outline"}>{group.options.length}</dso-badge>
+                  ))}
               </span>
             )}
             <dso-icon icon="caret-down"></dso-icon>
@@ -176,11 +171,11 @@ export class AdvancedSelect implements ComponentInterface {
         {this.open && (
           <div class="groups-container">
             <ul class="groups">
-              {this.options.map((optionOrGroup) =>
-                "options" in optionOrGroup || "placeholder" in optionOrGroup ? (
-                  <li class={clsx(["group", { [`group-${optionOrGroup.variant}`]: !!optionOrGroup.variant }])}>
-                    {optionOrGroup.label && <p class="group-label">{optionOrGroup.label}</p>}
-                    {optionOrGroup.options && optionOrGroup.options.length && (
+              {this.options.map(
+                (optionOrGroup) =>
+                  ("options" in optionOrGroup && (
+                    <li class={clsx(["group", { [`group-${optionOrGroup.variant}`]: !!optionOrGroup.variant }])}>
+                      <p class="group-label">{optionOrGroup.label}</p>
                       <ul class="options">
                         {optionOrGroup.options.map((option) => (
                           <li>
@@ -193,27 +188,35 @@ export class AdvancedSelect implements ComponentInterface {
                           </li>
                         ))}
                       </ul>
-                    )}
-                    {optionOrGroup.placeholder && (
+                      {optionOrGroup.redirect && (
+                        <RedirectElement
+                          redirect={optionOrGroup.redirect}
+                          callback={this.handleRedirectClick}
+                        ></RedirectElement>
+                      )}
+                    </li>
+                  )) ||
+                  ("placeholder" in optionOrGroup && (
+                    <li class="group">
+                      <p class="group-label">{optionOrGroup.label}</p>
                       <PlaceholderElement placeholder={optionOrGroup.placeholder}></PlaceholderElement>
-                    )}
-                    {optionOrGroup.redirect && (
-                      <RedirectElement
-                        redirect={optionOrGroup.redirect}
-                        callback={this.handleRedirectClick}
-                      ></RedirectElement>
-                    )}
-                  </li>
-                ) : (
-                  <li>
-                    <OptionElement
-                      option={optionOrGroup}
-                      active={this.active}
-                      activeHint={this.activeHint}
-                      callback={this.handleOptionClick}
-                    />
-                  </li>
-                ),
+                      {optionOrGroup.redirect && (
+                        <RedirectElement
+                          redirect={optionOrGroup.redirect}
+                          callback={this.handleRedirectClick}
+                        ></RedirectElement>
+                      )}
+                    </li>
+                  )) || (
+                    <li>
+                      <OptionElement
+                        option={optionOrGroup}
+                        active={this.active}
+                        activeHint={this.activeHint}
+                        callback={this.handleOptionClick}
+                      />
+                    </li>
+                  ),
               )}
             </ul>
           </div>

--- a/packages/core/src/components/advanced-select/advanced-select.tsx
+++ b/packages/core/src/components/advanced-select/advanced-select.tsx
@@ -181,6 +181,7 @@ export class AdvancedSelect implements ComponentInterface {
                           option={option}
                           active={this.active}
                           activeHint={this.activeHint}
+                          isPlaceholder={!option.value}
                           callback={this.handleOptionClick}
                         />
                       ))}
@@ -201,6 +202,7 @@ export class AdvancedSelect implements ComponentInterface {
                     option={optionOrGroup}
                     active={this.active}
                     activeHint={this.activeHint}
+                    isPlaceholder={!optionOrGroup.value}
                     callback={this.handleOptionClick}
                   />
                 ),
@@ -217,13 +219,15 @@ const OptionElement: FunctionalComponent<{
   option: AdvancedSelectOption<never>;
   active: AdvancedSelectOption<never> | undefined;
   activeHint: string | undefined;
+  isPlaceholder: boolean;
   callback: (event: MouseEvent, value: AdvancedSelectOption<never>) => void;
-}> = ({ option, active, activeHint, callback }) => (
+}> = ({ option, active, activeHint, isPlaceholder, callback }) => (
   <li>
     <button
-      class={clsx(["option", { "option-active": active === option }])}
+      class={clsx(["option", { "option-active": active === option, "option-placeholder": isPlaceholder }])}
       type="button"
-      onClick={(e) => callback(e, option)}
+      tabindex={isPlaceholder ? -1 : 0}
+      onClick={(e) => !isPlaceholder && callback(e, option)}
     >
       <span class="option-label">{option.label}</span>
       {!!activeHint && active === option && <span class="option-hint">({activeHint})</span>}

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.content.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.content.ts
@@ -11,6 +11,7 @@ export const options: AdvancedSelectOptionOrGroup<unknown>[] = [
     options: [
       {
         label: "In werking (laatst gewijzigd: 01-01-2024)",
+        value: {},
       },
     ],
   },
@@ -20,9 +21,11 @@ export const options: AdvancedSelectOptionOrGroup<unknown>[] = [
     options: [
       {
         label: "Citeertitel van het besluit (In werking per 01-03-2024)",
+        value: {},
       },
       {
         label: "Citeertitel van het besluit (In werking per 01-04-2024)",
+        value: {},
       },
     ],
   },
@@ -37,13 +40,28 @@ export const options: AdvancedSelectOptionOrGroup<unknown>[] = [
     options: [
       {
         label: "Verandering in annotaties (Einde inzage: 01-02-2024)",
+        value: {},
       },
       {
         label: "Herziening Achterwillense-weg 12-34 (Einde inzage: 08-02-2024)",
+        value: {},
       },
       {
         label:
           "Algemene regels voor het beheer en onderhoud van waterstaatswerken en het gebruik van watersystemen (Keur waterschap Vechtstromen 2020) (Einde inzage: 09-02-2024)",
+        value: {},
+      },
+    ],
+  },
+  {
+    label: "Groep met placeholder",
+    redirect: {
+      href: "#",
+      label: "Bekijk ontwerpen met afgeronde inzage termijn",
+    },
+    options: [
+      {
+        label: "Er zijn alleen ontwerpen met een afgeronde inzage termijn voor dit document.",
       },
     ],
   },

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.content.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.content.ts
@@ -11,7 +11,6 @@ export const options: AdvancedSelectOptionOrGroup<unknown>[] = [
     options: [
       {
         label: "In werking (laatst gewijzigd: 01-01-2024)",
-        value: {},
       },
     ],
   },
@@ -21,11 +20,9 @@ export const options: AdvancedSelectOptionOrGroup<unknown>[] = [
     options: [
       {
         label: "Citeertitel van het besluit (In werking per 01-03-2024)",
-        value: {},
       },
       {
         label: "Citeertitel van het besluit (In werking per 01-04-2024)",
-        value: {},
       },
     ],
   },
@@ -40,29 +37,22 @@ export const options: AdvancedSelectOptionOrGroup<unknown>[] = [
     options: [
       {
         label: "Verandering in annotaties (Einde inzage: 01-02-2024)",
-        value: {},
       },
       {
         label: "Herziening Achterwillense-weg 12-34 (Einde inzage: 08-02-2024)",
-        value: {},
       },
       {
         label:
           "Algemene regels voor het beheer en onderhoud van waterstaatswerken en het gebruik van watersystemen (Keur waterschap Vechtstromen 2020) (Einde inzage: 09-02-2024)",
-        value: {},
       },
     ],
   },
   {
     label: "Groep met placeholder",
+    placeholder: "Er zijn alleen ontwerpen met een afgeronde inzage termijn voor dit document.",
     redirect: {
       href: "#",
       label: "Bekijk ontwerpen met afgeronde inzage termijn",
     },
-    options: [
-      {
-        label: "Er zijn alleen ontwerpen met een afgeronde inzage termijn voor dit document.",
-      },
-    ],
   },
 ];

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
@@ -14,7 +14,8 @@ export interface AdvancedSelectGroup<T> {
   label: string;
   summaryCounter?: boolean;
   redirect?: AdvancedSelectGroupRedirect;
-  options: AdvancedSelectOption<T>[];
+  placeholder?: string;
+  options?: AdvancedSelectOption<T>[];
   variant?: AdvancedSelectVariant;
 }
 

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
@@ -14,12 +14,20 @@ export interface AdvancedSelectGroup<T> {
   label: string;
   summaryCounter?: boolean;
   redirect?: AdvancedSelectGroupRedirect;
-  placeholder?: string;
-  options?: AdvancedSelectOption<T>[];
+  options: AdvancedSelectOption<T>[];
   variant?: AdvancedSelectVariant;
 }
 
-export type AdvancedSelectOptionOrGroup<T> = AdvancedSelectOption<T> | AdvancedSelectGroup<T>;
+export interface AdvancedSelectPlaceholder {
+  label: string;
+  redirect?: AdvancedSelectGroupRedirect;
+  placeholder: string;
+}
+
+export type AdvancedSelectOptionOrGroup<T> =
+  | AdvancedSelectOption<T>
+  | AdvancedSelectGroup<T>
+  | AdvancedSelectPlaceholder;
 
 export interface AdvancedSelect<T> {
   options: AdvancedSelectOptionOrGroup<T>[];

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.variables.scss
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.variables.scss
@@ -38,6 +38,8 @@ $option-hover-color: $option-active-color;
 $option-hover-bg-color: colors.$grasgroen-10;
 $option-hover-font-weight: $option-active-font-weight;
 
+$option-placeholder-color: colors.$grijs-60;
+
 $default-variant-color: colors.$grijs-20;
 $info-variant-color: colors.$info-color;
 $primary-variant-color: colors.$bosgroen;


### PR DESCRIPTION
Ik heb het geimplementeerd op basis van het wel of niet hebben van een `value`. Opties met value werken gewoon zoals voorheen maar opties zonder value (wat normaal gesproken niet zou voorkomen voor werkende opties) hebben nu deze nieuwe styling. 