### PR TITLE
Form Group: Rich content overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Form Group: Rich content overflow ([#2600](https://github.com/dso-toolkit/dso-toolkit/issues/2600))
+
 ### Added
 * Ozon Content: Ondersteuning voor `<Inhoud wijzigactie="voegtoe|verwijder">` ([#2528](https://github.com/dso-toolkit/dso-toolkit/issues/2528))
 * Ozon Content: Afbeeldingen in renvooi kunnen weergeven ([#2433](https://github.com/dso-toolkit/dso-toolkit/issues/2433))

--- a/packages/dso-toolkit/src/components/form/form-group.scss
+++ b/packages/dso-toolkit/src/components/form/form-group.scss
@@ -60,8 +60,8 @@
     text-align: left;
   }
 
-  .dso-rich-content {
-    overflow-x: auto;
+  .dso-rich-content:has(table) {
+    overflow-x: auto; // facilitate table overflow if needed
   }
 
   legend + .dso-label-container {


### PR DESCRIPTION
Zolang er in de `dso-rich-content` geen tabel zit, is er geen `overflow` gedefinieerd, dus geen issues met afgekapte focus outlines.

ECHTER: als er _wel_ een tabel in zit, dan gebeurt het wel. edge case denk ik. dit is sowieso de beste optie die ik kan verzinnen.