### PR TITLE
#2610 [Fixed] Modal: Vanishes below 768px viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Document Component: Titel knop mist aria-expanded en sluit voor titel tekst ([#2480](https://github.com/dso-toolkit/dso-toolkit/issues/2480))
 * Document Component: Ondersteuning lijstnummers IMRO documenten ([#2500](https://github.com/dso-toolkit/dso-toolkit/issues/2500))
 * Document List: Add aria-expanded to dropdown menu example button ([#2561](https://github.com/dso-toolkit/dso-toolkit/issues/2561))
+* Modal: Vanishes below 768px viewport ([#2610](https://github.com/dso-toolkit/dso-toolkit/issues/2610))
 
 ### Tasks
 * Packages: Dependencies updates ([#2483](https://github.com/dso-toolkit/dso-toolkit/issues/2483))

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -76,12 +76,9 @@ export class Modal implements ComponentInterface {
 
       this.htmlDialogElement.showModal();
     }
-
-    document.body.classList.add("dso-modal-open");
   }
 
   disconnectedCallback(): void {
-    document.body.classList.remove("dso-modal-open");
     this.htmlDialogElement?.close();
 
     if (this.returnFocus === false) {

--- a/packages/core/src/components/modal/readme.md
+++ b/packages/core/src/components/modal/readme.md
@@ -1,6 +1,6 @@
 # dso-modal
 
-Bij het instantieren van een `dso-modal` wordt op de body `.dso-modal-open` gezet. Deze class zorgt ervoor dat het scrollgedrag 'achter' de modal wordt uitgezet. Als afnemer kun je dus een modal starten door `<dso-modal>` pas te renderen als je een modal wil.
+Bij het instantieren van een `dso-modal` wordt op de body het scrollgedrag 'achter' de modal automatisch uitgezet dmv detectie middels CSS. Als afnemer kun je dus een modal starten door `<dso-modal>` pas te renderen als je een modal wil.
 
 
 <!-- Auto Generated Below -->

--- a/packages/dso-toolkit/src/components/modal/modal.scss
+++ b/packages/dso-toolkit/src/components/modal/modal.scss
@@ -8,6 +8,7 @@
 
 body:has(dialog[open]),
 body:has(dso-modal.hydrated) {
+  // block scrolling of the body when a dialog is open
   overflow: hidden;
 }
 

--- a/packages/dso-toolkit/src/components/modal/modal.scss
+++ b/packages/dso-toolkit/src/components/modal/modal.scss
@@ -6,18 +6,9 @@
 
 @use "../../di";
 
-body.dso-modal-open {
-  @media screen and (min-width: media-query-breakpoints.$screen-sm-min) {
-    overflow: hidden;
-  }
-
-  @media screen and (max-width: media-query-breakpoints.$screen-xs-max) {
-    .container,
-    dso-banner,
-    .dso-banner {
-      display: none;
-    }
-  }
+body:has(dialog[open]),
+body:has(dso-modal.hydrated) {
+  overflow: hidden;
 }
 
 .dso-modal {

--- a/packages/dso-toolkit/src/components/modal/readme.md
+++ b/packages/dso-toolkit/src/components/modal/readme.md
@@ -1,3 +1,3 @@
 # `.dso-modal`
 
-Als een modal actief is moet er op `body` een class `.dso-modal-open` worden geplaatst.
+Als een modal actief is zal de `body` dit door middel van CSS automatisch detecteren, en het scrollgedrag 'achter' de modal uitzetten.

--- a/website/blog/2023-10-20-dso-toolkit-62.0.0.mdx
+++ b/website/blog/2023-10-20-dso-toolkit-62.0.0.mdx
@@ -2,40 +2,64 @@
 authors: [tfrijsewijk]
 ---
 
-# DSO Toolkit v62.19.0 🎤
+# DSO Toolkit v62.0.0 🎤
 
-In deze release is een bug in de Modal opgelost waardoor in sommige gevallen de modal in een viewport onder 768px breedte verdween.
+In deze release is een regressie bug in de Date Picker opgelost die in v60.0.0 is geintroduceerd.
 
-## Modal
+## Date Picker
 
-De CSS-code die een deel van de markup op `display: none` zette, is verwijderd, en de HTML `body` detecteert nu automatisch of een modal is geopend:
+Het change event `dsoDateChange` van `<dso-date-picker>` moet de value als `dd-mm-jjjj` emitten. In versie v60.0.0 is dit per abuis `jjjj-mm-dd` geworden. In [#2391](https://github.com/dso-toolkit/dso-toolkit/issues/2391) is dit opgelost en is de output format weer `dd-mm-jjjj`.
 
-Oud:
+Tegelijkertijd hebben we [#2380 Date Picker: Bij handmatige invoer van datum buiten min/max, geen event met error](https://github.com/dso-toolkit/dso-toolkit/issues/2380) opgelost. Dit betekent dat `event.error` weer klopt. Met de komst van `<input type="date">` in het Web Component is dit ook een erg beperkte API gebleven. Daarom hebben we de API uitgebreid met het validatieobject van de browser `validity: ValidityState`.
 
-```scss
-body.dso-modal-open {
-  @media screen and (min-width: media-query-breakpoints.$screen-sm-min) {
-    overflow: hidden;
-  }
+```typescript
+export interface DatePickerChangeEvent {
+  component: "dso-date-picker";
+  originalEvent: Event;
+  value: string;
+  valueAsDate: Date | undefined;
+  error?: "required" | "min-range" | "max-range" | "invalid";
 
-  @media screen and (max-width: media-query-breakpoints.$screen-xs-max) {
-    .container,
-    dso-banner,
-    .dso-banner {
-      display: none;
-    }
-  }
+  // Nieuw
+  validity: ValidityState;
 }
 ```
 
-Nieuw:
+## Selectable
 
-```scss
-body:has(dialog[open]),
-body:has(dso-modal.hydrated) {
-  // block scrolling of the body when a dialog is open
-  overflow: hidden;
+Het SelectableChangeEvent was voorheen een alias voor `Event`. Dit was verwarrend en we hebben dit gelijkgetrokken met de overige events:
+
+```typescript
+// ❌ Oud
+interface SelectableChangeEvent extends Event {}
+
+// ✅ Nieuw
+export interface SelectableChangeEvent {
+  originalEvent: Event;
+  checked: boolean;
 }
 ```
 
-Het is bij de html/css-versie van de Modal dus niet meer nodig om de class `dso-modal-open` te zetten; de `:has()`-pseudoclass, sinds kort breed ondersteund, zorgt automatisch dat het scrollgedrag 'achter' de modal wordt uitgezet.
+Voor het één-op-één migratiepad geldt dat het vorige `DsoSelectableCustomEvent<SelectableChangeEvent>.detail` object nu op `DsoSelectableCustomEvent<SelectableChangeEvent>.detail.originalEvent` staat:
+
+```ts
+event.detail === event.detail.originalEvent;
+```
+
+Voor de afnemers die de `checked` state willen weten kunnen ook gebruik maken van `DsoSelectableCustomEvent<SelectableChangeEvent>.detail.checked`:
+
+```ts
+event.detail.target.checked === event.detail.checked;
+```
+
+<!--truncate-->
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/JwtEOp7pC1A?si=yerY5rgfHtS9k9SW"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen
+></iframe>

--- a/website/blog/2023-10-20-dso-toolkit-62.0.0.mdx
+++ b/website/blog/2023-10-20-dso-toolkit-62.0.0.mdx
@@ -2,64 +2,40 @@
 authors: [tfrijsewijk]
 ---
 
-# DSO Toolkit v62.0.0 🎤
+# DSO Toolkit v62.19.0 🎤
 
-In deze release is een regressie bug in de Date Picker opgelost die in v60.0.0 is geintroduceerd.
+In deze release is een bug in de Modal opgelost waardoor in sommige gevallen de modal in een viewport onder 768px breedte verdween.
 
-## Date Picker
+## Modal
 
-Het change event `dsoDateChange` van `<dso-date-picker>` moet de value als `dd-mm-jjjj` emitten. In versie v60.0.0 is dit per abuis `jjjj-mm-dd` geworden. In [#2391](https://github.com/dso-toolkit/dso-toolkit/issues/2391) is dit opgelost en is de output format weer `dd-mm-jjjj`.
+De CSS-code die een deel van de markup op `display: none` zette, is verwijderd, en de HTML `body` detecteert nu automatisch of een modal is geopend:
 
-Tegelijkertijd hebben we [#2380 Date Picker: Bij handmatige invoer van datum buiten min/max, geen event met error](https://github.com/dso-toolkit/dso-toolkit/issues/2380) opgelost. Dit betekent dat `event.error` weer klopt. Met de komst van `<input type="date">` in het Web Component is dit ook een erg beperkte API gebleven. Daarom hebben we de API uitgebreid met het validatieobject van de browser `validity: ValidityState`.
+Oud:
 
-```typescript
-export interface DatePickerChangeEvent {
-  component: "dso-date-picker";
-  originalEvent: Event;
-  value: string;
-  valueAsDate: Date | undefined;
-  error?: "required" | "min-range" | "max-range" | "invalid";
+```scss
+body.dso-modal-open {
+  @media screen and (min-width: media-query-breakpoints.$screen-sm-min) {
+    overflow: hidden;
+  }
 
-  // Nieuw
-  validity: ValidityState;
+  @media screen and (max-width: media-query-breakpoints.$screen-xs-max) {
+    .container,
+    dso-banner,
+    .dso-banner {
+      display: none;
+    }
+  }
 }
 ```
 
-## Selectable
+Nieuw:
 
-Het SelectableChangeEvent was voorheen een alias voor `Event`. Dit was verwarrend en we hebben dit gelijkgetrokken met de overige events:
-
-```typescript
-// ❌ Oud
-interface SelectableChangeEvent extends Event {}
-
-// ✅ Nieuw
-export interface SelectableChangeEvent {
-  originalEvent: Event;
-  checked: boolean;
+```scss
+body:has(dialog[open]),
+body:has(dso-modal.hydrated) {
+  // block scrolling of the body when a dialog is open
+  overflow: hidden;
 }
 ```
 
-Voor het één-op-één migratiepad geldt dat het vorige `DsoSelectableCustomEvent<SelectableChangeEvent>.detail` object nu op `DsoSelectableCustomEvent<SelectableChangeEvent>.detail.originalEvent` staat:
-
-```ts
-event.detail === event.detail.originalEvent;
-```
-
-Voor de afnemers die de `checked` state willen weten kunnen ook gebruik maken van `DsoSelectableCustomEvent<SelectableChangeEvent>.detail.checked`:
-
-```ts
-event.detail.target.checked === event.detail.checked;
-```
-
-<!--truncate-->
-
-<iframe
-  width="560"
-  height="315"
-  src="https://www.youtube.com/embed/JwtEOp7pC1A?si=yerY5rgfHtS9k9SW"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowfullscreen
-></iframe>
+Het is bij de html/css-versie van de Modal dus niet meer nodig om de class `dso-modal-open` te zetten; de `:has()`-pseudoclass, sinds kort breed ondersteund, zorgt automatisch dat het scrollgedrag 'achter' de modal wordt uitgezet.

--- a/website/blog/2024-04-15-dso-toolkit-62.19.0.mdx
+++ b/website/blog/2024-04-15-dso-toolkit-62.19.0.mdx
@@ -1,0 +1,41 @@
+---
+authors: [tfrijsewijk]
+---
+
+# DSO Toolkit v62.19.0 🎤
+
+In deze release is een bug in de Modal opgelost waardoor in sommige gevallen de modal in een viewport onder 768px breedte verdween.
+
+## Modal
+
+De CSS-code die een deel van de markup op `display: none` zette, is verwijderd, en de HTML `body` detecteert nu automatisch of een modal is geopend:
+
+Oud:
+
+```scss
+body.dso-modal-open {
+  @media screen and (min-width: media-query-breakpoints.$screen-sm-min) {
+    overflow: hidden;
+  }
+
+  @media screen and (max-width: media-query-breakpoints.$screen-xs-max) {
+    .container,
+    dso-banner,
+    .dso-banner {
+      display: none;
+    }
+  }
+}
+```
+
+Nieuw:
+
+```scss
+body:has(dialog[open]),
+body:has(dso-modal.hydrated) {
+  // block scrolling of the body when a dialog is open
+  overflow: hidden;
+}
+```
+
+Het is bij de html/css-versie van de Modal dus niet meer nodig om de class `dso-modal-open` te zetten; de `:has()`-pseudoclass, sinds kort breed ondersteund, zorgt automatisch dat het scrollgedrag 'achter' de modal wordt uitgezet.

--- a/website/blog/2024-04-15-dso-toolkit-62.19.0.mdx
+++ b/website/blog/2024-04-15-dso-toolkit-62.19.0.mdx
@@ -1,5 +1,5 @@
 ---
-authors: [tfrijsewijk]
+authors: [hansgrimm]
 ---
 
 # DSO Toolkit v62.19.0 🎤

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -8,3 +8,8 @@ anneke:
   title: DSO Toolkit Maintainer
   url: https://github.com/anneke
   image_url: https://github.com/anneke.png
+hansgrimm:
+  name: Hans Grimm
+  title: DSO Toolkit Maintainer
+  url: https://github.com/hansgrimm
+  image_url: https://github.com/hansgrimm.png


### PR DESCRIPTION
- display: none rule removed
- made selector for overflow: hidden on the body smarter: detects modal (element AND webcomponent) when it is open/present.
- media query for body overflow not really needed, so it's gone