### PR TITLE
#2616 From Group Files: Ondersteuning voor een spinner (progress indicator) tijdens upload van bestand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Added
+* From Group Files: Ondersteuning voor een spinner (progress indicator) tijdens upload van bestand ([#2616](https://github.com/dso-toolkit/dso-toolkit/issues/2616))
+
 ## 🩹 62.20.1 - 26-04-2024
 
 ### Fixed

--- a/packages/dso-toolkit/src/components/form/content/files.content.ts
+++ b/packages/dso-toolkit/src/components/form/content/files.content.ts
@@ -25,5 +25,6 @@ export const files: FormGroupFilesFile[] = [
   },
   {
     filename: "legger-2022-06-20-v3.zip",
+    uploading: true,
   },
 ];

--- a/packages/dso-toolkit/src/components/form/form-groups/files/form-group-files.scss
+++ b/packages/dso-toolkit/src/components/form/form-groups/files/form-group-files.scss
@@ -22,6 +22,15 @@
     margin: #{units.$u1 * 0.5} 0;
   }
 
+  .dso-upload-loading {
+    margin: #{units.$u1 * 0.5} 0;
+    padding-inline-end: 26px;
+
+    span {
+      padding-inline-start: 6px;
+    }
+  }
+
   .dso-file-upload {
     input[type="file"] {
       @include utilities.sr-only();
@@ -158,9 +167,6 @@
         + .dso-remove {
           margin-inline-start: (units.$u4 * 2) + (units.$u1 * 1.5);
         }
-        + .dso-download {
-          margin-inline-start: units.$u4 + units.$u1;
-        }
       }
 
       dso-icon,
@@ -174,6 +180,7 @@
         li:has(.dso-download) {
           .dso-selectable,
           dso-selectable,
+          .dso-upload-loading,
           dso-icon,
           svg.di {
             + .dso-download {
@@ -185,6 +192,7 @@
         li:not(:has(.dso-download)) {
           .dso-selectable,
           dso-selectable,
+          .dso-upload-loading,
           dso-icon,
           svg.di {
             + .dso-remove {

--- a/packages/dso-toolkit/src/components/form/models/form-group-files.model.ts
+++ b/packages/dso-toolkit/src/components/form/models/form-group-files.model.ts
@@ -10,4 +10,5 @@ export interface FormGroupFiles<TemplateFnReturnType> extends FormGroupBase<Temp
 export interface FormGroupFilesFile {
   filename: string;
   confidential?: boolean;
+  uploading?: boolean;
 }

--- a/packages/dso-toolkit/src/components/icon/icon.args.ts
+++ b/packages/dso-toolkit/src/components/icon/icon.args.ts
@@ -7,7 +7,7 @@ export interface IconArgs {
 
 export const iconArgTypes: ArgTypes<IconArgs> = {
   icon: {
-    options: ["user", "table"],
+    options: ["user", "table", "sound", "spinner", "status-danger"],
     control: {
       type: "select",
     },

--- a/storybook/src/components/form/form-group-files.css-template.ts
+++ b/storybook/src/components/form/form-group-files.css-template.ts
@@ -37,15 +37,24 @@ export const cssFormGroupFiles: ComponentImplementation<FormGroupFiles<TemplateR
               ${formGroup.files.map(
                 (file, index) =>
                   html`<li>
-                    <div class="dso-filename" id=${`${formGroup.id}-file-filename-${index}`}>${file.filename}</div>
-                    ${selectableTemplate({
-                      id: `${formGroup.id}-file-confirm-${index}`,
-                      value: "",
-                      type: "checkbox",
-                      label: "Vertrouwelijk",
-                      describedById: `${formGroup.id}-file-filename-${index}`,
-                    })}
-                    ${file.confidential ? iconTemplate({ icon: "status-warning" }) : nothing}
+                    <div class="dso-filename" id=${`${formGroup.id}-file-filename-${index}`}>
+                      ${file.filename} ${file.confidential ? iconTemplate({ icon: "status-warning" }) : nothing}
+                    </div>
+                    ${!file.uploading
+                      ? selectableTemplate({
+                          id: `${formGroup.id}-file-confirm-${index}`,
+                          value: "",
+                          type: "checkbox",
+                          label: "Vertrouwelijk",
+                          describedById: `${formGroup.id}-file-filename-${index}`,
+                          checked: file.confidential,
+                        })
+                      : nothing}
+                    ${file.uploading
+                      ? html`<div class="dso-upload-loading">
+                          ${iconTemplate({ icon: "spinner" })}<span>Uploaden</span>
+                        </div>`
+                      : nothing}
                     ${buttonTemplate({
                       label: "download document",
                       variant: "tertiary",


### PR DESCRIPTION
Zie ook gerelateerd issue #2644.
Tevens de positie van het Warning icoon gewijzigd: stat nu direct actre de naam van het geüploade document. Hier mag UX (@MYpenburg) naar kijken.