### PR TITLE
#2498 blog en fixes voor Logo component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Added
+* Header: Aparte link voor applicatienaam in compacte header ([#2498](https://github.com/dso-toolkit/dso-toolkit/issues/2498))
+
 ### Fixed
 * Form: Fix error messages ([#2141](https://github.com/dso-toolkit/dso-toolkit/issues/2141))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Next
+## 🐸 Next
 
 ### Added
 * Header: Aparte link voor applicatienaam in compacte header ([#2498](https://github.com/dso-toolkit/dso-toolkit/issues/2498))

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -23,6 +23,7 @@ import { InfoButtonToggleEvent } from "./components/info-button/info-button.inte
 import { InputRangeChangeEvent } from "./components/input-range/input-range.interfaces";
 import { LegendItemRemoveClickEvent } from "./components/legend-item/legend-item.interfaces";
 import { ListButtonChangeEvent, ListButtonSelectedEvent } from "./components/list-button/list-button.interfaces";
+import { LogoClickEvent, LogoLabelClickEvent } from "./components/logo/logo.interfaces";
 import { BaseLayer, BaseLayerChangeEvent } from "./components/map-base-layers/map-base-layers.interfaces";
 import { MapControlsToggleEvent } from "./components/map-controls/map-controls.interfaces";
 import { Overlay, OverlayChangeEvent } from "./components/map-overlays/map-overlays.interfaces";
@@ -54,6 +55,7 @@ export { InfoButtonToggleEvent } from "./components/info-button/info-button.inte
 export { InputRangeChangeEvent } from "./components/input-range/input-range.interfaces";
 export { LegendItemRemoveClickEvent } from "./components/legend-item/legend-item.interfaces";
 export { ListButtonChangeEvent, ListButtonSelectedEvent } from "./components/list-button/list-button.interfaces";
+export { LogoClickEvent, LogoLabelClickEvent } from "./components/logo/logo.interfaces";
 export { BaseLayer, BaseLayerChangeEvent } from "./components/map-base-layers/map-base-layers.interfaces";
 export { MapControlsToggleEvent } from "./components/map-controls/map-controls.interfaces";
 export { Overlay, OverlayChangeEvent } from "./components/map-overlays/map-overlays.interfaces";
@@ -725,6 +727,14 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * The url the label is pointing to.
+         */
+        "labelUrl"?: string;
+        /**
+          * The url the logo is pointing to.
+         */
+        "logoUrl"?: string;
+        /**
           * The ribbon contains the text for a possible 'sticker' on top of the logo. Used to clarify the (non-production) server environment ("int", "kta", "pfm", "pre", or "dmo")
          */
         "ribbon"?: string;
@@ -1149,6 +1159,10 @@ export interface DsoLegendItemCustomEvent<T> extends CustomEvent<T> {
 export interface DsoListButtonCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLDsoListButtonElement;
+}
+export interface DsoLogoCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLDsoLogoElement;
 }
 export interface DsoMapBaseLayersCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -1595,7 +1609,19 @@ declare global {
         prototype: HTMLDsoListButtonElement;
         new (): HTMLDsoListButtonElement;
     };
+    interface HTMLDsoLogoElementEventMap {
+        "dsoLogoClick": LogoClickEvent;
+        "dsoLabelClick": LogoLabelClickEvent;
+    }
     interface HTMLDsoLogoElement extends Components.DsoLogo, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDsoLogoElementEventMap>(type: K, listener: (this: HTMLDsoLogoElement, ev: DsoLogoCustomEvent<HTMLDsoLogoElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDsoLogoElementEventMap>(type: K, listener: (this: HTMLDsoLogoElement, ev: DsoLogoCustomEvent<HTMLDsoLogoElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDsoLogoElement: {
         prototype: HTMLDsoLogoElement;
@@ -2726,6 +2752,22 @@ declare namespace LocalJSX {
           * The label clarifies the service within the Omgevingsloket, shown as a subtitle (and on smaller screens as the main wordmark itself).
          */
         "label"?: string;
+        /**
+          * The url the label is pointing to.
+         */
+        "labelUrl"?: string;
+        /**
+          * The url the logo is pointing to.
+         */
+        "logoUrl"?: string;
+        /**
+          * Emitted when the label in the logo is clicked (only when labelUrl is set).
+         */
+        "onDsoLabelClick"?: (event: DsoLogoCustomEvent<LogoLabelClickEvent>) => void;
+        /**
+          * Emitted when the logo is clicked (only when logoUrl is set).
+         */
+        "onDsoLogoClick"?: (event: DsoLogoCustomEvent<LogoClickEvent>) => void;
         /**
           * The ribbon contains the text for a possible 'sticker' on top of the logo. Used to clarify the (non-production) server environment ("int", "kta", "pfm", "pre", or "dmo")
          */

--- a/packages/core/src/components/logo/logo.interfaces.ts
+++ b/packages/core/src/components/logo/logo.interfaces.ts
@@ -1,20 +1,11 @@
-export interface Logo {
-  label?: string;
-  labelUrl?: string;
-  logoUrl?: string;
-  ribbon?: string;
-  dsoLogoClick?: (e: CustomEvent<LogoClickEvent>) => void;
-  dsoLabelClick?: (e: CustomEvent<LogoLabelClickEvent>) => void;
-}
-
-interface LogoClickEvent {
+export interface LogoClickEvent {
   originalEvent: MouseEvent;
   url: string;
   /** True when user selected the page holding Ctrl, Alt or other modifiers. Can be used to determine navigation. */
   isModifiedEvent: boolean;
 }
 
-interface LogoLabelClickEvent {
+export interface LogoLabelClickEvent {
   originalEvent: MouseEvent;
   url: string;
   /** True when user selected the page holding Ctrl, Alt or other modifiers. Can be used to determine navigation. */

--- a/packages/core/src/components/logo/logo.scss
+++ b/packages/core/src/components/logo/logo.scss
@@ -2,6 +2,7 @@
 @use "~dso-toolkit/src/variables/media-query-breakpoints";
 @use "~dso-toolkit/src/variables/typography";
 @use "~dso-toolkit/src/variables/units";
+@use "~dso-toolkit/src/components/anchor/anchor.mixins" as anchor-mixins;
 
 :host {
   max-block-size: units.$ru6;
@@ -16,6 +17,21 @@
   align-items: center;
   container-type: size;
   container-name: logo;
+
+  a {
+    display: flex;
+    align-items: center;
+    gap: units.$u2;
+
+    @include anchor-mixins.reverse();
+
+    &,
+    &:hover,
+    &:focus,
+    &:visited {
+      color: colors.$bosgroen;
+    }
+  }
 }
 
 .logo-target {

--- a/packages/core/src/components/logo/logo.scss
+++ b/packages/core/src/components/logo/logo.scss
@@ -2,7 +2,7 @@
 @use "~dso-toolkit/src/variables/media-query-breakpoints";
 @use "~dso-toolkit/src/variables/typography";
 @use "~dso-toolkit/src/variables/units";
-@use "~dso-toolkit/src/components/anchor/anchor.mixins" as anchor-mixins;
+@use "~dso-toolkit/src/components/anchor";
 
 :host {
   max-block-size: units.$ru6;
@@ -18,12 +18,13 @@
   container-type: size;
   container-name: logo;
 
-  a {
+  .logo-url,
+  .logo-label-url {
     display: flex;
     align-items: center;
     gap: units.$u2;
 
-    @include anchor-mixins.reverse();
+    @include anchor.reverse();
 
     &,
     &:hover,
@@ -32,6 +33,25 @@
       color: colors.$bosgroen;
     }
   }
+}
+
+:host([logo-url][ribbon]) {
+  grid-template-areas: "targetwordmark label";
+
+  .logo-url {
+    grid-area: targetwordmark;
+    + .logo-ribbon {
+      grid-area: targetwordmark;
+    }
+  }
+
+  .logo-label-url + .logo-ribbon {
+    grid-area: targetwordmark;
+  }
+}
+
+.logo-label-url {
+  grid-area: label;
 }
 
 .logo-target {
@@ -129,6 +149,12 @@
       font-size: initial;
       text-wrap: balance;
       overflow-wrap: normal;
+    }
+  }
+
+  :host([logo-url][ribbon]) {
+    .logo-label-url + .logo-ribbon {
+      grid-area: label;
     }
   }
 }

--- a/packages/core/src/components/logo/logo.tsx
+++ b/packages/core/src/components/logo/logo.tsx
@@ -1,4 +1,30 @@
-import { Component, ComponentInterface, Host, Prop, h } from "@stencil/core";
+import {
+  Component,
+  ComponentInterface,
+  Fragment,
+  Host,
+  Prop,
+  h,
+  Event,
+  EventEmitter,
+  FunctionalComponent,
+} from "@stencil/core";
+import { isModifiedEvent } from "../../utils/is-modified-event";
+import { LogoClickEvent, LogoLabelClickEvent } from "./logo.interfaces";
+
+const DsoLogo: FunctionalComponent = () => (
+  <>
+    <svg fill="none" viewBox="0 0 48 48" height="100%" class="logo-target">
+      <path class="outer" d="M26 0a24 24 0 1 0 0 47.9A24 24 0 0 0 24 0Z" />
+      <path class="middle" d="M24 8A16 16 0 0 0 8 24 16 16 0 1 0 24 8Z" />
+      <path class="inner" d="M24 32a8 8 0 0 0 0-16 8 8 0 0 0 0 16Z" />
+    </svg>
+    <div class="logo-wordmark">
+      <span class="logo-wordmark-omgevings">Omgevings</span>
+      <span class="logo-wordmark-loket">loket</span>
+    </div>
+  </>
+);
 
 @Component({
   tag: "dso-logo",
@@ -7,6 +33,12 @@ import { Component, ComponentInterface, Host, Prop, h } from "@stencil/core";
 })
 export class Logo implements ComponentInterface {
   /**
+   *  The url the logo is pointing to.
+   */
+  @Prop({ reflect: true })
+  logoUrl?: string;
+
+  /**
    * The label clarifies the service within the Omgevingsloket, shown
    * as a subtitle (and on smaller screens as the main wordmark itself).
    */
@@ -14,28 +46,57 @@ export class Logo implements ComponentInterface {
   label?: string;
 
   /**
+   *  The url the label is pointing to.
+   */
+  @Prop({ reflect: true })
+  labelUrl?: string;
+
+  /**
    * The ribbon contains the text for a possible 'sticker' on top of the logo.
    * Used to clarify the (non-production) server environment ("int", "kta", "pfm", "pre", or "dmo")
-   *
    */
   @Prop()
   ribbon?: string;
 
+  /**
+   * Emitted when the logo is clicked (only when logoUrl is set).
+   */
+  @Event()
+  dsoLogoClick!: EventEmitter<LogoClickEvent>;
+
+  /**
+   * Emitted when the label in the logo is clicked (only when labelUrl is set).
+   */
+  @Event()
+  dsoLabelClick!: EventEmitter<LogoLabelClickEvent>;
+
+  private handleLogoClick = (e: MouseEvent) => {
+    this.dsoLogoClick.emit({ originalEvent: e, url: this.logoUrl!, isModifiedEvent: isModifiedEvent(e) });
+  };
+
+  private handleLabelClick = (e: MouseEvent) => {
+    this.dsoLabelClick.emit({ originalEvent: e, url: this.labelUrl!, isModifiedEvent: isModifiedEvent(e) });
+  };
+
   render() {
     return (
       <Host aria-label={["Omgevingsloket", this.label, this.ribbon && `(${this.ribbon})`].filter((s) => !!s).join(" ")}>
-        <svg fill="none" viewBox="0 0 48 48" height="100%" class="logo-target">
-          <path class="outer" d="M26 0a24 24 0 1 0 0 47.9A24 24 0 0 0 24 0Z" />
-          <path class="middle" d="M24 8A16 16 0 0 0 8 24 16 16 0 1 0 24 8Z" />
-          <path class="inner" d="M24 32a8 8 0 0 0 0-16 8 8 0 0 0 0 16Z" />
-        </svg>
+        {this.logoUrl ? (
+          <a href={this.logoUrl} onClick={this.handleLogoClick}>
+            <DsoLogo />
+          </a>
+        ) : (
+          <DsoLogo />
+        )}
 
-        <div class="logo-wordmark">
-          <span class="logo-wordmark-omgevings">Omgevings</span>
-          <span class="logo-wordmark-loket">loket</span>
-        </div>
-
-        {this.label && <span class="logo-label">{this.label}</span>}
+        {this.label &&
+          (!this.labelUrl ? (
+            <span class="logo-label">{this.label}</span>
+          ) : (
+            <a href={this.labelUrl} onClick={this.handleLabelClick}>
+              <span class="logo-label">{this.label}</span>
+            </a>
+          ))}
         {this.ribbon && <div class="logo-ribbon">{this.ribbon}</div>}
       </Host>
     );

--- a/packages/core/src/components/logo/logo.tsx
+++ b/packages/core/src/components/logo/logo.tsx
@@ -55,7 +55,7 @@ export class Logo implements ComponentInterface {
    * The ribbon contains the text for a possible 'sticker' on top of the logo.
    * Used to clarify the (non-production) server environment ("int", "kta", "pfm", "pre", or "dmo")
    */
-  @Prop()
+  @Prop({ reflect: true })
   ribbon?: string;
 
   /**
@@ -82,7 +82,7 @@ export class Logo implements ComponentInterface {
     return (
       <Host aria-label={["Omgevingsloket", this.label, this.ribbon && `(${this.ribbon})`].filter((s) => !!s).join(" ")}>
         {this.logoUrl ? (
-          <a href={this.logoUrl} onClick={this.handleLogoClick}>
+          <a class="logo-url" href={this.logoUrl} onClick={this.handleLogoClick}>
             <DsoLogo />
           </a>
         ) : (
@@ -93,7 +93,7 @@ export class Logo implements ComponentInterface {
           (!this.labelUrl ? (
             <span class="logo-label">{this.label}</span>
           ) : (
-            <a href={this.labelUrl} onClick={this.handleLabelClick}>
+            <a class="logo-label-url" href={this.labelUrl} onClick={this.handleLabelClick}>
               <span class="logo-label">{this.label}</span>
             </a>
           ))}

--- a/packages/core/src/components/logo/readme.md
+++ b/packages/core/src/components/logo/readme.md
@@ -48,10 +48,20 @@ Als er een `label` en/of een `ribbon` worden toegevoegd, worden deze op het comp
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                                                                              | Type                  | Default     |
-| -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | ----------- |
-| `label`  | `label`   | The label clarifies the service within the Omgevingsloket, shown as a subtitle (and on smaller screens as the main wordmark itself).                                     | `string \| undefined` | `undefined` |
-| `ribbon` | `ribbon`  | The ribbon contains the text for a possible 'sticker' on top of the logo. Used to clarify the (non-production) server environment ("int", "kta", "pfm", "pre", or "dmo") | `string \| undefined` | `undefined` |
+| Property   | Attribute   | Description                                                                                                                                                              | Type                  | Default     |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | ----------- |
+| `label`    | `label`     | The label clarifies the service within the Omgevingsloket, shown as a subtitle (and on smaller screens as the main wordmark itself).                                     | `string \| undefined` | `undefined` |
+| `labelUrl` | `label-url` | The url the label is pointing to.                                                                                                                                        | `string \| undefined` | `undefined` |
+| `logoUrl`  | `logo-url`  | The url the logo is pointing to.                                                                                                                                         | `string \| undefined` | `undefined` |
+| `ribbon`   | `ribbon`    | The ribbon contains the text for a possible 'sticker' on top of the logo. Used to clarify the (non-production) server environment ("int", "kta", "pfm", "pre", or "dmo") | `string \| undefined` | `undefined` |
+
+
+## Events
+
+| Event           | Description                                                                | Type                               |
+| --------------- | -------------------------------------------------------------------------- | ---------------------------------- |
+| `dsoLabelClick` | Emitted when the label in the logo is clicked (only when labelUrl is set). | `CustomEvent<LogoLabelClickEvent>` |
+| `dsoLogoClick`  | Emitted when the logo is clicked (only when logoUrl is set).               | `CustomEvent<LogoClickEvent>`      |
 
 
 ----------------------------------------------

--- a/packages/dso-toolkit/src/components/header/header.args.ts
+++ b/packages/dso-toolkit/src/components/header/header.args.ts
@@ -7,6 +7,8 @@ import { Header } from "./header.models.js";
 
 export interface HeaderArgs {
   label: string;
+  labelUrl: string;
+  logoUrl: string;
   ribbon: string;
   mainMenu: {
     label: string;
@@ -29,6 +31,8 @@ export interface HeaderArgs {
 
 export const headerArgTypes: ArgTypes<HeaderArgs> = {
   label: noControl,
+  labelUrl: noControl,
+  logoUrl: noControl,
   ribbon: noControl,
   mainMenu: noControl,
   noMainMenu: {

--- a/packages/dso-toolkit/src/components/header/header.models.ts
+++ b/packages/dso-toolkit/src/components/header/header.models.ts
@@ -1,11 +1,9 @@
 export interface Header {
   label?: string;
+  labelUrl?: string;
+  logoUrl?: string;
   ribbon?: string;
-  mainMenu?: {
-    label: string;
-    url: string;
-    active?: boolean;
-  }[];
+  mainMenu?: HeaderMenuItem[];
   useDropDownMenu?: "always" | "auto";
   authStatus?: "none" | "loggedOut" | "loggedIn";
   loginUrl?: string;

--- a/packages/dso-toolkit/src/components/header/header.stories-of.ts
+++ b/packages/dso-toolkit/src/components/header/header.stories-of.ts
@@ -12,6 +12,8 @@ type HeaderStory = StoryObj<HeaderArgs, Renderer>;
 interface HeaderStories {
   Default: HeaderStory;
   WithLabel: HeaderStory;
+  WithLabelAndLabelUrl: HeaderStory;
+  WithLogoUrlAndLabelAndLabelUrl: HeaderStory;
   WithRibbon: HeaderStory;
   WithLabelAndRibbon: HeaderStory;
   UserHomeActive: HeaderStory;
@@ -92,6 +94,25 @@ export function headerStories<Implementation, Templates, TemplateFnReturnType>({
     WithLabel: {
       args: {
         label: "Maatregelen op maat",
+      },
+      render: templateContainer.render(storyTemplates, (args, { headerTemplate }) =>
+        headerTemplate(headerArgsMapper(args)),
+      ),
+    },
+    WithLabelAndLabelUrl: {
+      args: {
+        label: "Maatregelen op maat",
+        labelUrl: "maatregelen-op-maat",
+      },
+      render: templateContainer.render(storyTemplates, (args, { headerTemplate }) =>
+        headerTemplate(headerArgsMapper(args)),
+      ),
+    },
+    WithLogoUrlAndLabelAndLabelUrl: {
+      args: {
+        label: "Maatregelen op maat",
+        labelUrl: "maatregelen-op-maat",
+        logoUrl: "/",
       },
       render: templateContainer.render(storyTemplates, (args, { headerTemplate }) =>
         headerTemplate(headerArgsMapper(args)),

--- a/packages/dso-toolkit/src/components/logo/logo.args.ts
+++ b/packages/dso-toolkit/src/components/logo/logo.args.ts
@@ -1,10 +1,16 @@
 import { Logo } from "./logo.models.js";
 
 import { ArgTypes } from "@storybook/types";
+import { noControl } from "../../storybook";
+import { HandlerFunction } from "@storybook/addon-actions";
 
 export interface LogoArgs {
   label?: string;
+  labelUrl?: string;
+  logoUrl?: string;
   ribbon?: string;
+  dsoLabelClick?: HandlerFunction;
+  dsoLogoClick?: HandlerFunction;
 }
 
 export const logoArgTypes: ArgTypes<LogoArgs> = {
@@ -13,16 +19,36 @@ export const logoArgTypes: ArgTypes<LogoArgs> = {
       type: "text",
     },
   },
+  labelUrl: noControl,
+  logoUrl: noControl,
   ribbon: {
     control: {
       type: "text",
     },
+  },
+  dsoLogoClick: {
+    ...noControl,
+    action: "dsoLogoClick",
+  },
+  dsoLabelClick: {
+    ...noControl,
+    action: "dsoLogoLabelClick",
   },
 };
 
 export function logoArgsMapper(a: LogoArgs): Logo {
   return {
     label: a.label,
+    labelUrl: a.labelUrl,
+    logoUrl: a.logoUrl,
     ribbon: a.ribbon,
+    dsoLogoClick: (event) => {
+      event.detail.originalEvent.preventDefault();
+      a.dsoLogoClick?.(event);
+    },
+    dsoLabelClick: (event) => {
+      event.detail.originalEvent.preventDefault();
+      a.dsoLabelClick?.(event);
+    },
   };
 }

--- a/packages/dso-toolkit/src/components/logo/logo.stories-of.ts
+++ b/packages/dso-toolkit/src/components/logo/logo.stories-of.ts
@@ -17,19 +17,37 @@ export function storiesOfLogo<Implementation, Templates, TemplateFnReturnType>(
 ) {
   return storiesOfFactory("Logo", storiesOfArguments, (stories, templateMapper) => {
     stories.addParameters({
-      argTypes: {
-        logoArgTypes,
-      },
-      args: {},
+      argTypes: logoArgTypes,
     });
 
     const template = templateMapper<LogoArgs>((args, { logoTemplate }) => logoTemplate(logoArgsMapper(args)));
 
     stories.add("default", template);
 
+    stories.add("with logoUrl", template, {
+      args: {
+        logoUrl: "/",
+      },
+    });
+
     stories.add("with label", template, {
       args: {
         label: "Regels op de kaart",
+      },
+    });
+
+    stories.add("with label and labelUrl", template, {
+      args: {
+        label: "Regels op de kaart",
+        labelUrl: "regels-op-de-kaart",
+      },
+    });
+
+    stories.add("with logoUrl and label and labelUrl", template, {
+      args: {
+        label: "Regels op de kaart",
+        labelUrl: "regels-op-de-kaart",
+        logoUrl: "/",
       },
     });
 

--- a/storybook/cypress/e2e/logo.cy.ts
+++ b/storybook/cypress/e2e/logo.cy.ts
@@ -15,6 +15,134 @@ describe("Logo", () => {
     cy.checkA11y("dso-logo");
   });
 
+  it("should have an anchor surrounding the logo and the logo-wordmark", () => {
+    cy.get("dso-logo")
+      .invoke("prop", "logoUrl", "/")
+      .should("have.attr", "logo-url", "/")
+      .then(($logo) => {
+        $logo.on("dsoLogoClick", ($event) => $event.detail.originalEvent.preventDefault());
+        $logo.on("dsoLogoClick", cy.stub().as("logoClickListener"));
+      })
+      .shadow()
+      .find("a[href='/']")
+      .as("logoAnchor")
+      .click()
+      .get("@logoClickListener")
+      .its("callCount")
+      .should("equal", 1)
+      .get("@logoClickListener")
+      .invoke("getCall", "0")
+      .its("args.0.detail")
+      .should("deep.contain", { url: "/", isModifiedEvent: false })
+      // Ctrl
+      .get("@logoAnchor")
+      .click({ ctrlKey: true })
+      .get("@logoClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Command
+      .get("@logoAnchor")
+      .click({ commandKey: true })
+      .get("@logoClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Shift
+      .get("@logoAnchor")
+      .click({ shiftKey: true })
+      .get("@logoClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Alt
+      .get("@logoAnchor")
+      .click({ altKey: true })
+      .get("@logoClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Right Click
+      .get("@logoAnchor")
+      .rightclick()
+      .get("@logoClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true);
+    cy.injectAxe();
+    cy.checkA11y("dso-logo");
+  });
+
+  it("should have an anchor surrounding the label", () => {
+    cy.get("dso-logo")
+      .invoke("prop", "label", "Regels op de kaart")
+      .invoke("prop", "labelUrl", "regels-op-de-kaart")
+      .should("have.attr", "label", "Regels op de kaart")
+      .and("have.attr", "label-url", "regels-op-de-kaart")
+      .then(($logo) => {
+        $logo.on("dsoLabelClick", ($event) => $event.detail.originalEvent.preventDefault());
+        $logo.on("dsoLabelClick", cy.stub().as("labelClickListener"));
+      })
+      .shadow()
+      .find("a[href='regels-op-de-kaart']")
+      .as("labelAnchor")
+      .click()
+      .get("@labelClickListener")
+      .its("callCount")
+      .should("equal", 1)
+      .get("@labelClickListener")
+      .invoke("getCall", "0")
+      .its("args.0.detail")
+      .should("deep.contains", { url: "regels-op-de-kaart", isModifiedEvent: false })
+      // Ctrl
+      .get("@labelAnchor")
+      .click({ ctrlKey: true })
+      .get("@labelClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Command
+      .get("@labelAnchor")
+      .click({ commandKey: true })
+      .get("@labelClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Shift
+      .get("@labelAnchor")
+      .click({ shiftKey: true })
+      .get("@labelClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Alt
+      .get("@labelAnchor")
+      .click({ altKey: true })
+      .get("@labelClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true)
+      // Right Click
+      .get("@labelAnchor")
+      .rightclick()
+      .get("@labelClickListener")
+      .invoke("getCalls")
+      .invoke("at", -1)
+      .its("args.0.detail.isModifiedEvent")
+      .should("equal", true);
+    cy.injectAxe();
+    cy.checkA11y("dso-logo");
+  });
+
   it("shows a label and logo-wordmark on screens wider than 767px", () => {
     cy.get("dso-logo")
       .invoke("prop", "label", "Beheerportaal")

--- a/storybook/src/components/header/header.core-stories.ts
+++ b/storybook/src/components/header/header.core-stories.ts
@@ -12,16 +12,35 @@ const meta: Meta<HeaderArgs> = {
 
 export default meta;
 
-const { Default, WithLabel, WithRibbon, WithLabelAndRibbon, UserHomeActive, WithLinkToHelp, WithButtonToHelp } =
-  headerStories({
-    templateContainer,
-    storyTemplates: (templates) => {
-      const { headerTemplate } = templates;
+const {
+  Default,
+  WithLabel,
+  WithLabelAndLabelUrl,
+  WithLogoUrlAndLabelAndLabelUrl,
+  WithRibbon,
+  WithLabelAndRibbon,
+  UserHomeActive,
+  WithLinkToHelp,
+  WithButtonToHelp,
+} = headerStories({
+  templateContainer,
+  storyTemplates: (templates) => {
+    const { headerTemplate } = templates;
 
-      return {
-        headerTemplate,
-      };
-    },
-  });
+    return {
+      headerTemplate,
+    };
+  },
+});
 
-export { Default, WithLabel, WithRibbon, WithLabelAndRibbon, UserHomeActive, WithLinkToHelp, WithButtonToHelp };
+export {
+  Default,
+  WithLabel,
+  WithLabelAndLabelUrl,
+  WithLogoUrlAndLabelAndLabelUrl,
+  WithRibbon,
+  WithLabelAndRibbon,
+  UserHomeActive,
+  WithLinkToHelp,
+  WithButtonToHelp,
+};

--- a/storybook/src/components/header/header.core-template.ts
+++ b/storybook/src/components/header/header.core-template.ts
@@ -9,6 +9,8 @@ export const coreHeader: ComponentImplementation<Header> = {
   template: ({ logoTemplate }) =>
     function headerTemplate({
       label,
+      labelUrl,
+      logoUrl,
       ribbon,
       mainMenu,
       useDropDownMenu,
@@ -37,7 +39,7 @@ export const coreHeader: ComponentImplementation<Header> = {
         user-home-active=${ifDefined(userHomeActive)}
         @dsoHeaderClick=${dsoHeaderClick}
       >
-        <div slot="logo">${logoTemplate({ label, ribbon })}</div>
+        <div slot="logo">${logoTemplate({ label, ribbon, labelUrl, logoUrl })}</div>
       </dso-header>`;
     },
 };

--- a/storybook/src/components/logo/logo.core-template.ts
+++ b/storybook/src/components/logo/logo.core-template.ts
@@ -7,7 +7,14 @@ export const coreLogo: ComponentImplementation<Logo> = {
   component: "logo",
   implementation: "core",
   template: () =>
-    function logoTemplate({ label, ribbon }) {
-      return html`<dso-logo .label=${ifDefined(label)} ribbon=${ifDefined(ribbon)}></dso-logo>`;
+    function logoTemplate({ label, ribbon, labelUrl, logoUrl, dsoLogoClick, dsoLabelClick }) {
+      return html`<dso-logo
+        .label=${ifDefined(label)}
+        .labelUrl=${ifDefined(labelUrl)}
+        .logoUrl=${ifDefined(logoUrl)}
+        ribbon=${ifDefined(ribbon)}
+        @dsoLogoClick=${ifDefined(dsoLogoClick)}
+        @dsoLabelClick=${ifDefined(dsoLabelClick)}
+      ></dso-logo>`;
     },
 };

--- a/website/blog/2024-05-14-dso-toolkit-62.22.0.mdx
+++ b/website/blog/2024-05-14-dso-toolkit-62.22.0.mdx
@@ -1,0 +1,40 @@
+---
+authors: [iterox]
+---
+
+# DSO Toolkit v62.22.0 🐸
+
+In deze release zijn twee nieuwe features aan het Logo component toegevoegd, die op zich niet breaking zijn, maar toch een toelichting behoeven.
+
+## Logo
+
+Voorheen kon een afnemer van het Logo component een anchor om het Logo component plaatsen om zo routering binnen de afnemende applicatie te faciliteren.
+
+Markup voor deze situatie ziet er ongeveer zo uit:
+
+```html
+<a href="/">
+  <dso-logo label="Regels op de kaart"></dso-logo>
+</a>
+```
+
+In deze release is het Logo component uitgebreid met 2 nieuwe properties: `logoUrl` en `labelUrl`.
+
+### logoUrl
+
+Indien de afnemer aan het Logo component de property `logoUrl` meegeeft, dan zal het Logo component een anchor met href zetten rondom het beeldmerk en het woordmerk.
+Wanneer een gebruiker deze link aanklikt dan zal het Logo component het custom event `dsoLogoClick` uitsturen.
+
+### labelUrl
+
+Indien de afnemer aan het Logo component de property `labelUrl` meegeeft, dan zal het Logo component een anchor met href zetten rondom het label.
+Voorwaarde is dan ook dat de property `label` is gezet. De property `labelUrl` zonder property `label` zal door het Logo component worden genegereerd.
+Wanneer een gebruiker deze link aanklikt dan zal het Logo component het custom event `dsoLabelClick` uitsturen.
+
+De markup voor deze nieuwe mogelijkheden van het Logo component ziet er zo uit:
+
+```html
+  <dso-logo logo-url="/" label="Regels op de kaart" label-url="regels-op-de-kaart"></dso-logo>
+```
+
+Bekijk de nieuwe mogelijkheden in de storybook van het Logo component: https://storybook.dso-toolkit.nl/master/?path=/story/core-logo--with-logourl-and-label-and-labelurl

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -13,3 +13,8 @@ hansgrimm:
   title: DSO Toolkit Maintainer
   url: https://github.com/hansgrimm
   image_url: https://github.com/hansgrimm.png
+iterox:
+  name: Eric Tamminga
+  title: DSO Toolkit Maintainer
+  url: https://github.com/iterox
+  image_url: https://github.com/iterox.png


### PR DESCRIPTION
Heb deze PR klaar gezet, zodat de fixes voor de verkeerde uitlijning van de ribbon en de blog post over de nieuwe mogelijkheden van het Logo component.

Dienen we de issue trouwens niet te hernoemen?

Nu: `Header: Aparte link voor applicatienaam in compacte header`

Voorstel: `Logo: Aparte link voor applicatienaam`