### PR TITLE
#2658 [Fixed] Tooltip: Long words overflow box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Tooltip: Long words overflow box ([#2658](https://github.com/dso-toolkit/dso-toolkit/issues/2658))
+
 ## 🐸 62.22.0 - 15-05-2024
 
 ### Added

--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -25,7 +25,7 @@
   text-shadow: none;
   text-transform: none;
   letter-spacing: normal;
-  word-break: normal;
+  word-break: break-word;
   word-spacing: normal;
   word-wrap: normal;
   white-space: normal;


### PR DESCRIPTION
word-break set to break-word