### PR TITLE
#2806 [Fixed] Mark Bar: Pointer on empty field button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Mark Bar: Pointer on empty field button ([#2806](https://github.com/dso-toolkit/dso-toolkit/issues/2806))
+
 ### Tasks
 * Sass: Deprecation warning mixed declarations ([#2724](https://github.com/dso-toolkit/dso-toolkit/issues/2724))
 * Packages: Dependencies updates ([#2783](https://github.com/dso-toolkit/dso-toolkit/issues/2783))

--- a/packages/core/src/components/mark-bar/mark-bar.scss
+++ b/packages/core/src/components/mark-bar/mark-bar.scss
@@ -114,6 +114,7 @@ $focus-border-width: 1px;
       text-align: center;
       inset-block-start: 0;
       inline-size: $block-size;
+      cursor: pointer;
     }
   }
 }
@@ -139,9 +140,11 @@ $focus-border-width: 1px;
     border: 0;
     background-color: transparent;
     color: colors.$grasgroen;
+    cursor: pointer;
 
     &:disabled {
       color: colors.$grijs-20;
+      cursor: default;
     }
   }
 


### PR DESCRIPTION
`cursor: pointer` on *all* buttons within Mark Bar 