### PR TITLE
#2424 [Fixed] Webfont Asap: Strikethrough in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Webfont Asap: Strikethrough in Firefox ([#2424](https://github.com/dso-toolkit/dso-toolkit/issues/2424))
+
 ## 🍫 Release 66.1.0 - 2024-10-28
 
 ### Fixed

--- a/packages/dso-toolkit/src/components/delete/delete.mixins.scss
+++ b/packages/dso-toolkit/src/components/delete/delete.mixins.scss
@@ -6,5 +6,10 @@
 
   & {
     text-decoration: line-through;
+    // stylelint-disable media-feature-name-no-unknown -- counter line-through displaying as underline in firefox
+    // http://browserhacks.com/#hack-48ca6fc2947b7850c571a2f69bdbffbd
+    @media screen and (min--moz-device-pixel-ratio: 0) {
+      font-family: sans-serif;
+    }
   }
 }


### PR DESCRIPTION
Added browser-hack targeting Firefox, replacing font in `<del>` element.