### PR TITLE
#2828 card  internalize webcomponent styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Document Component: type "inhoudsopgave" ([#2271](https://github.com/dso-toolkit/dso-toolkit/issues/2271))
 * Accordion: Ondersteuning voor renvooi en wijzigactie ([#2857](https://github.com/dso-toolkit/dso-toolkit/issues/2857))
 
+### Tasks
+* Card: Internalize webcomponent styling ([#2828](https://github.com/dso-toolkit/dso-toolkit/issues/2828))
+
 ## ✍️ Release 67.0.0 - 2024-11-25
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Task
 * Responsive-element: e2e test schrijven ([#2692](https://github.com/dso-toolkit/dso-toolkit/issues/2692))
+* Card: Internalize webcomponent styling ([#2828](https://github.com/dso-toolkit/dso-toolkit/issues/2828))
 
 ## 📜 Release 67.1.0 - 2024-12-06
 
@@ -22,9 +23,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Document Component: Wijzigactie voor kenmerkenpaneel ([#2905](https://github.com/dso-toolkit/dso-toolkit/issues/2905))
 * Document Component: type "inhoudsopgave" ([#2271](https://github.com/dso-toolkit/dso-toolkit/issues/2271))
 * Accordion: Ondersteuning voor renvooi en wijzigactie ([#2857](https://github.com/dso-toolkit/dso-toolkit/issues/2857))
-
-### Task
-* Card: Internalize webcomponent styling ([#2828](https://github.com/dso-toolkit/dso-toolkit/issues/2828))
 
 ## ✍️ Release 67.0.0 - 2024-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Document Component: type "inhoudsopgave" ([#2271](https://github.com/dso-toolkit/dso-toolkit/issues/2271))
 * Accordion: Ondersteuning voor renvooi en wijzigactie ([#2857](https://github.com/dso-toolkit/dso-toolkit/issues/2857))
 
-### Tasks
+### Task
 * Card: Internalize webcomponent styling ([#2828](https://github.com/dso-toolkit/dso-toolkit/issues/2828))
 
 ## ✍️ Release 67.0.0 - 2024-11-25

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -46,10 +46,13 @@
   .dso-card-heading {
     align-items: center;
     display: flex;
-    margin-block-end: units.$u1;
 
     @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
       flex-wrap: wrap;
+    }
+
+    + .dso-card-content {
+      margin-block-start: units.$u1;
     }
   }
 }

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -82,14 +82,6 @@
   }
 }
 
-.dso-card-heading a {
-  text-decoration: none;
-
-  dso-icon:last-child {
-    align-self: flex-start;
-  }
-}
-
 ::slotted([slot="selectable"]) {
   font-size: 0 !important;
 }
@@ -113,8 +105,7 @@
   --_dt-rich-content-margin-block-start: 0;
 }
 
-::slotted([slot="interactions"]),
-::slotted([slot="interaction"]) {
+::slotted([slot="interactions"]) {
   display: flex !important;
   justify-content: space-between !important;
   margin-inline-start: auto !important;

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -78,3 +78,46 @@
     @include utilities.sr-only();
   }
 }
+
+.dso-card-heading a {
+  text-decoration: none;
+
+  dso-icon:last-child {
+    align-self: flex-start;
+  }
+}
+
+::slotted([slot="selectable"]) {
+  font-size: 0 !important;
+}
+
+::slotted([slot="heading"]) {
+  display: flex !important;
+  align-items: center !important;
+
+  margin-block-end: 0 !important;
+  margin-block-start: 0 !important;
+
+  font-size: 1.125em !important;
+  font-weight: 700 !important;
+  color: colors.$bosgroen !important;
+  line-height: 1.25 !important;
+}
+
+::slotted([slot="content"]) {
+  --_dt-rich-content-margin-block: #{units.$u1};
+  --_dt-rich-content-margin-block-end: 0;
+  --_dt-rich-content-margin-block-start: 0;
+}
+
+::slotted([slot="interactions"]),
+::slotted([slot="interaction"]) {
+  display: flex !important;
+  justify-content: space-between !important;
+  margin-inline-start: auto !important;
+
+  @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
+    flex-basis: 100% !important;
+    margin-block-start: units.$u2 !important;
+  }
+}

--- a/packages/core/src/components/document-card/document-card.scss
+++ b/packages/core/src/components/document-card/document-card.scss
@@ -1,6 +1,7 @@
 @use "~dso-toolkit/src/utilities";
 @use "~dso-toolkit/src/variables/media-query-breakpoints";
 @use "~dso-toolkit/src/variables/units";
+@use "~dso-toolkit/src/variables/colors";
 @use "~dso-toolkit/src/components/document-card";
 
 @include utilities.box-sizing();
@@ -47,9 +48,12 @@
 }
 
 ::slotted([slot="heading"]) {
-  align-items: center !important;
   display: flex !important;
+  align-items: center !important;
+  color: colors.$bosgroen !important;
   font-size: 1.125em !important;
+  font-weight: 700 !important;
+  line-height: 1.25 !important;
   margin-block-end: 0 !important;
   margin-block-start: 0 !important;
 }

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.scss
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.scss
@@ -96,6 +96,10 @@ del.dso-plekinfo-card-container {
   align-items: center !important;
   display: flex !important;
   font-size: 1.125em !important;
+  font-weight: 700 !important;
+  color: colors.$bosgroen !important;
+  line-height: 1.25 !important;
+
   margin-block-end: 0 !important;
   margin-block-start: 0 !important;
 }

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.scss
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.scss
@@ -112,7 +112,6 @@ del.dso-plekinfo-card-container {
   --_dt-rich-content-margin-block-start: 0;
 }
 
-::slotted([slot="interactions"]),
 ::slotted([slot="interaction"]) {
   display: flex !important;
   justify-content: space-between !important;

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.scss
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.scss
@@ -106,6 +106,18 @@ del.dso-plekinfo-card-container {
   --_dt-rich-content-margin-block-start: 0;
 }
 
+::slotted([slot="interactions"]),
+::slotted([slot="interaction"]) {
+  display: flex !important;
+  justify-content: space-between !important;
+  margin-inline-start: auto !important;
+
+  @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
+    flex-basis: 100% !important;
+    margin-block-start: units.$u2 !important;
+  }
+}
+
 .heading-anchor {
   display: flex;
   flex-wrap: nowrap;

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.scss
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.scss
@@ -2,6 +2,7 @@
 @use "~dso-toolkit/src/variables/media-query-breakpoints";
 @use "~dso-toolkit/src/variables/units";
 @use "~dso-toolkit/src/components/plekinfo-card";
+@use "~dso-toolkit/src/variables/colors";
 
 @use "~dso-toolkit/src/components/insert/insert";
 @use "~dso-toolkit/src/components/delete/delete";
@@ -93,8 +94,9 @@ del.dso-plekinfo-card-container {
 }
 
 ::slotted([slot="heading"]) {
-  align-items: center !important;
   display: flex !important;
+  align-items: center !important;
+
   font-size: 1.125em !important;
   font-weight: 700 !important;
   color: colors.$bosgroen !important;

--- a/packages/dso-toolkit/src/components/card/card.scss
+++ b/packages/dso-toolkit/src/components/card/card.scss
@@ -142,9 +142,7 @@ dso-card {
   }
 }
 
-.dso-card-interactions,
-[slot="interactions"],
-[slot="interaction"] {
+.dso-card-interactions {
   display: flex;
   justify-content: space-between;
   margin-inline-start: auto;

--- a/packages/dso-toolkit/src/components/card/card.scss
+++ b/packages/dso-toolkit/src/components/card/card.scss
@@ -45,47 +45,6 @@
   }
 }
 
-dso-card {
-  .dso-card-heading a {
-    text-decoration: none;
-
-    dso-icon:last-child {
-      align-self: flex-start;
-    }
-  }
-
-  h2[slot="heading"],
-  h3[slot="heading"],
-  h4[slot="heading"],
-  h5[slot="heading"] {
-    font-size: 1.125em;
-    margin-block-end: 0;
-    margin-block-start: 0;
-
-    span {
-      margin-inline-end: units.$u1 * 0.5;
-
-      + dso-icon,
-      + svg.di {
-        flex-shrink: 0;
-        position: relative;
-      }
-    }
-  }
-
-  div[slot="content"] {
-    --_dt-rich-content-margin-block: #{units.$u1};
-    --_dt-rich-content-margin-block-end: 0;
-    --_dt-rich-content-margin-block-start: 0;
-  }
-
-  dso-selectable {
-    label {
-      font-size: 0;
-    }
-  }
-}
-
 .dso-card-container {
   padding-block: units.$u2;
   padding-inline: units.$u2;

--- a/packages/dso-toolkit/src/components/card/card.scss
+++ b/packages/dso-toolkit/src/components/card/card.scss
@@ -43,85 +43,85 @@
       font-size: 0;
     }
   }
-}
 
-.dso-card-container {
-  padding-block: units.$u2;
-  padding-inline: units.$u2;
-  inline-size: 100%;
+  .dso-card-container {
+    padding-block: units.$u2;
+    padding-inline: units.$u2;
+    inline-size: 100%;
 
-  &.dso-card-active {
-    background-color: card-variables.$background-color-active;
+    &.dso-card-active {
+      background-color: card-variables.$background-color-active;
+    }
+
+    .dso-card-selectable {
+      grid-row: span 2;
+    }
   }
 
-  .dso-card-selectable {
-    grid-row: span 2;
-  }
-}
-
-.dso-card-heading {
-  align-items: center;
-  display: flex;
-  margin-block-end: units.$u1;
-
-  h2:first-child,
-  h3:first-child,
-  h4:first-child,
-  h5:first-child {
+  .dso-card-heading {
     align-items: center;
     display: flex;
-    font-size: 1.125em;
-    margin-block-end: 0;
-    margin-block-start: 0;
+    margin-block-end: units.$u1;
 
-    span {
-      margin-inline-end: units.$u1 * 0.5;
+    h2:first-child,
+    h3:first-child,
+    h4:first-child,
+    h5:first-child {
+      align-items: center;
+      display: flex;
+      font-size: 1.125em;
+      margin-block-end: 0;
+      margin-block-start: 0;
 
-      + dso-icon,
-      + svg.di {
-        flex-shrink: 0;
-        position: relative;
+      span {
+        margin-inline-end: units.$u1 * 0.5;
+
+        + dso-icon,
+        + svg.di {
+          flex-shrink: 0;
+          position: relative;
+        }
       }
     }
-  }
 
-  a {
-    text-decoration: none;
+    a {
+      text-decoration: none;
 
-    &,
-    &#{button.$not-dso-buttons}:visited,
-    &:active,
-    &:focus-visible {
-      color: card-variables.$heading-anchor-color;
+      &,
+      &#{button.$not-dso-buttons}:visited,
+      &:active,
+      &:focus-visible {
+        color: card-variables.$heading-anchor-color;
+      }
+    }
+
+    @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
+      flex-wrap: wrap;
     }
   }
 
-  @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
-    flex-wrap: wrap;
-  }
-}
-
-.dso-card-interactions {
-  display: flex;
-  justify-content: space-between;
-  margin-inline-start: auto;
-
-  .dso-card-interaction {
-    align-items: center;
+  .dso-card-interactions {
     display: flex;
-    text-align: center;
+    justify-content: space-between;
+    margin-inline-start: auto;
 
-    p {
-      margin-block-end: 0;
+    .dso-card-interaction {
+      align-items: center;
+      display: flex;
+      text-align: center;
+
+      p {
+        margin-block-end: 0;
+      }
     }
-  }
 
-  .dso-info-button {
-    margin: 0;
-  }
+    .dso-info-button {
+      margin: 0;
+    }
 
-  @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
-    flex-basis: 100%;
-    margin-block-start: units.$u2;
+    @media screen and (max-width: media-query-breakpoints.$screen-xs-min) {
+      flex-basis: 100%;
+      margin-block-start: units.$u2;
+    }
   }
 }

--- a/packages/react/src/components/card/card.react-template.tsx
+++ b/packages/react/src/components/card/card.react-template.tsx
@@ -27,7 +27,7 @@ export const reactCard: ComponentImplementation<Card<JSX.Element>> = {
             <span id="card-title">{label}</span>
           </h2>
           {interactions && interactions.length > 0 && (
-            <div slot="interactions" className="dso-card-interactions">
+            <div slot="interactions">
               {interactions.map((interaction, index) => (
                 <div key={index} className="dso-card-interaction">
                   {isButtonInterface(interaction) && (


### PR DESCRIPTION
Bijvoorbeeld r111-123 in [packages/dso-toolkit/src/components/card/card.scss](https://github.com/dso-toolkit/dso-toolkit/compare/%232828-card--internalize-webcomponent-styling?expand=1#diff-eb00d0066a2c1cfd6f6d880acecbfc5b1a11b7a07373bfbb7282f70026a6dcf3) zullen nooit werken vanuit `::slotted` binnen een constructed stylesheet.

Update 28/29-11: ^^ uit de 'light dom'-scss de `[slot="interaction"]` en `[slot="interactions"]` selectors verwijderd, omdat ze op die plek zonder prefix een te groot conflictrisico vormden. zonder die css blijft de core-versie vooralsnog overeind.