### PR TITLE
#2955 [Fixed] Icon mixins: Spritesheet di.svg niet beschikbaar in dso-toolkit package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Icon Mixins: Spritesheet di.svg niet beschikbaar in dso-toolkit package ([#2955](https://github.com/dso-toolkit/dso-toolkit/issues/2955))
+
 ## 🛝 Release 67.3.0 - 2025-01-13
 
 ### Fixed

--- a/packages/dso-toolkit/package.json
+++ b/packages/dso-toolkit/package.json
@@ -9,6 +9,7 @@
   "files": [
     "assets",
     "dist/dso-icons.svg",
+    "dist/di.svg",
     "dist/*.css",
     "dist/*.map",
     "src/**/*.scss",


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [ ] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [ ] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
