### PR TITLE
#2925 [Fixed] Annotation (Activiteit): Lange tekst component drukt Slide Toggle weg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Annotation (Activiteit): Lange tekst component drukt Slide Toggle weg ([#2925](https://github.com/dso-toolkit/dso-toolkit/issues/2925))
+
 ## ⚖️ Release 68.0.0 - 2025-01-20
 
 ### Added
@@ -13,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * **BREAKING** List Button: Het wijzigen van het aantal met plus/min knoppen is ontoegankelijk ([#2555](https://github.com/dso-toolkit/dso-toolkit/issues/2555))
+
 
 ## 👕 Release 67.3.2 - 2025-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * **BREAKING** List Button: Het wijzigen van het aantal met plus/min knoppen is ontoegankelijk ([#2555](https://github.com/dso-toolkit/dso-toolkit/issues/2555))
 
-
 ## 👕 Release 67.3.2 - 2025-01-16
 
 ### Docs

--- a/packages/core/src/components/annotation/annotation.scss
+++ b/packages/core/src/components/annotation/annotation.scss
@@ -37,6 +37,7 @@
 
 .annotation-title {
   font-weight: 500;
+  word-break: break-word;
 }
 
 .annotation-title,


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
