### PR TITLE
#2929 [Changed] Document Component: Tooltip bij Ontwerp wijzigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Document Component: Tooltip bij Ontwerp wijzigen ([#2929](https://github.com/dso-toolkit/dso-toolkit/issues/2929))
+
 ## 🛢️ Release 68.2.0 - 2025-02-04
 
 ### Added

--- a/packages/core/src/components/document-component/document-component.tsx
+++ b/packages/core/src/components/document-component/document-component.tsx
@@ -362,7 +362,9 @@ export class DocumentComponent implements ComponentInterface {
                   <dso-badge status="warning" aria-describedby="nested-draft-description">
                     !
                   </dso-badge>
-                  <dso-tooltip id="nested-draft-description">Er is een ontwerp beschikbaar.</dso-tooltip>
+                  <dso-tooltip id="nested-draft-description">
+                    Er zijn onderliggende onderdelen die veranderen binnen dit ontwerp.
+                  </dso-tooltip>
                 </>
               )}
               {(this.bevatOntwerpInformatie || this.annotated) && (

--- a/storybook/cypress/e2e/document-component.cy.ts
+++ b/storybook/cypress/e2e/document-component.cy.ts
@@ -22,6 +22,20 @@ describe("Document Component", () => {
       ]);
   });
 
+  it("shows a badge with an exclamationmark with tooltip", () => {
+    cy.visit("http://localhost:45000/iframe.html?id=core-document-component--default")
+      .get("dso-document-component")
+      .invoke("attr", "geneste-ontwerp-informatie", true)
+      .invoke("attr", "bevat-ontwerp-informatie", false)
+      .shadow()
+      .as("dsoDocumentComponent")
+      .find("dso-badge[aria-describedby='nested-draft-description'].hydrated")
+      .should("have.text", "!")
+      .get("@dsoDocumentComponent")
+      .find("dso-tooltip#nested-draft-description.hydrated")
+      .should("have.text", "Er zijn onderliggende onderdelen die veranderen binnen dit ontwerp.");
+  });
+
   const states = ["default", "voegtoe", "verwijder"];
 
   for (const wijzigactie of states) {


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
