### PR TITLE
#2926 [Changed] Ozon Content: Selectie kopieren naar klembord zonder sr-only teksten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * Document Component: Tooltip bij Ontwerp wijzigen ([#2929](https://github.com/dso-toolkit/dso-toolkit/issues/2929))
+* Ozon Content: Selectie kopieren naar klembord zonder sr-only teksten ([#2926](https://github.com/dso-toolkit/dso-toolkit/issues/2926))
 
 ### Fixed
 * Tooltip: Exceptie bij unmounten ([#2997](https://github.com/dso-toolkit/dso-toolkit/issues/2997))

--- a/packages/core/src/components/ozon-content/nodes/ext-ref.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/ext-ref.node.tsx
@@ -12,8 +12,14 @@ export class OzonContentExtRefNode implements OzonContentNode {
     const className = kebabCase(node.tagName);
 
     return (
-      <a target="_blank" rel="noopener noreferrer" href={href ?? undefined} class={className}>
-        {mapNodeToJsx(node.childNodes)} <span class="sr-only">(Opent andere website in nieuw tabblad)</span>
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href={href ?? undefined}
+        class={className}
+        title="Opent andere website in nieuw tabblad"
+      >
+        {mapNodeToJsx(node.childNodes)}
         <dso-icon icon="external-link"></dso-icon>
       </a>
     );

--- a/packages/core/src/components/ozon-content/nodes/ext-ref.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/ext-ref.node.tsx
@@ -19,7 +19,7 @@ export class OzonContentExtRefNode implements OzonContentNode {
         class={className}
         title="Opent andere website in nieuw tabblad"
       >
-        {mapNodeToJsx(node.childNodes)}
+        <span>{mapNodeToJsx(node.childNodes)}</span>
         <dso-icon icon="external-link"></dso-icon>
       </a>
     );

--- a/packages/core/src/components/ozon-content/ozon-content.scss
+++ b/packages/core/src/components/ozon-content/ozon-content.scss
@@ -1,5 +1,3 @@
-@use "~dso-toolkit/src/utilities";
-
 @use "~dso-toolkit/src/variables/units";
 @use "~dso-toolkit/src/variables/colors";
 
@@ -21,10 +19,6 @@
 
 :host([inline]) {
   display: inline;
-}
-
-.sr-only {
-  @include utilities.sr-only();
 }
 
 button.toggle-note {

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -202,7 +202,7 @@ describe("Ozon Content", () => {
     cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
   });
 
-  it("should render ExtRef element", () => {
+  it.only("should render ExtRef element", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--al");
 
     cy.get("dso-ozon-content").then((c) => {
@@ -213,8 +213,7 @@ describe("Ozon Content", () => {
       .shadow()
       .find("a[href='doc'][target='_blank'][rel='noopener noreferrer']")
       .should("have.text", "document")
-      .should("have.attr", "title")
-      .and("include", "Opent andere website in nieuw tabblad");
+      .and("have.attr", "title", "Opent andere website in nieuw tabblad");
 
     cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
   });

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -212,8 +212,9 @@ describe("Ozon Content", () => {
     cy.get("dso-ozon-content")
       .shadow()
       .find("a[href='doc'][target='_blank'][rel='noopener noreferrer']")
-      .should("exist")
-      .and("have.text", "document (Opent andere website in nieuw tabblad)");
+      .and("have.text", "document")
+      .should("have.attr", "title")
+      .and("include", "Opent andere website in nieuw tabblad");
 
     cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
   });
@@ -233,10 +234,7 @@ describe("Ozon Content", () => {
         "href",
         "https://identifier-eto.overheid.nl//join/id/regdata/pv25/2021/OKBebouwdEenOpHonderdWRIJ/nld@2021-11-14;1",
       )
-      .and(
-        "have.text",
-        "/join/id/regdata/pv25/2021/OKBebouwdEenOpHonderdWRIJ/nld@2021-11-14;1 (Opent andere website in nieuw tabblad)",
-      );
+      .and("have.text", "/join/id/regdata/pv25/2021/OKBebouwdEenOpHonderdWRIJ/nld@2021-11-14;1");
 
     cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
   });
@@ -493,7 +491,7 @@ describe("Ozon Content", () => {
       .shadow()
       .find("dso-table > div > .dso-ozon-bron")
       .should("exist")
-      .and("have.text", "bron: artikel 4.7 van de wet (Opent andere website in nieuw tabblad)");
+      .and("have.text", "bron: artikel 4.7 van de wet");
   });
 
   it("should accept XMLDocument", () => {

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -202,7 +202,7 @@ describe("Ozon Content", () => {
     cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
   });
 
-  it.only("should render ExtRef element", () => {
+  it("should render ExtRef element", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--al");
 
     cy.get("dso-ozon-content").then((c) => {

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -212,7 +212,7 @@ describe("Ozon Content", () => {
     cy.get("dso-ozon-content")
       .shadow()
       .find("a[href='doc'][target='_blank'][rel='noopener noreferrer']")
-      .and("have.text", "document")
+      .should("have.text", "document")
       .should("have.attr", "title")
       .and("include", "Opent andere website in nieuw tabblad");
 


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl

**Testen:**
- Instructies: Copy de url en check of de sr-only text is verdwenen
- Url: https://storybook.dso-toolkit.nl/_2926-ozon-content-selectie--copy-to-clipboard-without-sr-only/?path=/story/core-ozon-content--ext-io-ref
