### PR TITLE
#2946 [Changed] Slide Toggle: Uitlijning klopt niet met titel in Annotation component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Slide Toggle: Uitlijning klopt niet met titel in Annotation component ([#2946](https://github.com/dso-toolkit/dso-toolkit/issues/2946))
+
 ## 🎶 Release 68.3.0 - 2025-02-13
 
 ### Added

--- a/packages/core/src/components/slide-toggle/slide-toggle.scss
+++ b/packages/core/src/components/slide-toggle/slide-toggle.scss
@@ -2,6 +2,11 @@
 @use "~dso-toolkit/src/variables/colors";
 @use "~dso-toolkit/src/variables/units";
 
+:host {
+  display: inline-block;
+  padding-block-start: 2px;
+}
+
 button.dso-slider {
   border: 0;
   padding: 0;

--- a/packages/core/src/components/slide-toggle/slide-toggle.scss
+++ b/packages/core/src/components/slide-toggle/slide-toggle.scss
@@ -1,10 +1,13 @@
 @use "~dso-toolkit/src/utilities";
 @use "~dso-toolkit/src/variables/colors";
 @use "~dso-toolkit/src/variables/units";
+@use "~dso-toolkit/src/variables/typography";
+
+$slide-toggle-height: 200px;
 
 :host {
   display: inline-block;
-  padding-block-start: 2px;
+  padding-block-start: (typography.$line-height-base * typography.$font-size-base - $slide-toggle-height) * 0.5;
 }
 
 button.dso-slider {

--- a/packages/core/src/components/slide-toggle/slide-toggle.tsx
+++ b/packages/core/src/components/slide-toggle/slide-toggle.tsx
@@ -1,10 +1,11 @@
-import { h, Component, ComponentInterface, Event, Fragment, Prop, EventEmitter, Element, State } from "@stencil/core";
+import { h, Component, ComponentInterface, Event, Prop, EventEmitter, Element, State, Fragment } from "@stencil/core";
 import { v4 } from "uuid";
 import { SlideToggleActiveEvent } from "./slide-toggle.interfaces";
 
 @Component({
   tag: "dso-slide-toggle",
   styleUrl: "slide-toggle.scss",
+  scoped: true,
   shadow: false,
 })
 export class SlideToggle implements ComponentInterface {


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- De slide-toggle e2e faalt vanwege de 2px padding die we toepassen
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
