### PR TITLE
#2947 [Changed] Autosuggest: aria-live van ul naar eerste li verplaatsen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * Slide Toggle: Uitlijning klopt niet met titel in Annotation component ([#2946](https://github.com/dso-toolkit/dso-toolkit/issues/2946))
+* Autosuggest: aria-live van ul naar eerste li verplaatsen ([#2947](https://github.com/dso-toolkit/dso-toolkit/issues/2947))
 
 ### Added
 * Survey Rating: Nieuw component ([#2603](https://github.com/dso-toolkit/dso-toolkit/issues/2603))

--- a/packages/core/src/components/autosuggest/autosuggest.tsx
+++ b/packages/core/src/components/autosuggest/autosuggest.tsx
@@ -506,7 +506,6 @@ export class Autosuggest {
             >
               <ul
                 role="listbox"
-                aria-live="polite"
                 id={this.listboxId}
                 aria-labelledby={this.labelId}
                 ref={(element) => (this.listbox = element)}
@@ -514,7 +513,7 @@ export class Autosuggest {
               >
                 {(this.showSuggestions &&
                   this.suggestions &&
-                  this.suggestions.map((suggestion) => (
+                  this.suggestions.map((suggestion, suggestionIndex) => (
                     <li
                       role="option"
                       id={this.listboxItemId(suggestion)}
@@ -524,6 +523,7 @@ export class Autosuggest {
                       onClick={() => this.pickSelectedValue()}
                       aria-selected={(suggestion === this.selectedSuggestion).toString()}
                       aria-label={suggestion.value}
+                      aria-live={suggestionIndex === 0 ? "polite" : undefined}
                       ref={(li) => li && this.listboxItems.push(li)}
                     >
                       <div class="suggestion-row">
@@ -543,7 +543,7 @@ export class Autosuggest {
                     </li>
                   ))) ||
                   (this.notFound && (
-                    <li>
+                    <li aria-live="polite">
                       <span class="value">
                         {this.notFoundLabel ||
                           this.showInputValueNotFound(this.text("notFound", { inputValue: this.inputValue }))}

--- a/storybook/cypress/e2e/autosuggest.cy.ts
+++ b/storybook/cypress/e2e/autosuggest.cy.ts
@@ -44,6 +44,8 @@ describe("Autosuggest", () => {
       .find("ul[role='listbox']")
       .then(($listbox) => cy.get("input").should("have.attr", "aria-controls", $listbox.prop("id")));
 
+    cy.get("dso-autosuggest.hydrated").find("li:first-child").should("have.attr", "aria-live", "polite");
+
     cy.realPress("ArrowDown");
     cy.realPress("ArrowDown");
     cy.dsoCheckA11y("dso-autosuggest.hydrated");
@@ -300,7 +302,7 @@ describe("Autosuggest", () => {
     cy.get("input").focus().type("akjehfowef");
     cy.wait(200);
     cy.get("dso-autosuggest.hydrated").find("ul[role='listbox']").should("be.visible");
-    cy.get("dso-autosuggest.hydrated").find("li").should("have.length", 1);
+    cy.get("dso-autosuggest.hydrated").find("li").should("have.length", 1).and("have.attr", "aria-live", "polite");
     cy.get("dso-autosuggest.hydrated").find("ul[role='listbox'] li mark").should("be.visible").contains("akjehfowef");
     cy.get("dso-autosuggest.hydrated")
       .find("ul[role='listbox'] li span")
@@ -315,7 +317,7 @@ describe("Autosuggest", () => {
     cy.get("input").focus().type("akjehfowef");
     cy.wait(200);
     cy.get("dso-autosuggest.hydrated").find("ul[role='listbox']").should("be.visible");
-    cy.get("dso-autosuggest.hydrated").find("li").should("have.length", 1);
+    cy.get("dso-autosuggest.hydrated").find("li").should("have.length", 1).and("have.attr", "aria-live", "polite");
     cy.get("dso-autosuggest.hydrated").find("ul[role='listbox'] li mark").should("be.visible").contains("akjehfowef");
     cy.get("dso-autosuggest.hydrated")
       .find("ul[role='listbox'] li span")
@@ -336,7 +338,7 @@ describe("Autosuggest", () => {
     cy.get("input").focus().type("akjehfowef");
     cy.wait(200);
     cy.get("dso-autosuggest.hydrated").find("ul[role='listbox']").should("be.visible");
-    cy.get("dso-autosuggest.hydrated").find("li").should("have.length", 1);
+    cy.get("dso-autosuggest.hydrated").find("li").should("have.length", 1).and("have.attr", "aria-live", "polite");
     cy.get("dso-autosuggest.hydrated")
       .find("li span")
       .should("be.visible")


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
