### PR TITLE
#2995 [Changed] Accordion: Status zonder underline tonen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
-### Fixed
-* Accordion: Default variant tussenruimte secties is niet consistent ([#3009](https://github.com/dso-toolkit/dso-toolkit/issues/3009))
-
 ### Added
 * Document Component: `<Kop>` ([#2974](https://github.com/dso-toolkit/dso-toolkit/issues/2974))
 * Accordion: Slide Toggle toevoegen aan sectie ([#2936](https://github.com/dso-toolkit/dso-toolkit/issues/2936))
 
+### Changed
+* Accordion: Status zonder underline tonen ([#2995](https://github.com/dso-toolkit/dso-toolkit/issues/2995))
+
 ### Fixed
 * Verticaal Ritme: List Buttons staan tegen elkaar aan geplakt ([#3008](https://github.com/dso-toolkit/dso-toolkit/issues/3008))
+* Accordion: Default variant tussenruimte secties is niet consistent ([#3009](https://github.com/dso-toolkit/dso-toolkit/issues/3009))
 
 ## 🐇 Release 68.4.0 - 2025-02-17
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
@@ -20,6 +20,10 @@
         color: accordion.$compact-color;
       }
     }
+
+    .dso-status {
+      color: accordion.$compact-black-color;
+    }
   }
 
   .dso-section-body {

--- a/packages/core/src/components/accordion/components/accordion-section-theme-default.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-default.scss
@@ -19,6 +19,10 @@
         color: accordion.$default-color;
       }
     }
+
+    .dso-status {
+      text-decoration: underline;
+    }
   }
 
   .dso-section-body {

--- a/packages/core/src/components/accordion/components/accordion-section.scss
+++ b/packages/core/src/components/accordion/components/accordion-section.scss
@@ -38,7 +38,6 @@
 
     .dso-status {
       font-weight: 400;
-      text-decoration: underline;
     }
   }
 

--- a/packages/core/src/components/accordion/components/accordion-section.tsx
+++ b/packages/core/src/components/accordion/components/accordion-section.tsx
@@ -430,7 +430,7 @@ export class AccordionSection implements ComponentInterface {
           >
             {reverseAlign ? (
               <Fragment>
-                {hasAddons && (
+                {this.icon && (
                   <div class="dso-section-handle-addons">
                     <HandleIcon icon={this.icon} />
                   </div>
@@ -441,27 +441,26 @@ export class AccordionSection implements ComponentInterface {
                     {this.label}
                   </dso-label>
                 )}
-                <dso-icon class="dso-section-handle-chevron" icon="chevron-down"></dso-icon>
+                <div class="dso-section-handle-addons">
+                  {this.statusDescription && <span class="dso-status">{this.statusDescription}</span>}
+                  <dso-icon class="dso-section-handle-chevron" icon="chevron-down"></dso-icon>
+                </div>
               </Fragment>
             ) : (
               <Fragment>
                 <dso-icon class="dso-section-handle-chevron" icon="chevron-right"></dso-icon>
-
                 {this.status && <span class="sr-only">{stateMap[this.status]}</span>}
-
                 <span>
                   <dso-renvooi value={this.handleTitle} />
                   {this.isNeutral && (
                     <dso-icon class="info-icon" icon={this.open || this.hover ? "info-active" : "info"} />
                   )}
                 </span>
-
                 {this.label && (
                   <dso-label status={this.labelStatus} compact>
                     {this.label}
                   </dso-label>
                 )}
-
                 {hasAddons && (
                   <div class="dso-section-handle-addons">
                     {this.statusDescription && <span class="dso-status">{this.statusDescription}</span>}

--- a/packages/dso-toolkit/src/components/accordion/accordion-theme-compact.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion-theme-compact.scss
@@ -29,6 +29,10 @@
         &.active {
           color: accordion.$compact-color;
         }
+
+        .dso-status {
+          color: accordion.$compact-black-color;
+        }
       }
     }
 

--- a/packages/dso-toolkit/src/components/accordion/accordion-theme-default.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion-theme-default.scss
@@ -59,6 +59,10 @@
       &.active {
         color: accordion.$default-color;
       }
+
+      .dso-status {
+        text-decoration: underline;
+      }
     }
   }
 

--- a/packages/dso-toolkit/src/components/accordion/accordion.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion.scss
@@ -210,28 +210,29 @@
       inset-block-start: (accordion.$handle-block-size - accordion.$state-icon-size) * 0.5;
     }
 
-    .dso-status,
-    .dso-icon {
-      font-weight: 400;
+    .dso-section-handle-addons {
       margin-inline-start: auto;
-      padding-inline-start: units.$u2;
-      text-decoration: underline;
-    }
+      text-align: end;
 
-    dso-attachments-counter,
-    .dso-attachments {
-      margin-inline-start: auto;
-      padding-inline-start: units.$u2;
-    }
+      .dso-status,
+      .dso-icon {
+        font-weight: 400;
+        margin-inline-start: units.$u2;
+      }
 
-    .dso-attachments {
-      &::after {
-        @include di.base("paperclip-grijs", accordion.$chevron-icon-size);
+      dso-attachments-counter,
+      .dso-attachments {
+        margin-inline-start: units.$u2;
+      }
+
+      .dso-attachments {
+        &::after {
+          @include di.base("paperclip-grijs", accordion.$chevron-icon-size);
+        }
       }
     }
 
     > .dso-label {
-      margin-inline-start: auto;
       padding-inline-start: units.$u1;
       word-break: normal;
 
@@ -253,7 +254,7 @@
 }
 
 // exceptions to the rule ^^:
-:where(.dso-accordion-compact, .dso-accordion-neutral, .dso-accordion-compact-black) {
+:where(.dso-accordion-compact, .dso-accordion-compact-black) {
   + :where(.dso-accordion-section) {
     margin-block-start: 0;
   }

--- a/storybook/cypress/e2e/accordion.cy.ts
+++ b/storybook/cypress/e2e/accordion.cy.ts
@@ -153,11 +153,11 @@ describe("Accordion", () => {
       .invoke("prop", "reverseAlign")
       .should("eq", true)
       .get("@dsoAccordionHandle")
-      .find("dso-icon:first-child")
+      .children("dso-icon")
       .should("not.exist")
       .get("@dsoAccordionHandle")
-      .find("dso-icon:last-child")
-      .should("exist");
+      .find(".dso-section-handle-addons")
+      .children("dso-icon");
   });
 
   it("should focus handle element with AccordionSection.focusHandle()", () => {

--- a/storybook/cypress/e2e/accordion.cy.ts
+++ b/storybook/cypress/e2e/accordion.cy.ts
@@ -157,7 +157,8 @@ describe("Accordion", () => {
       .should("not.exist")
       .get("@dsoAccordionHandle")
       .find(".dso-section-handle-addons")
-      .children("dso-icon");
+      .children("dso-icon")
+      .should("exist");
   });
 
   it("should focus handle element with AccordionSection.focusHandle()", () => {

--- a/storybook/src/components/accordion/accordion.css-template.ts
+++ b/storybook/src/components/accordion/accordion.css-template.ts
@@ -35,8 +35,16 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
           ${section.icon && !accordion.reverseAlign
             ? html`<span class="dso-icon">${iconTemplate({ icon: section.icon })}</span>`
             : nothing}
-          ${section.statusDescription ? html`<span class="dso-status">${section.statusDescription}</span>` : nothing}
-          ${section.attachmentCount ? html`${attachmentsCounterTemplate({ count: section.attachmentCount })}` : nothing}
+          ${section.statusDescription || section.attachmentCount
+            ? html`<div class="dso-section-handle-addons">
+                ${section.statusDescription
+                  ? html`<span class="dso-status">${section.statusDescription}</span>`
+                  : nothing}
+                ${!section.status && !accordion.reverseAlign && section.attachmentCount
+                  ? html`${attachmentsCounterTemplate({ count: section.attachmentCount })}`
+                  : nothing}
+              </div>`
+            : nothing}
         `;
       }
 
@@ -90,7 +98,7 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
         return html`
           <div
             class="dso-accordion-section ${classMap({
-              [`dso-${section.status}`]: !!section.status,
+              [`dso-${section.status}`]: !!section.status && !accordion.reverseAlign,
               "dso-open": !!section.open,
               "dso-nested-accordion": hasNestedAccordion,
               [`dso-accordion-wijzigactie-${section.wijzigactie}`]: !!section.wijzigactie,

--- a/storybook/src/components/accordion/accordion.css-template.ts
+++ b/storybook/src/components/accordion/accordion.css-template.ts
@@ -29,14 +29,14 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
           ${typeof section.handleTitle !== "string"
             ? renvooiTemplate({ value: section.handleTitle })
             : section.handleTitle}
-          ${section.label
-            ? labelTemplate({ status: section.labelStatus, label: section.label, compact: true })
-            : nothing}
           ${section.icon && !accordion.reverseAlign
             ? html`<span class="dso-icon">${iconTemplate({ icon: section.icon })}</span>`
             : nothing}
-          ${section.statusDescription || section.attachmentCount
+          ${section.statusDescription || section.attachmentCount || section.label
             ? html`<div class="dso-section-handle-addons">
+                ${section.label
+                  ? labelTemplate({ status: section.labelStatus, label: section.label, compact: true })
+                  : nothing}
                 ${section.statusDescription
                   ? html`<span class="dso-status">${section.statusDescription}</span>`
                   : nothing}


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
