### PR TITLE
#2991 [Task] Accordion: Verbeter het etaleren van de `Nested` Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Verticaal Ritme: List Buttons staan tegen elkaar aan geplakt ([#3008](https://github.com/dso-toolkit/dso-toolkit/issues/3008))
 * Accordion: Default variant tussenruimte secties is niet consistent ([#3009](https://github.com/dso-toolkit/dso-toolkit/issues/3009))
 
+### Task
+* Accordion: Verbeter het etaleren van de `Nested` Accordion ([#2991](https://github.com/dso-toolkit/dso-toolkit/issues/2991))
+
 ## 🐇 Release 68.4.0 - 2025-02-17
 
 ### Changed

--- a/packages/dso-toolkit/src/components/accordion/accordion.stories-of.ts
+++ b/packages/dso-toolkit/src/components/accordion/accordion.stories-of.ts
@@ -39,7 +39,7 @@ interface AccordionTemplates<TemplateFnReturnType> {
   neutralSections: AccordionSection<TemplateFnReturnType>[];
   compactBlackSections: AccordionSection<TemplateFnReturnType>[];
   anchorSections: AccordionSection<TemplateFnReturnType>[];
-  subSections: AccordionSection<TemplateFnReturnType>[];
+  nestedSections: AccordionSection<TemplateFnReturnType>[];
   addonsSections: AccordionSection<TemplateFnReturnType>[];
   alignmentSections: AccordionSection<TemplateFnReturnType>[];
   renvooiSections: AccordionSection<TemplateFnReturnType>[];
@@ -125,8 +125,11 @@ export function accordionStories<Implementation, Templates, TemplateFnReturnType
       ),
     },
     Nested: {
-      render: templateContainer.render(storyTemplates, (args, { accordionTemplate, subSections }) =>
-        accordionTemplate(accordionArgsMapper(args, subSections)),
+      args: {
+        open: true,
+      },
+      render: templateContainer.render(storyTemplates, (args, { accordionTemplate, nestedSections }) =>
+        accordionTemplate(accordionArgsMapper(args, nestedSections)),
       ),
     },
     AddonsSections: {

--- a/packages/react/src/components/accordion/accordion.content.tsx
+++ b/packages/react/src/components/accordion/accordion.content.tsx
@@ -103,10 +103,11 @@ export const anchorSections: AccordionSection<React.JSX.Element>[] = [
   },
 ];
 
-export function subSections({ accordionTemplate }: Templates): AccordionSection<React.JSX.Element>[] {
+export function nestedSections({ accordionTemplate }: Templates): AccordionSection<React.JSX.Element>[] {
   return [
+    section1,
     {
-      ...section1,
+      ...section2,
       content: (
         <>
           <div className="dso-rich-content">
@@ -150,7 +151,6 @@ export function subSections({ accordionTemplate }: Templates): AccordionSection<
         </>
       ),
     },
-    section2,
     section3,
     section4,
   ];

--- a/packages/react/src/components/accordion/accordion.stories.tsx
+++ b/packages/react/src/components/accordion/accordion.stories.tsx
@@ -11,7 +11,7 @@ import {
   anchorSections,
   basicSections,
   renvooiSections,
-  subSections,
+  nestedSections,
 } from "./accordion.content";
 
 const meta: Meta<AccordionArgs> = {
@@ -48,7 +48,7 @@ const {
       compactSections: basicSections,
       compactBlackSections: basicSections,
       neutralSections: basicSections,
-      subSections: subSections(templates),
+      nestedSections: nestedSections(templates),
       renvooiSections,
       activatableSections,
     };

--- a/storybook/cypress/e2e/accordion.cy.ts
+++ b/storybook/cypress/e2e/accordion.cy.ts
@@ -260,6 +260,14 @@ describe("Accordion", () => {
       .matchImageSnapshot(`${Cypress.currentTest.title} -- Verwijderd`);
   });
 
+  describe("Nested", () => {
+    it("shows a nested accordion", () => {
+      cy.visit("http://localhost:45000/iframe.html?id=core-accordion--nested");
+
+      cy.get("dso-accordion.hydrated:has(dso-accordion.hydrated)").should("exist").matchImageSnapshot();
+    });
+  });
+
   describe("Activatable", () => {
     beforeEach(() => {
       cy.visit("http://localhost:45000/iframe.html?id=core-accordion--activatable");

--- a/storybook/src/components/accordion/accordion.content.ts
+++ b/storybook/src/components/accordion/accordion.content.ts
@@ -103,24 +103,25 @@ export function anchorSections(templates: Templates): AccordionSection<TemplateR
   ];
 }
 
-export function subSections(templates: Templates): AccordionSection<TemplateResult>[] {
+export function nestedSections(templates: Templates): AccordionSection<TemplateResult>[] {
   const { accordionTemplate, richContentTemplate } = templates;
 
   return [
+    section1,
     {
-      ...section1,
-      content: html` ${richContentTemplate({ children: html`<p><strong>hallo</strong> dit is content</p>` })}
+      ...section2,
+      content: html`${richContentTemplate({ children: html`<p><strong>hallo</strong> dit is content</p>` })}
       ${accordionTemplate({
         sections: [
           {
-            handleTitle: "Voor hoeveel locaties kan ik de Vergunningcheck doen?",
+            handleTitle: "(Genest) Voor hoeveel locaties kan ik de Vergunningcheck doen?",
             heading: "h4",
             content: richContentTemplate({
               children: html` <p><strong>hallo</strong> dit is content</p> `,
             }),
           },
           {
-            handleTitle: "Hoe lang duurt de Vergunningcheck?",
+            handleTitle: "(Genest) Hoe lang duurt de Vergunningcheck?",
             heading: "h4",
             open: true,
             content: richContentTemplate({
@@ -134,7 +135,6 @@ export function subSections(templates: Templates): AccordionSection<TemplateResu
       })}
       ${richContentTemplate({ children: html` <p><strong>hallo</strong> dit is content na de nested section</p> ` })}`,
     },
-    section2,
     section3,
     section4(templates),
   ];

--- a/storybook/src/components/accordion/accordion.core-stories.ts
+++ b/storybook/src/components/accordion/accordion.core-stories.ts
@@ -12,7 +12,7 @@ import {
   anchorSections,
   basicSections,
   renvooiSections,
-  subSections,
+  nestedSections,
 } from "./accordion.content";
 
 const meta: Meta<AccordionArgs> = {
@@ -49,7 +49,7 @@ const {
       compactSections: basicSections(templates),
       compactBlackSections: basicSections(templates),
       neutralSections: basicSections(templates),
-      subSections: subSections(templates),
+      nestedSections: nestedSections(templates),
       renvooiSections,
       activatableSections,
     };

--- a/storybook/src/components/accordion/accordion.css-stories.ts
+++ b/storybook/src/components/accordion/accordion.css-stories.ts
@@ -10,7 +10,7 @@ import {
   anchorSections,
   basicSections,
   renvooiSections,
-  subSections,
+  nestedSections,
 } from "./accordion.content";
 import readme from "dso-toolkit/src/components/accordion/readme.md?raw";
 
@@ -47,7 +47,7 @@ const {
       compactSections: basicSections(templates),
       compactBlackSections: basicSections(templates),
       neutralSections: basicSections(templates),
-      subSections: subSections(templates),
+      nestedSections: nestedSections(templates),
       renvooiSections,
       activatableSections,
     };

--- a/storybook/src/components/accordion/accordion.css-template.ts
+++ b/storybook/src/components/accordion/accordion.css-template.ts
@@ -87,8 +87,8 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
       function accordionSectionTemplate(
         accordion: Accordion<TemplateResult>,
         section: AccordionSection<TemplateResult>,
+        index: number,
       ): TemplateResult {
-        const hasNestedAccordion = section.content?.strings.includes("<dso-accordion") ?? false;
         const showSlideToggle = section.activatable && accordion.variant === "compact-black" && !accordion.reverseAlign;
 
         if (!section.heading) {
@@ -100,7 +100,7 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
             class="dso-accordion-section ${classMap({
               [`dso-${section.status}`]: !!section.status && !accordion.reverseAlign,
               "dso-open": !!section.open,
-              "dso-nested-accordion": hasNestedAccordion,
+              "dso-nested-accordion": index === 1,
               [`dso-accordion-wijzigactie-${section.wijzigactie}`]: !!section.wijzigactie,
               "dso-accordion-section-activate": !!showSlideToggle,
             })}"
@@ -118,7 +118,7 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
             "dso-accordion-reverse-align": !!accordion.reverseAlign,
           })}"
         >
-          ${accordion.sections.map((section) => accordionSectionTemplate(accordion, section))}
+          ${accordion.sections.map((section, index) => accordionSectionTemplate(accordion, section, index))}
         </div>
       `;
     },


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
