### PR TITLE
#3013 [Changed] Verticaal Ritme: afstand boven en onder knoppenbalk naar 32px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Verticaal Ritme: afstand boven en onder knoppenbalk naar 32px ([#3013](https://github.com/dso-toolkit/dso-toolkit/issues/3013))
+
 ### Task
 * Packages: Dependencies updates ([#2977](https://github.com/dso-toolkit/dso-toolkit/issues/2977))
 

--- a/packages/dso-toolkit/src/components/form-buttons/form-buttons.args.ts
+++ b/packages/dso-toolkit/src/components/form-buttons/form-buttons.args.ts
@@ -1,21 +1,13 @@
 import { ArgTypes } from "@storybook/types";
-
 import { Button } from "../button/button.models.js";
-
 import { FormButtons } from "./form-buttons.models.js";
 
 export interface FormButtonsArgs {
-  formModifier?: string;
   buttons: Button[];
   asideButtons: Button[];
 }
 
 export const formButtonsArgTypes: ArgTypes<FormButtonsArgs> = {
-  formModifier: {
-    control: {
-      disable: true,
-    },
-  },
   buttons: {
     control: {
       disable: true,
@@ -30,7 +22,6 @@ export const formButtonsArgTypes: ArgTypes<FormButtonsArgs> = {
 
 export function formButtonsArgsMapper(a: FormButtonsArgs): FormButtons {
   return {
-    formModifier: a.formModifier,
     buttons: a.buttons,
     asideButtons: a.asideButtons,
   };

--- a/packages/dso-toolkit/src/components/form-buttons/form-buttons.models.ts
+++ b/packages/dso-toolkit/src/components/form-buttons/form-buttons.models.ts
@@ -1,7 +1,6 @@
 import { Button } from "../button/button.models.js";
 
 export interface FormButtons {
-  formModifier?: string;
   buttons: Button[];
   asideButtons?: Button[];
 }

--- a/packages/dso-toolkit/src/components/form-buttons/form-buttons.scss
+++ b/packages/dso-toolkit/src/components/form-buttons/form-buttons.scss
@@ -13,11 +13,6 @@
     flex-direction: column;
   }
 
-  // stylelint-disable-next-line no-duplicate-selectors -- needed to fix sass deprecation warnings: #2724
-  & {
-    margin-block-end: units.$block-spacing-medium;
-  }
-
   &:last-child {
     margin-block-end: units.$block-spacing-xlarge;
   }
@@ -60,9 +55,5 @@
 
       margin-inline-end: auto;
     }
-  }
-
-  .dso-single-page & {
-    justify-content: flex-start;
   }
 }

--- a/packages/dso-toolkit/src/components/form-buttons/form-buttons.stories-of.ts
+++ b/packages/dso-toolkit/src/components/form-buttons/form-buttons.stories-of.ts
@@ -13,7 +13,6 @@ interface FormButtonsStories {
   Default: FormButtonsStory;
   MultiPage: FormButtonsStory;
   Sections: FormButtonsStory;
-  SinglePage: FormButtonsStory;
   SimpleForm: FormButtonsStory;
 }
 
@@ -106,22 +105,6 @@ export function formButtonsStories<Implementation, Templates, TemplateFnReturnTy
           {
             variant: "primary",
             label: "Primaire actie",
-          },
-        ],
-      },
-      render,
-    },
-    SinglePage: {
-      args: {
-        formModifier: "dso-single-page",
-        buttons: [
-          {
-            variant: "primary",
-            label: "Primaire actie",
-          },
-          {
-            variant: "secondary",
-            label: "Secundaire actie",
           },
         ],
       },

--- a/packages/dso-toolkit/src/components/form/form-single-page.scss
+++ b/packages/dso-toolkit/src/components/form/form-single-page.scss
@@ -1,0 +1,5 @@
+.dso-single-page {
+  .dso-form-buttons {
+    justify-content: flex-start;
+  }
+}

--- a/packages/dso-toolkit/src/components/form/form.args.ts
+++ b/packages/dso-toolkit/src/components/form/form.args.ts
@@ -6,6 +6,7 @@ import { Form, FormAsteriskExplanationPosition, FormContent } from "./form.model
 export interface FormArgs {
   asteriskExplanation?: FormAsteriskExplanationPosition;
   mode: "horizontal" | "vertical" | undefined;
+  formModifier?: string;
 }
 
 export const formArgTypes: ArgTypes<FormArgs> = {
@@ -31,6 +32,7 @@ export function formArgsMapper<TemplateFnReturnType>(
     asteriskExplanation: a.asteriskExplanation,
     mode: a.mode,
     content,
+    formModifier: a.formModifier,
     formButtons: buttons,
   };
 }

--- a/packages/dso-toolkit/src/components/form/form.models.ts
+++ b/packages/dso-toolkit/src/components/form/form.models.ts
@@ -4,6 +4,7 @@ import { FormGroup } from "../form-group/form-group.models.js";
 export interface Form<TemplateFnReturnType> {
   asteriskExplanation?: FormAsteriskExplanationPosition;
   mode?: "vertical" | "horizontal";
+  formModifier?: string;
   content: FormContent<TemplateFnReturnType>;
   formButtons?: FormButtons;
 }

--- a/packages/dso-toolkit/src/components/form/form.scss
+++ b/packages/dso-toolkit/src/components/form/form.scss
@@ -1,3 +1,4 @@
 @use "form-group-collection";
 @use "form-horizontal";
 @use "form-explanation";
+@use "form-single-page";

--- a/packages/dso-toolkit/src/components/form/form.stories-of.ts
+++ b/packages/dso-toolkit/src/components/form/form.stories-of.ts
@@ -15,6 +15,7 @@ interface FormStories {
   HorizontalCollections: FormStory;
   Vertical: FormStory;
   VerticalCollections: FormStory;
+  SinglePage: FormStory;
 }
 
 export interface FormTemplates<TemplateFnReturnType> {
@@ -72,6 +73,14 @@ export function formStories<Implementation, Templates, TemplateFnReturnType>({
     VerticalCollections: {
       args: {
         mode: "vertical",
+      },
+      render: templateContainer.render(storyTemplates, (args, { formTemplate }) =>
+        formTemplate(formArgsMapper(args, formGroupCollectionContent)),
+      ),
+    },
+    SinglePage: {
+      args: {
+        formModifier: "dso-single-page",
       },
       render: templateContainer.render(storyTemplates, (args, { formTemplate }) =>
         formTemplate(formArgsMapper(args, formGroupCollectionContent)),

--- a/packages/dso-toolkit/src/global/spacing.scss
+++ b/packages/dso-toolkit/src/global/spacing.scss
@@ -64,6 +64,11 @@
   margin-block-start: units.$block-spacing-medium;
 }
 
+:where(*) + :where(.dso-form-buttons),
+:where(.dso-form-buttons) + :where(*) {
+  margin-block: units.$block-spacing-xlarge;
+}
+
 $spacers: (
   (
     space: units.$block-spacing-small,

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -205,7 +205,7 @@
   {
     "name": "form",
     "selector": "",
-    "stories": ["horizontal", "horizontal-collections", "vertical", "vertical-collections"],
+    "stories": ["horizontal", "horizontal-collections", "vertical", "vertical-collections", "single-page"],
     "type": "html-css",
     "wait": "dso-date-picker.hydrated"
   },

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -212,7 +212,7 @@
   {
     "name": "form-buttons",
     "selector": "",
-    "stories": ["default", "multi-page", "sections", "single-page", "simple-form"],
+    "stories": ["default", "multi-page", "sections", "simple-form"],
     "type": "html-css"
   },
   {

--- a/storybook/src/components/form-buttons/form-buttons.css-stories.ts
+++ b/storybook/src/components/form-buttons/form-buttons.css-stories.ts
@@ -13,7 +13,7 @@ const meta: Meta = {
 
 export default meta;
 
-const { Default, MultiPage, Sections, SinglePage, SimpleForm } = formButtonsStories({
+const { Default, MultiPage, Sections, SimpleForm } = formButtonsStories({
   templateContainer,
   storyTemplates: (templates) => {
     const { formButtonsTemplate } = templates;
@@ -24,4 +24,4 @@ const { Default, MultiPage, Sections, SinglePage, SimpleForm } = formButtonsStor
   },
 });
 
-export { Default, MultiPage, Sections, SinglePage, SimpleForm };
+export { Default, MultiPage, Sections, SimpleForm };

--- a/storybook/src/components/form-buttons/form-buttons.css-template.ts
+++ b/storybook/src/components/form-buttons/form-buttons.css-template.ts
@@ -1,22 +1,17 @@
 import { Button, FormButtons } from "dso-toolkit";
 import { html } from "lit-html";
-import { ifDefined } from "lit-html/directives/if-defined.js";
 import { ComponentImplementation } from "../../templates";
 
 export const cssFormButtons: ComponentImplementation<FormButtons> = {
   component: "formButtons",
   implementation: "html-css",
   template: ({ buttonTemplate }) =>
-    function formButtonsTemplate({ formModifier, buttons, asideButtons }) {
-      return html`
-        <form class=${ifDefined(formModifier)}>
-          <div class="dso-form-buttons">
-            ${asideButtons &&
-            asideButtons.length > 0 &&
-            html`<div class="dso-aside">${asideButtons.map((button: Button) => buttonTemplate(button))}</div>`}
-            ${buttons.map((button) => buttonTemplate(button))}
-          </div>
-        </form>
-      `;
+    function formButtonsTemplate({ buttons, asideButtons }) {
+      return html` <div class="dso-form-buttons">
+        ${asideButtons &&
+        asideButtons.length > 0 &&
+        html`<div class="dso-aside">${asideButtons.map((button: Button) => buttonTemplate(button))}</div>`}
+        ${buttons.map((button) => buttonTemplate(button))}
+      </div>`;
     },
 };

--- a/storybook/src/components/form/form.css-stories.ts
+++ b/storybook/src/components/form/form.css-stories.ts
@@ -13,7 +13,7 @@ const meta: Meta<FormArgs> = {
 
 export default meta;
 
-const { Horizontal, HorizontalCollections, Vertical, VerticalCollections } = formStories({
+const { Horizontal, HorizontalCollections, Vertical, VerticalCollections, SinglePage } = formStories({
   templateContainer,
   storyTemplates: (templates) => {
     const { formTemplate } = templates;
@@ -24,4 +24,4 @@ const { Horizontal, HorizontalCollections, Vertical, VerticalCollections } = for
   },
 });
 
-export { Horizontal, HorizontalCollections, Vertical, VerticalCollections };
+export { Horizontal, HorizontalCollections, Vertical, VerticalCollections, SinglePage };

--- a/storybook/src/components/form/form.css-template.ts
+++ b/storybook/src/components/form/form.css-template.ts
@@ -1,14 +1,13 @@
 import { Form, FormGroupCollection, FormGroupCollectionHeadingLevel } from "dso-toolkit";
 import { html, nothing, TemplateResult } from "lit-html";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-
 import { ComponentImplementation } from "../../templates";
+import { classMap } from "lit-html/directives/class-map.js";
 
 export const cssForm: ComponentImplementation<Form<TemplateResult>> = {
   component: "form",
   implementation: "html-css",
   template: ({ formGroupTemplate, formButtonsTemplate }) =>
-    function formTemplate({ asteriskExplanation, mode, content, formButtons }) {
+    function formTemplate({ asteriskExplanation, mode, formModifier, content, formButtons }) {
       function asteriskExplanationTemplate() {
         return html`<div class="form-explanation" aria-hidden="true">
           <p class="form-explanation-text">
@@ -53,7 +52,12 @@ export const cssForm: ComponentImplementation<Form<TemplateResult>> = {
       }
 
       return html`
-        <form class=${ifDefined(mode === "horizontal" ? "form-horizontal" : undefined)}>
+        <form
+          class=${classMap({
+            "form-horizontal": mode === "horizontal",
+            [formModifier || ""]: !!formModifier,
+          })}
+        >
           ${asteriskExplanation === "top" || asteriskExplanation === "both" ? asteriskExplanationTemplate() : nothing}
           ${content.map((formGroup) =>
             "title" in formGroup ? formGroupCollection(formGroup) : formGroupTemplate(formGroup),

--- a/website/docs/components/form/form-buttons.mdx
+++ b/website/docs/components/form/form-buttons.mdx
@@ -20,4 +20,4 @@ Uitzondering: dit is niet nodig in een <code>.dso-single-page</code>, daar worde
 
 ### Single page
 
-<StorybookComponent name="form-buttons" implementations={["html-css"]} variant="single-page" />
+<StorybookComponent name="form" implementations={["html-css"]} variant="single-page" />


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
