### PR TITLE
#3058 [Fixed] "@stencil/angular-output-target": downgrade naar versie 0.7.1 inclusief patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* "@stencil/angular-output-target": downgrade naar versie 0.7.1 inclusief patch ([#3058](https://github.com/dso-toolkit/dso-toolkit/issues/3058))
+
 ## 🧳 Release 69.2.0 - 2025-03-17
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "uuid": "^11.0.5"
   },
   "devDependencies": {
-    "@stencil/angular-output-target": "0.10.2",
+    "@stencil/angular-output-target": "0.7.1",
     "@stencil/react-output-target": "^0.7.4",
     "@stencil/sass": "^3.0.12",
     "@types/concurrently": "^7.0.3",

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -20,7 +20,7 @@ export const config: Config = {
     angularOutputTarget({
       componentCorePackage: "@dso-toolkit/core",
       customElementsDir: "dist/components",
-      outputType: "standalone",
+      includeImportCustomElements: true,
       directivesProxyFile: "../../angular-workspace/projects/component-library/src/lib/stencil-generated/components.ts",
       directivesArrayFile: "../../angular-workspace/projects/component-library/src/lib/stencil-generated/index.ts",
     }),

--- a/patches/@stencil+angular-output-target+0.7.1.patch
+++ b/patches/@stencil+angular-output-target+0.7.1.patch
@@ -1,0 +1,392 @@
+diff --git a/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts b/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
+index 58ed93b..b77e640 100644
+--- a/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
++++ b/node_modules/@stencil/angular-output-target/angular-component-lib/utils.ts
+@@ -36,6 +36,28 @@ export const defineCustomElement = (tagName: string, customElement: any) => {
+   }
+ };
+ 
++/**
++ * The Angular property name that contains the object of metadata properties
++ * for the component added by the Angular compiler.
++ */
++const NG_COMP_DEF = 'ɵcmp';
++
++export const clearAngularOutputBindings = (cls: any) => {
++  if (typeof cls === 'function' && cls !== null) {
++    if (cls.prototype.constructor) {
++      const instance = cls.prototype.constructor;
++      if (instance[NG_COMP_DEF]) {
++        /**
++         * With the output targets generating @Output() proxies, we need to
++         * clear the metadata (ɵcmp.outputs) so that Angular does not add its own event listener
++         * and cause duplicate event emissions for the web component events.
++         */
++        instance[NG_COMP_DEF].outputs = {};
++      }
++    }
++  }
++};
++
+ // tslint:disable-next-line: only-arrow-functions
+ export function ProxyCmp(opts: { defineCustomElementFn?: () => void; inputs?: any; methods?: any }) {
+   const decorator = function (cls: any) {
+@@ -45,6 +67,8 @@ export function ProxyCmp(opts: { defineCustomElementFn?: () => void; inputs?: an
+       defineCustomElementFn();
+     }
+ 
++    clearAngularOutputBindings(cls);
++
+     if (inputs) {
+       proxyInputs(cls, inputs);
+     }
+diff --git a/node_modules/@stencil/angular-output-target/dist/generate-angular-component.d.ts b/node_modules/@stencil/angular-output-target/dist/generate-angular-component.d.ts
+index aa00d18..a6bfe59 100644
+--- a/node_modules/@stencil/angular-output-target/dist/generate-angular-component.d.ts
++++ b/node_modules/@stencil/angular-output-target/dist/generate-angular-component.d.ts
+@@ -9,7 +9,7 @@ import type { ComponentCompilerEvent } from '@stencil/core/internal';
+  * @param includeImportCustomElements Whether to define the component as a custom element.
+  * @returns The component declaration as a string.
+  */
+-export declare const createAngularComponentDefinition: (tagName: string, inputs: readonly string[], outputs: readonly string[], methods: readonly string[], includeImportCustomElements?: boolean) => string;
++export declare const createAngularComponentDefinition: (tagName: string, inputs: readonly string[], outputs: readonly ComponentCompilerEvent[], methods: readonly string[], includeImportCustomElements?: boolean) => string;
+ /**
+  * Creates the component interface type definition.
+  * @param tagNameAsPascal The tag name as PascalCase.
+diff --git a/node_modules/@stencil/angular-output-target/dist/generate-angular-component.js b/node_modules/@stencil/angular-output-target/dist/generate-angular-component.js
+index b1b095f..1238ffd 100644
+--- a/node_modules/@stencil/angular-output-target/dist/generate-angular-component.js
++++ b/node_modules/@stencil/angular-output-target/dist/generate-angular-component.js
+@@ -17,7 +17,7 @@ export const createAngularComponentDefinition = (tagName, inputs, outputs, metho
+     // Formats the input strings into comma separated, single quoted values.
+     const formattedInputs = formatToQuotedList(inputs);
+     // Formats the output strings into comma separated, single quoted values.
+-    const formattedOutputs = formatToQuotedList(outputs);
++    const formattedOutputs = formatToQuotedList(outputs.map((event) => event.name));
+     // Formats the method strings into comma separated, single quoted values.
+     const formattedMethods = formatToQuotedList(methods);
+     const proxyCmpOptions = [];
+@@ -31,32 +31,54 @@ export const createAngularComponentDefinition = (tagName, inputs, outputs, metho
+     if (hasMethods) {
+         proxyCmpOptions.push(`\n  methods: [${formattedMethods}]`);
+     }
+-    /**
+-     * Notes on the generated output:
+-     * - We disable @angular-eslint/no-inputs-metadata-property, so that
+-     * Angular does not complain about the inputs property. The output target
+-     * uses the inputs property to define the inputs of the component instead of
+-     * having to use the @Input decorator (and manually define the type and default value).
+-     */
+-    const output = `@ProxyCmp({${proxyCmpOptions.join(',')}\n})
+-@Component({
+-  selector: '${tagName}',
+-  changeDetection: ChangeDetectionStrategy.OnPush,
+-  template: '<ng-content></ng-content>',
+-  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+-  inputs: [${formattedInputs}],
+-})
+-export class ${tagNameAsPascal} {
+-  protected el: HTMLElement;
+-  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+-    c.detach();
+-    this.el = r.nativeElement;${hasOutputs
+-        ? `
+-    proxyOutputs(this, this.el, [${formattedOutputs}]);`
+-        : ''}
+-  }
+-}`;
+-    return output;
++    const output = [
++        `@ProxyCmp({${proxyCmpOptions.join(',')}\n})`,
++        `@Component({`,
++        `  selector: '${tagName}',`,
++        `  changeDetection: ChangeDetectionStrategy.OnPush,`,
++        `  template: '<ng-content></ng-content>',`,
++        /**
++         * We disable @angular-eslint/no-inputs-metadata-property, so that
++         * Angular does not complain about the inputs property. The output target
++         * uses the inputs property to define the inputs of the component instead of
++         * having to use the @Input decorator (and manually define the type and default value).
++         */
++        `  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property`,
++        `  inputs: [${formattedInputs}],`,
++        `})`,
++        `export class ${tagNameAsPascal} {`,
++    ];
++    if (hasOutputs) {
++        for (let compilerEvent of outputs) {
++            output.push(`  ${createAngularOutputDecorator(tagName, compilerEvent)}`);
++        }
++    }
++    output.push(`  protected el: HTMLElement;`);
++    output.push(`  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {`);
++    output.push(`    c.detach();`);
++    output.push(`    this.el = r.nativeElement;`);
++    if (hasOutputs) {
++        output.push(`    proxyOutputs(this, this.el, [${formattedOutputs}]);`);
++    }
++    output.push(`  }`);
++    output.push(`}`);
++    return output.join('\n');
++};
++/**
++ * Creates an `@Output()` decorator for a custom event on a Stencil component.
++ * @param tagName The tag name of the component.
++ * @param event The Stencil component event.
++ * @returns The `@Output()` decorator as a string.
++ */
++const createAngularOutputDecorator = (tagName, event) => {
++    const tagNameAsPascal = dashToPascalCase(tagName);
++    // When updating to Stencil 3.0, the component custom event generic will be
++    // exported by default and can be referenced here with:
++    // const customEvent = `${tagNameAsPascal}CustomEvent`;
++    const customEventType = `CustomEvent`;
++    const eventType = formatOutputType(tagNameAsPascal, event);
++    const outputType = `${customEventType}<${eventType}>`;
++    return `@Output() ${event.name}: EventEmitter<${outputType}> = new EventEmitter();`;
+ };
+ /**
+  * Sanitizes and formats the component event type.
+diff --git a/node_modules/@stencil/angular-output-target/dist/index.cjs.js b/node_modules/@stencil/angular-output-target/dist/index.cjs.js
+index 7d8a725..6cf6861 100644
+--- a/node_modules/@stencil/angular-output-target/dist/index.cjs.js
++++ b/node_modules/@stencil/angular-output-target/dist/index.cjs.js
+@@ -148,7 +148,7 @@ const createAngularComponentDefinition = (tagName, inputs, outputs, methods, inc
+     // Formats the input strings into comma separated, single quoted values.
+     const formattedInputs = formatToQuotedList(inputs);
+     // Formats the output strings into comma separated, single quoted values.
+-    const formattedOutputs = formatToQuotedList(outputs);
++    const formattedOutputs = formatToQuotedList(outputs.map((event) => event.name));
+     // Formats the method strings into comma separated, single quoted values.
+     const formattedMethods = formatToQuotedList(methods);
+     const proxyCmpOptions = [];
+@@ -162,32 +162,54 @@ const createAngularComponentDefinition = (tagName, inputs, outputs, methods, inc
+     if (hasMethods) {
+         proxyCmpOptions.push(`\n  methods: [${formattedMethods}]`);
+     }
+-    /**
+-     * Notes on the generated output:
+-     * - We disable @angular-eslint/no-inputs-metadata-property, so that
+-     * Angular does not complain about the inputs property. The output target
+-     * uses the inputs property to define the inputs of the component instead of
+-     * having to use the @Input decorator (and manually define the type and default value).
+-     */
+-    const output = `@ProxyCmp({${proxyCmpOptions.join(',')}\n})
+-@Component({
+-  selector: '${tagName}',
+-  changeDetection: ChangeDetectionStrategy.OnPush,
+-  template: '<ng-content></ng-content>',
+-  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+-  inputs: [${formattedInputs}],
+-})
+-export class ${tagNameAsPascal} {
+-  protected el: HTMLElement;
+-  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+-    c.detach();
+-    this.el = r.nativeElement;${hasOutputs
+-        ? `
+-    proxyOutputs(this, this.el, [${formattedOutputs}]);`
+-        : ''}
+-  }
+-}`;
+-    return output;
++    const output = [
++        `@ProxyCmp({${proxyCmpOptions.join(',')}\n})`,
++        `@Component({`,
++        `  selector: '${tagName}',`,
++        `  changeDetection: ChangeDetectionStrategy.OnPush,`,
++        `  template: '<ng-content></ng-content>',`,
++        /**
++         * We disable @angular-eslint/no-inputs-metadata-property, so that
++         * Angular does not complain about the inputs property. The output target
++         * uses the inputs property to define the inputs of the component instead of
++         * having to use the @Input decorator (and manually define the type and default value).
++         */
++        `  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property`,
++        `  inputs: [${formattedInputs}],`,
++        `})`,
++        `export class ${tagNameAsPascal} {`,
++    ];
++    if (hasOutputs) {
++        for (let compilerEvent of outputs) {
++            output.push(`  ${createAngularOutputDecorator(tagName, compilerEvent)}`);
++        }
++    }
++    output.push(`  protected el: HTMLElement;`);
++    output.push(`  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {`);
++    output.push(`    c.detach();`);
++    output.push(`    this.el = r.nativeElement;`);
++    if (hasOutputs) {
++        output.push(`    proxyOutputs(this, this.el, [${formattedOutputs}]);`);
++    }
++    output.push(`  }`);
++    output.push(`}`);
++    return output.join('\n');
++};
++/**
++ * Creates an `@Output()` decorator for a custom event on a Stencil component.
++ * @param tagName The tag name of the component.
++ * @param event The Stencil component event.
++ * @returns The `@Output()` decorator as a string.
++ */
++const createAngularOutputDecorator = (tagName, event) => {
++    const tagNameAsPascal = dashToPascalCase(tagName);
++    // When updating to Stencil 3.0, the component custom event generic will be
++    // exported by default and can be referenced here with:
++    // const customEvent = `${tagNameAsPascal}CustomEvent`;
++    const customEventType = `CustomEvent`;
++    const eventType = formatOutputType(tagNameAsPascal, event);
++    const outputType = `${customEventType}<${eventType}>`;
++    return `@Output() ${event.name}: EventEmitter<${outputType}> = new EventEmitter();`;
+ };
+ /**
+  * Sanitizes and formats the component event type.
+@@ -399,6 +421,7 @@ function generateProxies(components, pkgData, outputTarget, rootDir) {
+     const angularCoreImports = ['ChangeDetectionStrategy', 'ChangeDetectorRef', 'Component', 'ElementRef'];
+     if (includeOutputImports) {
+         angularCoreImports.push('EventEmitter');
++        angularCoreImports.push('Output');
+     }
+     angularCoreImports.push('NgZone');
+     /**
+@@ -468,7 +491,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
+         inputs.sort();
+         const outputs = [];
+         if (cmpMeta.events) {
+-            outputs.push(...cmpMeta.events.filter(filterInternalProps).map(mapPropName));
++            outputs.push(...cmpMeta.events.filter(filterInternalProps));
+         }
+         const methods = [];
+         if (cmpMeta.methods) {
+diff --git a/node_modules/@stencil/angular-output-target/dist/index.js b/node_modules/@stencil/angular-output-target/dist/index.js
+index df5aeb9..61fc2c6 100644
+--- a/node_modules/@stencil/angular-output-target/dist/index.js
++++ b/node_modules/@stencil/angular-output-target/dist/index.js
+@@ -140,7 +140,7 @@ const createAngularComponentDefinition = (tagName, inputs, outputs, methods, inc
+     // Formats the input strings into comma separated, single quoted values.
+     const formattedInputs = formatToQuotedList(inputs);
+     // Formats the output strings into comma separated, single quoted values.
+-    const formattedOutputs = formatToQuotedList(outputs);
++    const formattedOutputs = formatToQuotedList(outputs.map((event) => event.name));
+     // Formats the method strings into comma separated, single quoted values.
+     const formattedMethods = formatToQuotedList(methods);
+     const proxyCmpOptions = [];
+@@ -154,32 +154,54 @@ const createAngularComponentDefinition = (tagName, inputs, outputs, methods, inc
+     if (hasMethods) {
+         proxyCmpOptions.push(`\n  methods: [${formattedMethods}]`);
+     }
+-    /**
+-     * Notes on the generated output:
+-     * - We disable @angular-eslint/no-inputs-metadata-property, so that
+-     * Angular does not complain about the inputs property. The output target
+-     * uses the inputs property to define the inputs of the component instead of
+-     * having to use the @Input decorator (and manually define the type and default value).
+-     */
+-    const output = `@ProxyCmp({${proxyCmpOptions.join(',')}\n})
+-@Component({
+-  selector: '${tagName}',
+-  changeDetection: ChangeDetectionStrategy.OnPush,
+-  template: '<ng-content></ng-content>',
+-  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+-  inputs: [${formattedInputs}],
+-})
+-export class ${tagNameAsPascal} {
+-  protected el: HTMLElement;
+-  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+-    c.detach();
+-    this.el = r.nativeElement;${hasOutputs
+-        ? `
+-    proxyOutputs(this, this.el, [${formattedOutputs}]);`
+-        : ''}
+-  }
+-}`;
+-    return output;
++    const output = [
++        `@ProxyCmp({${proxyCmpOptions.join(',')}\n})`,
++        `@Component({`,
++        `  selector: '${tagName}',`,
++        `  changeDetection: ChangeDetectionStrategy.OnPush,`,
++        `  template: '<ng-content></ng-content>',`,
++        /**
++         * We disable @angular-eslint/no-inputs-metadata-property, so that
++         * Angular does not complain about the inputs property. The output target
++         * uses the inputs property to define the inputs of the component instead of
++         * having to use the @Input decorator (and manually define the type and default value).
++         */
++        `  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property`,
++        `  inputs: [${formattedInputs}],`,
++        `})`,
++        `export class ${tagNameAsPascal} {`,
++    ];
++    if (hasOutputs) {
++        for (let compilerEvent of outputs) {
++            output.push(`  ${createAngularOutputDecorator(tagName, compilerEvent)}`);
++        }
++    }
++    output.push(`  protected el: HTMLElement;`);
++    output.push(`  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {`);
++    output.push(`    c.detach();`);
++    output.push(`    this.el = r.nativeElement;`);
++    if (hasOutputs) {
++        output.push(`    proxyOutputs(this, this.el, [${formattedOutputs}]);`);
++    }
++    output.push(`  }`);
++    output.push(`}`);
++    return output.join('\n');
++};
++/**
++ * Creates an `@Output()` decorator for a custom event on a Stencil component.
++ * @param tagName The tag name of the component.
++ * @param event The Stencil component event.
++ * @returns The `@Output()` decorator as a string.
++ */
++const createAngularOutputDecorator = (tagName, event) => {
++    const tagNameAsPascal = dashToPascalCase(tagName);
++    // When updating to Stencil 3.0, the component custom event generic will be
++    // exported by default and can be referenced here with:
++    // const customEvent = `${tagNameAsPascal}CustomEvent`;
++    const customEventType = `CustomEvent`;
++    const eventType = formatOutputType(tagNameAsPascal, event);
++    const outputType = `${customEventType}<${eventType}>`;
++    return `@Output() ${event.name}: EventEmitter<${outputType}> = new EventEmitter();`;
+ };
+ /**
+  * Sanitizes and formats the component event type.
+@@ -391,6 +413,7 @@ function generateProxies(components, pkgData, outputTarget, rootDir) {
+     const angularCoreImports = ['ChangeDetectionStrategy', 'ChangeDetectorRef', 'Component', 'ElementRef'];
+     if (includeOutputImports) {
+         angularCoreImports.push('EventEmitter');
++        angularCoreImports.push('Output');
+     }
+     angularCoreImports.push('NgZone');
+     /**
+@@ -460,7 +483,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
+         inputs.sort();
+         const outputs = [];
+         if (cmpMeta.events) {
+-            outputs.push(...cmpMeta.events.filter(filterInternalProps).map(mapPropName));
++            outputs.push(...cmpMeta.events.filter(filterInternalProps));
+         }
+         const methods = [];
+         if (cmpMeta.methods) {
+diff --git a/node_modules/@stencil/angular-output-target/dist/output-angular.js b/node_modules/@stencil/angular-output-target/dist/output-angular.js
+index c84fc38..36cffed 100644
+--- a/node_modules/@stencil/angular-output-target/dist/output-angular.js
++++ b/node_modules/@stencil/angular-output-target/dist/output-angular.js
+@@ -47,6 +47,7 @@ export function generateProxies(components, pkgData, outputTarget, rootDir) {
+     const angularCoreImports = ['ChangeDetectionStrategy', 'ChangeDetectorRef', 'Component', 'ElementRef'];
+     if (includeOutputImports) {
+         angularCoreImports.push('EventEmitter');
++        angularCoreImports.push('Output');
+     }
+     angularCoreImports.push('NgZone');
+     /**
+@@ -116,7 +117,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
+         inputs.sort();
+         const outputs = [];
+         if (cmpMeta.events) {
+-            outputs.push(...cmpMeta.events.filter(filterInternalProps).map(mapPropName));
++            outputs.push(...cmpMeta.events.filter(filterInternalProps));
+         }
+         const methods = [];
+         if (cmpMeta.methods) {

--- a/website/docs/voor-maintainers/dependencies-update-procedure.md
+++ b/website/docs/voor-maintainers/dependencies-update-procedure.md
@@ -2,7 +2,25 @@
 
 Dependency updates doen we bij voorkeur aan het begin van een sprint zodat we de nieuwe versies zelf kunnen ervaren. Dit sluit bevindingen van afnemers natuurlijk niet uit.
 
+## Patches
+
 Inventariseer voor welke packages er patches zijn gemaakt in `/patches`. Voor een update van een package met 'n patch betekent onderzoek naar de gevolgen.
+
+In release 🪼 69.3.0 kennen we 2 patches:
+
+### `@stencil+angular-output-target+0.7.1.patch`
+
+In deze patch fixen wij een bug (omissie) in `@stencil/angular-output-target`, waarbij de events die web-componenten
+kunnen emitten niet herkend worden door een IDE. Deze fix zorgt ervoor dat de door
+`@stencil/angular-output-target` gegenereerde code de juiste typings bevat, zodat er wel
+intellisense/code-completion is in de IDE.
+Momenteel kunnen we `@stencil/angular-output-target` niet zonder meerwerk updaten. Pas wanneer het DSO-toolkit
+github-issue [3049](https://github.com/dso-toolkit/dso-toolkit/pull/3059) in een reproduceerbare en in een
+Angular-project verifieerbare oplossing heeft geresulteerd gaan we daar mee verder.
+
+### `@whitespace+storybook-addon-html+5.1.6.patch`
+
+🚧 Documentatie volgt 🚧
 
 ## Yarn update
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3646,7 +3646,7 @@ __metadata:
   resolution: "@dso-toolkit/core@workspace:packages/core"
   dependencies:
     "@popperjs/core": "npm:^2.11.8"
-    "@stencil/angular-output-target": "npm:0.10.2"
+    "@stencil/angular-output-target": "npm:0.7.1"
     "@stencil/core": "npm:4.25.1"
     "@stencil/react-output-target": "npm:^0.7.4"
     "@stencil/sass": "npm:^3.0.12"
@@ -7507,12 +7507,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/angular-output-target@npm:0.10.2":
-  version: 0.10.2
-  resolution: "@stencil/angular-output-target@npm:0.10.2"
+"@stencil/angular-output-target@npm:0.7.1":
+  version: 0.7.1
+  resolution: "@stencil/angular-output-target@npm:0.7.1"
   peerDependencies:
     "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
-  checksum: 10/285604aa8ec0ddb9739ef964596e806d9966fcd57da002cad4d8fbb003bc8ea627c129e25925178ac834d55aff4b60d4f0ea32f253d6f7316fd763241a9aa716
+  checksum: 10/04bda55be6777df786b71f4be27c93e0ac1be3db9b61a78d6e335bc927d5f34af743d80e54751165319fcc54c56875ab22243b9a2d1ce86b6bdc5e8373f07966
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [ ] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl

### Opmerking
Ik heb lokaal een separaat Angular 19 project aangemaakt. Daarin heb ik `@dso-toolkit/core`, `@dso-toolkit/angular` en `dso-toolkit` geïnstalleerd. Vervolgens heb ik in mijn lokale workspace van dso-toolkit op de branch van deze PR `yarn` en `yarn patch-package` gedaan. Daarna een `yarn build`. Vervolgens heb ik de inhoud van `angular-workspace/dist/component-library` gekopieerd naar `node_modules/@dso-toolkit/angular` van het separate Angular 19 project. In de `app.component.html` heb ik 
```angular
<dso-survey-rating (dsoClose)="handleClose($event)" (dsoSubmit)="handleSubmit($event)"></dso-survey-rating>
```
geplaatst.

Er is weer code-completion:
![Screenshot 2025-03-21 at 13 29 05](https://github.com/user-attachments/assets/70192d08-9086-4051-be9d-7ce503fd2d3d)

En de toolkit werkt:
![Screenshot 2025-03-21 at 13 29 45](https://github.com/user-attachments/assets/df9cc2a9-3b1d-4387-83a0-d89f31aa4eaf)

