### PR TITLE
#2934 [Task] Document Component: flaky e2e tests verbeteren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Packages: Dependencies updates ([#2977](https://github.com/dso-toolkit/dso-toolkit/issues/2977))
 * Dropdown Menu: Flaky tests fix ([#3081](https://github.com/dso-toolkit/dso-toolkit/issues/3081))
 * Action List: flaky screenshot test ([#2894](https://github.com/dso-toolkit/dso-toolkit/issues/2894))
+* Document Component: flaky e2e tests verbeteren ([#2934](https://github.com/dso-toolkit/dso-toolkit/issues/2934))
 
 ## 🪼 Release 69.2.1 - 2025-03-21
 

--- a/packages/core/src/components/list-button/list-button.tsx
+++ b/packages/core/src/components/list-button/list-button.tsx
@@ -102,7 +102,9 @@ export class ListButton implements ComponentInterface {
   }
 
   componentDidRender(): void {
-    this.subcontentSlot?.setAttribute("aria-hidden", "true");
+    if (!this.subcontentSlot?.hasAttribute("aria-hidden")) {
+      this.subcontentSlot?.setAttribute("aria-hidden", "true");
+    }
   }
 
   disconnectedCallback(): void {

--- a/storybook/cypress/e2e/document-component.cy.ts
+++ b/storybook/cypress/e2e/document-component.cy.ts
@@ -41,8 +41,7 @@ describe("Document Component", () => {
 
   for (const wijzigactie of states) {
     for (const annotationsWijzigactie of states) {
-      // Test uitgezet ivm flakyness. Gaan we weer aanzetten in #2934
-      it.skip(`matches image snapshot wijzigactie ${wijzigactie} with annotationsWijzigactie ${annotationsWijzigactie}`, () => {
+      it(`matches image snapshot wijzigactie ${wijzigactie} with annotationsWijzigactie ${annotationsWijzigactie}`, () => {
         // this test uses args to set the initial state of the component because the argsMapper is needed for the annotations
         cy.visit(
           "http://localhost:45000/iframe.html?id=core-document-component--default&args=open:!true;openAnnotation:!true",
@@ -60,8 +59,7 @@ describe("Document Component", () => {
   }
 
   for (const state of ["default", "voegtoe", "verwijder"]) {
-    // Test uitgezet ivm flakyness. Gaan we weer aanzetten in #2934
-    it.skip(`matches image snapshot ${state} - table-of-contents`, () => {
+    it(`matches image snapshot ${state} - table-of-contents`, () => {
       cy.visit(
         "http://localhost:45000/iframe.html?id=core-document-component--default&args=filtered:!false;mode:table-of-contents",
       )

--- a/storybook/cypress/support/commands.ts
+++ b/storybook/cypress/support/commands.ts
@@ -72,16 +72,12 @@ Cypress.Commands.overwrite("visit", (originalFn, url, options) => {
 });
 
 /**
- * This overwrite tries to wait for all fonts to load before taking the screenshot.
+ * This overwrite waits for the DOM to stabilise before taking the screenshot.
  *
- * See #2748 for more information.
+ * See https://github.com/narinluangrath/cypress-wait-for-stable-dom.
  */
 Cypress.Commands.overwrite("screenshot", (originalFn, ...args) => {
-  return cy
-    .document()
-    .its("fonts.status")
-    .should("equal", "loaded", { timeout: 10000 })
-    .then(() => originalFn(...args));
+  return cy.waitForStableDOM().then(() => originalFn(...args));
 });
 
 /**

--- a/storybook/cypress/support/e2e.ts
+++ b/storybook/cypress/support/e2e.ts
@@ -20,6 +20,7 @@ import "cypress-axe";
 import "cypress-real-events";
 
 import { addMatchImageSnapshotCommand } from "@simonsmith/cypress-image-snapshot/command";
+import { registerCommand } from "cypress-wait-for-stable-dom";
 
 addMatchImageSnapshotCommand({
   failureThreshold: 0.1,
@@ -28,3 +29,5 @@ addMatchImageSnapshotCommand({
   customDiffDir: "cypress/snapshot-diff",
   customSnapshotsDir: "cypress/snapshot-baseline",
 });
+
+registerCommand();

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -36,6 +36,7 @@
     "cypress-multi-reporters": "2.0.5",
     "cypress-parallel": "0.14.0",
     "cypress-real-events": "^1.14.0",
+    "cypress-wait-for-stable-dom": "^0.1.0",
     "dso-toolkit": "workspace:^",
     "http-proxy-middleware": "^3.0.3",
     "http-server": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13744,6 +13744,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cypress-wait-for-stable-dom@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "cypress-wait-for-stable-dom@npm:0.1.0"
+  checksum: 10/c8d505dcc92c9e56831543b07beecc46937076e643a77cbfef57bb05c32c3a1d446b84ef3da6f38517a5f74d8d6ee9767550c15ce1612643cd16f557efddb3fc
+  languageName: node
+  linkType: hard
+
 "cypress@npm:^13.17.0":
   version: 13.17.0
   resolution: "cypress@npm:13.17.0"
@@ -14667,6 +14674,7 @@ __metadata:
     cypress-multi-reporters: "npm:2.0.5"
     cypress-parallel: "npm:0.14.0"
     cypress-real-events: "npm:^1.14.0"
+    cypress-wait-for-stable-dom: "npm:^0.1.0"
     dso-toolkit: "workspace:^"
     http-proxy-middleware: "npm:^3.0.3"
     http-server: "npm:^14.1.1"


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl

# De oplossing:

We maken nu gebruik van de npm-package `cypress-wait-for-stable-dom` met de default options. 
Zie: https://github.com/narinluangrath/cypress-wait-for-stable-dom.

De overwrite van het Cypress command `screenshot` heb ik aangepast. Op deze centrale plek wordt nu altijd `waitForStableDom()` uitgevoerd, voordat het screenshot genomen wordt. 🙏 .

# De Toelichting
## header.cy.ts
De diff `should be accessible -- dropdown menu.diff.png` van wordt veroorzaakt doordat nu (voor het eerst) lang genoeg wordt gewacht wordt, voordat het screenshot genomen wordt.
![should be accessible -- dropdown menu diff](https://github.com/user-attachments/assets/3256c1da-dda8-4d10-abf1-2cf6f35858f4)

## document-component.cy.ts
Er zijn 12 nieuwe screenshot voor Document Component: die zijn in deze PR weer aangezet.

## list-button.cy.ts
En deze van `List Button` is een interessante, want hier zien we de wait for stable DOM een timeout krijgen.
```
{
  test: 'ListButton - should render subcontent in slot without prefix (cypress/e2e/list-button.cy.ts)',
  error: 'Error: Timed out waiting for stable DOM\n' +
    '    at Context.eval (webpack://dso-storybook/../node_modules/cypress-wait-for-stable-dom/src/wait-for-stable-dom.js:49:0)'
}
```
Na enig speurwerk in de console van de cypress runner kom ik er achter dat dit inderdaad gebeurt om dat in `list-button-tsx`
```
  componentDidRender(): void {
       this.subcontentSlot?.setAttribute("aria-hidden", "true");
  }
```
continu wordt aangeroepen.
![Screenshot 2025-03-27 at 13 10 32](https://github.com/user-attachments/assets/db9bb038-5f82-4d53-bab8-4d34579f2610)

Nu heb ik er dit van gemaakt:
```
  componentDidRender(): void {
    if (!this.subcontentSlot?.hasAttribute("aria-hidden")) {
      this.subcontentSlot?.setAttribute("aria-hidden", "true");
    }
  }
```

De test gaat nu goed.

Maar de dieperliggende oorzaak ontgaat mij @tfrijsewijk