### PR TITLE
#3042 [Changed] Accordion: Kleine visuele verbeteringen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Accordion: Kleine visuele verbeteringen ([#3042](https://github.com/dso-toolkit/dso-toolkit/issues/3042))
+
 ### Fixed
 * Button: Externe links in Highlight-box hebben herhalend icoon ([#3055](https://github.com/dso-toolkit/dso-toolkit/issues/3055))
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-compact-black.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-compact-black.scss
@@ -47,8 +47,7 @@
   .dso-section-handle {
     a,
     button {
-      padding-inline-start: units.$u2;
-      padding-inline-end: 0;
+      padding-inline: units.$u2 0;
     }
   }
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-compact-black.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-compact-black.scss
@@ -48,6 +48,7 @@
     a,
     button {
       padding-inline-start: units.$u2;
+      padding-inline-end: 0;
     }
   }
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
@@ -40,6 +40,7 @@
     a,
     button {
       padding-inline-start: units.$u2;
+      padding-inline-end: 0;
     }
   }
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-compact.scss
@@ -39,8 +39,7 @@
   .dso-section-handle {
     a,
     button {
-      padding-inline-start: units.$u2;
-      padding-inline-end: 0;
+      padding-inline: units.$u2 0;
     }
   }
 

--- a/packages/core/src/components/accordion/components/accordion-section-theme-neutral.scss
+++ b/packages/core/src/components/accordion/components/accordion-section-theme-neutral.scss
@@ -15,7 +15,7 @@
     button {
       color: accordion.$neutral-color;
       padding-block: 5px;
-      padding-inline: 0 16px;
+      padding-inline: 0;
 
       &:hover,
       &:active,

--- a/packages/core/src/components/accordion/components/accordion-section.scss
+++ b/packages/core/src/components/accordion/components/accordion-section.scss
@@ -37,6 +37,8 @@
     }
 
     .dso-status {
+      color: colors.$zwart;
+      font-size: typography.$font-size-small;
       font-weight: 400;
     }
   }
@@ -83,7 +85,7 @@
 
       dso-attachments-counter,
       dso-icon {
-        margin-inline-start: units.$u2;
+        margin-inline-start: units.$u1;
       }
     }
 

--- a/packages/dso-toolkit/src/components/accordion/accordion-theme-compact.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion-theme-compact.scss
@@ -115,6 +115,7 @@
       a,
       button {
         padding-inline-start: units.$u2;
+        padding-inline-end: units.$u4;
 
         &::before {
           @include di.base("chevron-down-grasgroen");

--- a/packages/dso-toolkit/src/components/accordion/accordion-theme-compact.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion-theme-compact.scss
@@ -114,8 +114,7 @@
     .dso-section-handle {
       a,
       button {
-        padding-inline-start: units.$u2;
-        padding-inline-end: units.$u4;
+        padding-inline: units.$u2 units.$u4;
 
         &::before {
           @include di.base("chevron-down-grasgroen");

--- a/packages/dso-toolkit/src/components/accordion/accordion-theme-default.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion-theme-default.scss
@@ -32,7 +32,7 @@
             a,
             button {
               &::before {
-                @include di.variant("chevron-down-mauve");
+                @include di.variant("chevron-down-wit");
               }
             }
           }
@@ -62,6 +62,7 @@
 
       .dso-status {
         text-decoration: underline;
+        color: colors.$zwart;
       }
     }
   }
@@ -93,6 +94,10 @@
             &::after {
               @include di.variant("paperclip-wit");
             }
+          }
+
+          .dso-status {
+            color: colors.$wit;
           }
         }
       }

--- a/packages/dso-toolkit/src/components/accordion/accordion.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion.scss
@@ -46,8 +46,7 @@
         padding-inline-end: units.$u6;
 
         &::before {
-          inset-inline-start: auto;
-          inset-inline-end: 0;
+          inset-inline: auto 0;
         }
 
         .dso-icon {
@@ -162,6 +161,18 @@
   }
 
   &.dso-accordion-compact-black.dso-accordion-reverse-align {
+    .dso-accordion-section:not(.dso-open) {
+      .dso-section-handle {
+        a,
+        a:hover,
+        button,
+        button:hover {
+          &::before {
+            @include di.base("chevron-down-zwart", accordion.$chevron-icon-size);
+          }
+        }
+      }
+    }
     .dso-accordion-section {
       &.dso-open:not(.dso-nested-accordion) {
         .dso-section-handle {
@@ -225,7 +236,6 @@
       .dso-status,
       .dso-icon {
         font-weight: 400;
-        color: colors.$zwart;
         font-size: typography.$font-size-small;
         margin-inline-start: units.$u2;
       }

--- a/packages/dso-toolkit/src/components/accordion/accordion.scss
+++ b/packages/dso-toolkit/src/components/accordion/accordion.scss
@@ -1,5 +1,6 @@
 @use "../../variables/units";
 @use "../../variables/colors";
+@use "../../variables/typography";
 @use "../../components/anchor";
 @use "../../components/accordion";
 
@@ -46,7 +47,7 @@
 
         &::before {
           inset-inline-start: auto;
-          inset-inline-end: units.$u2;
+          inset-inline-end: 0;
         }
 
         .dso-icon {
@@ -73,6 +74,13 @@
     &,
     .dso-nested-accordion .dso-accordion {
       @include accordion-theme-conclusion.conclusion();
+    }
+  }
+
+  &:not(.dso-accordion-compact):not(.dso-accordion-compact-black).dso-accordion-reverse-align .dso-section-handle {
+    a::before,
+    button::before {
+      inset-inline-end: units.$u2;
     }
   }
 
@@ -217,6 +225,8 @@
       .dso-status,
       .dso-icon {
         font-weight: 400;
+        color: colors.$zwart;
+        font-size: typography.$font-size-small;
         margin-inline-start: units.$u2;
       }
 

--- a/storybook/cypress/e2e/accordion.cy.ts
+++ b/storybook/cypress/e2e/accordion.cy.ts
@@ -130,6 +130,7 @@ describe("Accordion", () => {
     cy.get("dso-accordion.hydrated")
       .find("dso-accordion-section")
       .first()
+      .as("accordionSection")
       .invoke("attr", "status-description", statusDescription)
       .shadow()
       .find(".dso-section-handle .dso-status")
@@ -162,7 +163,7 @@ describe("Accordion", () => {
       .children("dso-icon")
       .should("exist");
 
-    cy.get("@accordionSection").matchImageSnapshot(`${Cypress.currentTest.title} -- reverse-align mode`);
+    cy.get("@dsoAccordion").matchImageSnapshot(`${Cypress.currentTest.title} -- reverse-align mode`);
   });
 
   it("should focus handle element with AccordionSection.focusHandle()", () => {

--- a/storybook/cypress/e2e/accordion.cy.ts
+++ b/storybook/cypress/e2e/accordion.cy.ts
@@ -134,6 +134,8 @@ describe("Accordion", () => {
       .shadow()
       .find(".dso-section-handle .dso-status")
       .should("contain.text", statusDescription);
+
+    cy.get("@accordionSection").matchImageSnapshot(`${Cypress.currentTest.title} -- status description`);
   });
 
   it("should render the handle correctly in reverseAlign mode", () => {
@@ -159,6 +161,8 @@ describe("Accordion", () => {
       .find(".dso-section-handle-addons")
       .children("dso-icon")
       .should("exist");
+
+    cy.get("@accordionSection").matchImageSnapshot(`${Cypress.currentTest.title} -- reverse-align mode`);
   });
 
   it("should focus handle element with AccordionSection.focusHandle()", () => {


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
  - Action-list heeft een padding wijziging waardoor er een diff ontstaan met het icon van de neutral variant
  - Er worden twee nieuwe screenshots gemaakt van de accordion
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
