### PR TITLE
#3101 [Fixed] Logo: Ribbon uit positie wanneer logo-url aanwezig is en label-url afwezig is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Next
 
 ### Fixed
+* Logo: Ribbon uit positie wanneer logo-url aanwezig is en label-url afwezig is ([#3101](https://github.com/dso-toolkit/dso-toolkit/issues/3101))
 * Viewer Grid: ScrollIntoView scrolled te ver door ([#3096](https://github.com/dso-toolkit/dso-toolkit/issues/3096))
 
 ## 🛩️ Release 70.1.0 - 2025-04-14

--- a/packages/core/src/components/logo/logo.scss
+++ b/packages/core/src/components/logo/logo.scss
@@ -35,17 +35,11 @@
   }
 }
 
-:host([logo-url][ribbon]) {
+:host([logo-url]:not([logo-url=""])[ribbon]:not([ribbon=""])) {
   grid-template-areas: "targetwordmark label";
 
-  .logo-url {
-    grid-area: targetwordmark;
-    + .logo-ribbon {
-      grid-area: targetwordmark;
-    }
-  }
-
-  .logo-label-url + .logo-ribbon {
+  .logo-url,
+  .logo-ribbon {
     grid-area: targetwordmark;
   }
 }

--- a/storybook/cypress/e2e/logo.cy.ts
+++ b/storybook/cypress/e2e/logo.cy.ts
@@ -222,6 +222,19 @@ describe("Logo", () => {
     cy.dsoCheckA11y("dso-logo.hydrated");
   });
 
+  it("with an empty label-url, the beta tag still shows on the correct place", () => {
+    cy.get("dso-logo")
+      .invoke("attr", "ribbon", "beta")
+      .invoke("attr", "label-url", "")
+      .shadow()
+      .find(".logo-ribbon")
+      .should("be.visible")
+      .should("have.text", "beta");
+    cy.get("dso-logo.hydrated").matchImageSnapshot();
+    cy.injectAxe();
+    cy.dsoCheckA11y("dso-logo.hydrated");
+  });
+
   it("should be accessible", () => {
     cy.get("dso-logo.hydrated").matchImageSnapshot();
     cy.injectAxe();


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
  - **Er is een nieuwe snapshot wanneer het ribbon attribuut is gevuld en het label-url niet**
  
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl. (https://storybook.dso-toolkit.nl/_3101-header-ribbon-position-bug/?path=/story/core-logo--with-logo-url-and-label-and-label-url&args=ribbon:test, gooi label-url attribuut leeg op het logo component)
