### PR TITLE
#3046 [Added] Survey Rating: Vraagteken achter de vraag en role alert toevoegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 * Viewer Grid: Top bar in het grid plaatsen ([#3103](https://github.com/dso-toolkit/dso-toolkit/issues/3103))
+* Survey Rating: Vraagteken achter de vraag en role alert toevoegen ([#3046](https://github.com/dso-toolkit/dso-toolkit/issues/3046))
 
 ### Task
 * Packages: Dependencies updates ([#3091](https://github.com/dso-toolkit/dso-toolkit/issues/3091))

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -3850,7 +3850,7 @@ declare namespace LocalJSX {
          */
         "onDsoClose"?: (event: DsoSurveyRatingCustomEvent<SurveyRatingCloseEvent>) => void;
         /**
-          * Emitted when user submits the Survey Rating.
+          * Emitted when the user submits the Survey Rating.
          */
         "onDsoSubmit"?: (event: DsoSurveyRatingCustomEvent<SurveyRatingSubmitEvent>) => void;
     }

--- a/packages/core/src/components/survey-rating/readme.md
+++ b/packages/core/src/components/survey-rating/readme.md
@@ -10,7 +10,7 @@
 | Event       | Description                                              | Type                                   |
 | ----------- | -------------------------------------------------------- | -------------------------------------- |
 | `dsoClose`  | Emitted when the user wants to close the  Survey Rating. | `CustomEvent<SurveyRatingCloseEvent>`  |
-| `dsoSubmit` | Emitted when user submits the Survey Rating.             | `CustomEvent<SurveyRatingSubmitEvent>` |
+| `dsoSubmit` | Emitted when the user submits the Survey Rating.         | `CustomEvent<SurveyRatingSubmitEvent>` |
 
 
 ## Dependencies

--- a/packages/core/src/components/survey-rating/survey-rating.tsx
+++ b/packages/core/src/components/survey-rating/survey-rating.tsx
@@ -43,8 +43,15 @@ export class SurveyRating implements ComponentInterface {
     ];
 
     return (
-      <dso-panel emphasized onDsoCloseClick={(e) => this.dsoClose.emit({ originalEvent: e })} role="alert">
-        <h2 slot="heading">Help ons met een onderzoek</h2>
+      <dso-panel
+        emphasized
+        onDsoCloseClick={(e) => this.dsoClose.emit({ originalEvent: e })}
+        role="dialog"
+        aria-labelledby="panel-heading"
+      >
+        <h2 id="panel-heading" slot="heading">
+          Help ons met een onderzoek
+        </h2>
         <strong>Hoe moeilijk of makkelijk was deze taak om uit te voeren?</strong>
         <form onSubmit={(e) => this.handleForm(e)}>
           <div class="visual-rating-labels" aria-hidden="true">

--- a/packages/core/src/components/survey-rating/survey-rating.tsx
+++ b/packages/core/src/components/survey-rating/survey-rating.tsx
@@ -10,7 +10,7 @@ export class SurveyRating implements ComponentInterface {
   private rating: number | undefined;
 
   /**
-   * Emitted when user submits the Survey Rating.
+   * Emitted when the user submits the Survey Rating.
    */
   @Event()
   dsoSubmit!: EventEmitter<SurveyRatingSubmitEvent>;
@@ -43,9 +43,9 @@ export class SurveyRating implements ComponentInterface {
     ];
 
     return (
-      <dso-panel emphasized onDsoCloseClick={(e) => this.dsoClose.emit({ originalEvent: e })}>
+      <dso-panel emphasized onDsoCloseClick={(e) => this.dsoClose.emit({ originalEvent: e })} role="alert">
         <h2 slot="heading">Help ons met een onderzoek</h2>
-        <strong>Hoe moeilijk of makkelijk was deze taak om uit te voeren</strong>
+        <strong>Hoe moeilijk of makkelijk was deze taak om uit te voeren?</strong>
         <form onSubmit={(e) => this.handleForm(e)}>
           <div class="visual-rating-labels" aria-hidden="true">
             <span>Heel moeilijk</span>


### PR DESCRIPTION


- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [ ] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
