### PR TITLE
#3116 [Changed] ListButton: indent en styling subcontent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
-### Task
-* Prettier: gebruik prettier-config van `@infoprojects/prettier-config` ([#3127](https://github.com/dso-toolkit/dso-toolkit/issues/3127))
-
 ### Changed
 * Searchbar: Uitlijnen dropdown met titel invulveld ([#3104](https://github.com/dso-toolkit/dso-toolkit/issues/3104))
 * Autosuggest: Aanpassing top padding Suggestion Groups ([#3060](https://github.com/dso-toolkit/dso-toolkit/issues/3060))
+* ListButton: indent en styling subcontent ([#3116](https://github.com/dso-toolkit/dso-toolkit/issues/3116))
+* 
+### Task
+* Prettier: gebruik prettier-config van `@infoprojects/prettier-config` ([#3127](https://github.com/dso-toolkit/dso-toolkit/issues/3127))
 
 ## 🏋🏼 Release 72.2.0 - 2025-05-08
 

--- a/packages/core/src/components/list-button/list-button.scss
+++ b/packages/core/src/components/list-button/list-button.scss
@@ -211,7 +211,8 @@
     display: block;
   }
 
-  .dso-sublabel {
+  .dso-sublabel,
+  .subcontent {
     font-weight: 400;
     inline-size: 100%;
     padding-inline-start: selectable.$size + units.$u1;

--- a/packages/core/src/components/list-button/list-button.tsx
+++ b/packages/core/src/components/list-button/list-button.tsx
@@ -187,7 +187,11 @@ export class ListButton implements ComponentInterface {
               {this.sublabel}
             </span>
           )}
-          <slot name="subcontent" />
+          {this.subcontentSlot && (
+            <div class="subcontent">
+              <slot name="subcontent" />
+            </div>
+          )}
         </div>
 
         {this.count !== undefined && this.count > 0 && (


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
