### PR TITLE
#3130 [Fixed] Map Controls: bij inzoomen heeft de knop kaartlagen geen accessible name meer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Map Controls: bij inzoomen heeft de knop kaartlagen geen accessible name meer ([#3130](https://github.com/dso-toolkit/dso-toolkit/issues/3130))
+
 ## 🪜 Release 73.0.1 - 2025-05-16
 
 ### Fixed

--- a/packages/core/src/components/map-controls/map-controls.scss
+++ b/packages/core/src/components/map-controls/map-controls.scss
@@ -140,7 +140,7 @@ header {
     }
 
     span {
-      visibility: hidden;
+      @include utilities.sr-only();
     }
   }
 


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
