### PR TITLE
#3168 [Fixed] Alert: Icon bij de link heeft de verkeerde kleur in core variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Alert: Icon bij de link heeft de verkeerde kleur in core variant ([#3168](https://github.com/dso-toolkit/dso-toolkit/issues/3168))
+
 ### Changed
 * **BREAKING** Modal: Closable ([#2743](https://github.com/dso-toolkit/dso-toolkit/issues/2743))
 

--- a/packages/core/src/components/alert/alert.scss
+++ b/packages/core/src/components/alert/alert.scss
@@ -6,55 +6,6 @@
   display: block;
 }
 
-:host(:not(:first-child)) {
-  margin-block-start: units.$u3;
-}
-
-:host([compact]:not([compact="false"])) {
-  position: relative;
-  @include alert.compact();
-}
-
-:host([status="success"]) {
-  @include alert.status-success();
-}
-
-:host([status="success"][compact]:not([compact="false"])) {
-  &::before {
-    background-color: alert.$success-compact-accent-bg;
-  }
-}
-
-:host([status="error"]) {
-  @include alert.status-error();
-}
-
-:host([status="error"][compact]:not([compact="false"])) {
-  &::before {
-    background-color: alert.$danger-compact-accent-bg;
-  }
-}
-
-:host([status="warning"]) {
-  @include alert.status-warning();
-}
-
-:host([status="warning"][compact]:not([compact="false"])) {
-  &::before {
-    background-color: alert.$warning-compact-accent-bg;
-  }
-}
-
-:host([status="info"]) {
-  @include alert.status-info();
-}
-
-:host([status="info"][compact]:not([compact="false"])) {
-  &::before {
-    background-color: alert.$info-compact-accent-bg;
-  }
-}
-
 @include utilities.box-sizing();
 
 .sr-only {

--- a/packages/core/src/components/alert/alert.scss
+++ b/packages/core/src/components/alert/alert.scss
@@ -6,6 +6,10 @@
   display: block;
 }
 
+:host(:not(:first-child)) {
+  margin-block-start: units.$u3;
+}
+
 @include utilities.box-sizing();
 
 .sr-only {

--- a/packages/dso-toolkit/src/components/alert/alert.scss
+++ b/packages/dso-toolkit/src/components/alert/alert.scss
@@ -132,8 +132,4 @@ dso-alert {
       background-color: alert.$info-compact-accent-bg;
     }
   }
-
-  &:not(:first-child) {
-    margin-block-start: units.$u3;
-  }
 }

--- a/packages/dso-toolkit/src/components/alert/alert.scss
+++ b/packages/dso-toolkit/src/components/alert/alert.scss
@@ -1,10 +1,10 @@
 @use "../alert";
 @use "../../di";
+@use "../../variables/units";
 
 // HTML/CSS
 .alert {
   @include alert.root();
-
   @include alert.children();
 
   .dso-close {
@@ -86,4 +86,54 @@
 // Web Component
 dso-alert {
   @include alert.children();
+
+  &[status="success"] {
+    @include alert.status-success();
+  }
+
+  &[status="error"] {
+    @include alert.status-error();
+  }
+
+  &[status="warning"] {
+    @include alert.status-warning();
+  }
+
+  &[status="info"] {
+    @include alert.status-info();
+  }
+
+  &[compact]:not([compact="false"]) {
+    @include alert.compact();
+
+    position: relative;
+  }
+
+  &[status="success"][compact]:not([compact="false"]) {
+    &::before {
+      background-color: alert.$success-compact-accent-bg;
+    }
+  }
+
+  &[status="error"][compact]:not([compact="false"]) {
+    &::before {
+      background-color: alert.$danger-compact-accent-bg;
+    }
+  }
+
+  &[status="warning"][compact]:not([compact="false"]) {
+    &::before {
+      background-color: alert.$warning-compact-accent-bg;
+    }
+  }
+
+  &[status="info"][compact]:not([compact="false"]) {
+    &::before {
+      background-color: alert.$info-compact-accent-bg;
+    }
+  }
+
+  &:not(:first-child) {
+    margin-block-start: units.$u3;
+  }
 }


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl


Ik heb de css moeten verplaatsen naar de dso-toolkit folder, zoals bij `banner.scss` het geval is. De `set-colors.apply` sass functie lijkt anders niet goed te werken.