### PR TITLE
#3170 [Changed] Badge: Verwijderen danger variant en kleuraanpassing info variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
-### Fixed
-* Alert: Icon bij de link heeft de verkeerde kleur in core variant ([#3168](https://github.com/dso-toolkit/dso-toolkit/issues/3168))
-
 ### Changed
 * **BREAKING** Banner: Verwijderen Danger variant en toevoegen Succes variant ([#3187](https://github.com/dso-toolkit/dso-toolkit/issues/3187))
 * **BREAKING** Modal: Closable ([#2743](https://github.com/dso-toolkit/dso-toolkit/issues/2743))
 * **BREAKING** Legend Item: Aanpassingen ([#3185](https://github.com/dso-toolkit/dso-toolkit/issues/3185))
+* **BREAKING** Badge: Verwijderen danger variant en kleuraanpassing info variant ([#3170](https://github.com/dso-toolkit/dso-toolkit/issues/3170))
+
+### Fixed
+* Alert: Icon bij de link heeft de verkeerde kleur in core variant ([#3168](https://github.com/dso-toolkit/dso-toolkit/issues/3168))
+
 
 ### Task
 * Website: Aanpassing structuur van de opdeling van alle componenten ([#3072](https://github.com/dso-toolkit/dso-toolkit/issues/3072))

--- a/angular-workspace/components/badge/badge.stories.ts
+++ b/angular-workspace/components/badge/badge.stories.ts
@@ -18,7 +18,7 @@ const meta: Meta<BadgeArgs> = {
 
 export default meta;
 
-const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plain } = badgeStories({
+const { Primary, Success, Info, Warning, Error, Outline, Attention, Plain } = badgeStories({
   templateContainer,
   storyTemplates: (templates) => {
     const { badgeTemplate } = templates;
@@ -29,4 +29,4 @@ const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plai
   },
 });
 
-export { Attention, Danger, Error, Info, Outline, Plain, Primary, Success, Warning };
+export { Attention, Error, Info, Outline, Plain, Primary, Success, Warning };

--- a/packages/core/src/components/advanced-select/advanced-select.interfaces.ts
+++ b/packages/core/src/components/advanced-select/advanced-select.interfaces.ts
@@ -1,4 +1,4 @@
-export type AdvancedSelectVariant = "primary" | "success" | "info" | "warning" | "danger" | "error" | "attention";
+export type AdvancedSelectVariant = "primary" | "success" | "info" | "warning" | "error" | "attention";
 
 export interface AdvancedSelectOption<T> {
   label: string;

--- a/packages/core/src/components/advanced-select/advanced-select.scss
+++ b/packages/core/src/components/advanced-select/advanced-select.scss
@@ -154,10 +154,6 @@
   @include set-colors.apply(advanced-select.$warning-variant-color, $icons: false, $links: false);
 }
 
-.group-danger .option-label::before {
-  @include set-colors.apply(advanced-select.$danger-variant-color, $icons: false, $links: false);
-}
-
 .group-error .option-label::before {
   @include set-colors.apply(advanced-select.$error-variant-color, $icons: false, $links: false);
 }

--- a/packages/core/src/components/advanced-select/advanced-select.tsx
+++ b/packages/core/src/components/advanced-select/advanced-select.tsx
@@ -12,7 +12,6 @@ import {
   h,
 } from "@stencil/core";
 import clsx from "clsx";
-import { BadgeStatus } from "dso-toolkit";
 import { FocusTrap, createFocusTrap } from "focus-trap";
 import { tabbable } from "tabbable";
 
@@ -25,7 +24,6 @@ import {
   AdvancedSelectOption,
   AdvancedSelectOptionOrGroup,
   AdvancedSelectRedirectEvent,
-  AdvancedSelectVariant,
 } from "./advanced-select.interfaces";
 
 @Component({
@@ -143,13 +141,6 @@ export class AdvancedSelect implements ComponentInterface {
     this.open = false;
   };
 
-  private mapVariantToStatus(variant?: AdvancedSelectVariant): BadgeStatus {
-    if (variant === "danger") {
-      return "error";
-    }
-    return variant ?? "outline";
-  }
-
   render() {
     return (
       <>
@@ -173,7 +164,7 @@ export class AdvancedSelect implements ComponentInterface {
                       "options" in option && "summaryCounter" in option && !!option?.summaryCounter,
                   )
                   .map((group) => (
-                    <dso-badge status={this.mapVariantToStatus(group.variant)}>{group.options.length}</dso-badge>
+                    <dso-badge status={group.variant ?? "outline"}>{group.options.length}</dso-badge>
                   ))}
               </span>
             )}

--- a/packages/core/src/components/advanced-select/advanced-select.tsx
+++ b/packages/core/src/components/advanced-select/advanced-select.tsx
@@ -12,6 +12,7 @@ import {
   h,
 } from "@stencil/core";
 import clsx from "clsx";
+import { BadgeStatus } from "dso-toolkit";
 import { FocusTrap, createFocusTrap } from "focus-trap";
 import { tabbable } from "tabbable";
 
@@ -24,6 +25,7 @@ import {
   AdvancedSelectOption,
   AdvancedSelectOptionOrGroup,
   AdvancedSelectRedirectEvent,
+  AdvancedSelectVariant,
 } from "./advanced-select.interfaces";
 
 @Component({
@@ -141,6 +143,13 @@ export class AdvancedSelect implements ComponentInterface {
     this.open = false;
   };
 
+  private mapVariantToStatus(variant?: AdvancedSelectVariant): BadgeStatus {
+    if (variant === "danger") {
+      return "error";
+    }
+    return variant ?? "outline";
+  }
+
   render() {
     return (
       <>
@@ -164,7 +173,7 @@ export class AdvancedSelect implements ComponentInterface {
                       "options" in option && "summaryCounter" in option && !!option?.summaryCounter,
                   )
                   .map((group) => (
-                    <dso-badge status={group.variant ?? "outline"}>{group.options.length}</dso-badge>
+                    <dso-badge status={this.mapVariantToStatus(group.variant)}>{group.options.length}</dso-badge>
                   ))}
               </span>
             )}

--- a/packages/core/src/components/badge/badge.interfaces.ts
+++ b/packages/core/src/components/badge/badge.interfaces.ts
@@ -1,1 +1,1 @@
-export type BadgeStatus = "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline" | "attention";
+export type BadgeStatus = "primary" | "success" | "info" | "warning" | "error" | "outline" | "attention";

--- a/packages/core/src/components/badge/readme.md
+++ b/packages/core/src/components/badge/readme.md
@@ -5,9 +5,9 @@
 
 ## Properties
 
-| Property | Attribute | Description              | Type                                                                                                            | Default     |
-| -------- | --------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- | ----------- |
-| `status` | `status`  | The status of the Badge. | `"attention" \| "danger" \| "error" \| "info" \| "outline" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
+| Property | Attribute | Description              | Type                                                                                                | Default     |
+| -------- | --------- | ------------------------ | --------------------------------------------------------------------------------------------------- | ----------- |
+| `status` | `status`  | The status of the Badge. | `"attention" \| "error" \| "info" \| "outline" \| "primary" \| "success" \| "warning" \| undefined` | `undefined` |
 
 
 ## Dependencies

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
@@ -1,4 +1,4 @@
-export type AdvancedSelectVariant = "primary" | "success" | "info" | "warning" | "danger" | "error" | "attention";
+export type AdvancedSelectVariant = "primary" | "success" | "info" | "warning" | "error" | "attention";
 
 export interface AdvancedSelectOption<T> {
   label: string;

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.variables.scss
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.variables.scss
@@ -45,6 +45,5 @@ $info-variant-color: colors.$info-color;
 $primary-variant-color: colors.$bosgroen;
 $success-variant-color: colors.$success-color;
 $warning-variant-color: colors.$warning-color;
-$danger-variant-color: colors.$danger-color;
 $error-variant-color: colors.$error-color;
 $attention-variant-color: colors.$mauve;

--- a/packages/dso-toolkit/src/components/badge/badge.args.ts
+++ b/packages/dso-toolkit/src/components/badge/badge.args.ts
@@ -9,7 +9,7 @@ export interface BadgeArgs {
 
 export const badgeArgTypes: ArgTypes<BadgeArgs> = {
   status: {
-    options: [undefined, "primary", "success", "info", "warning", "danger", "error", "outline", "attention"],
+    options: [undefined, "primary", "success", "info", "warning", "error", "outline", "attention"],
     control: {
       type: "select",
     },

--- a/packages/dso-toolkit/src/components/badge/badge.mixins.scss
+++ b/packages/dso-toolkit/src/components/badge/badge.mixins.scss
@@ -35,10 +35,6 @@
     @include set-colors.apply(badge-variables.$warning-bg-color, $icons: false, $links: false);
   }
 
-  &.badge-danger {
-    @include set-colors.apply(badge-variables.$danger-bg-color, $icons: false, $links: false);
-  }
-
   &.badge-error {
     @include set-colors.apply(badge-variables.$error-bg-color, $icons: false, $links: false);
   }

--- a/packages/dso-toolkit/src/components/badge/badge.models.ts
+++ b/packages/dso-toolkit/src/components/badge/badge.models.ts
@@ -1,4 +1,4 @@
-export type BadgeStatus = "primary" | "success" | "info" | "warning" | "danger" | "error" | "outline" | "attention";
+export type BadgeStatus = "primary" | "success" | "info" | "warning" | "error" | "outline" | "attention";
 
 export interface Badge {
   status?: BadgeStatus;

--- a/packages/dso-toolkit/src/components/badge/badge.stories-of.ts
+++ b/packages/dso-toolkit/src/components/badge/badge.stories-of.ts
@@ -15,7 +15,6 @@ interface BadgeStories {
   Success: BadgeStory;
   Info: BadgeStory;
   Warning: BadgeStory;
-  Danger: BadgeStory;
   Error: BadgeStory;
   Outline: BadgeStory;
   Attention: BadgeStory;
@@ -88,15 +87,6 @@ export function badgeStories<Implementation, Templates, TemplateFnReturnType>({
       args: {
         status: "warning",
         message: "Warning",
-      },
-      render: templateContainer.render(storyTemplates, (args, { badgeTemplate }) =>
-        badgeTemplate(badgeArgsMapper(args)),
-      ),
-    },
-    Danger: {
-      args: {
-        status: "danger",
-        message: "Danger",
       },
       render: templateContainer.render(storyTemplates, (args, { badgeTemplate }) =>
         badgeTemplate(badgeArgsMapper(args)),

--- a/packages/dso-toolkit/src/components/badge/badge.variables.scss
+++ b/packages/dso-toolkit/src/components/badge/badge.variables.scss
@@ -1,11 +1,10 @@
 @use "../../variables/colors";
 
 $default-bg-color: colors.$grijs-60;
-$info-bg-color: colors.$info-color;
+$info-bg-color: colors.$donkerblauw;
 $primary-bg-color: colors.$bosgroen;
 $success-bg-color: colors.$success-color;
 $warning-bg-color: colors.$warning-color;
-$danger-bg-color: colors.$danger-color;
 $error-bg-color: colors.$error-color;
 $attention-bg-color: colors.$mauve;
 

--- a/packages/react/src/components/badge/badge.stories.tsx
+++ b/packages/react/src/components/badge/badge.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<BadgeArgs> = {
 
 export default meta;
 
-const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plain } = badgeStories({
+const { Primary, Success, Info, Warning, Error, Outline, Attention, Plain } = badgeStories({
   templateContainer,
   storyTemplates: (templates) => {
     const { badgeTemplate } = templates;
@@ -22,4 +22,4 @@ const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plai
   },
 });
 
-export { Attention, Danger, Error, Info, Outline, Plain, Primary, Success, Warning };
+export { Attention, Error, Info, Outline, Plain, Primary, Success, Warning };

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -8,7 +8,7 @@
   {
     "name": "badge",
     "selector": "dso-badge.hydrated",
-    "stories": ["plain", "primary", "success", "info", "warning", "danger", "outline"],
+    "stories": ["attention", "error", "info", "outline" ,"plain", "primary", "success", "warning"],
     "type": "core"
   },
   {
@@ -94,7 +94,7 @@
   {
     "name": "badge",
     "selector": ".dso-badge",
-    "stories": ["attention", "danger", "error", "info", "outline", "plain", "primary", "success", "warning"],
+    "stories": ["attention", "error", "info", "outline" ,"plain", "primary", "success", "warning"],
     "type": "html-css"
   },
   {

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -8,7 +8,7 @@
   {
     "name": "badge",
     "selector": "dso-badge.hydrated",
-    "stories": ["attention", "error", "info", "outline" ,"plain", "primary", "success", "warning"],
+    "stories": ["attention", "error", "info", "outline", "plain", "primary", "success", "warning"],
     "type": "core"
   },
   {
@@ -94,7 +94,7 @@
   {
     "name": "badge",
     "selector": ".dso-badge",
-    "stories": ["attention", "error", "info", "outline" ,"plain", "primary", "success", "warning"],
+    "stories": ["attention", "error", "info", "outline", "plain", "primary", "success", "warning"],
     "type": "html-css"
   },
   {

--- a/storybook/src/components/badge/badge.core-stories.ts
+++ b/storybook/src/components/badge/badge.core-stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<BadgeArgs> = {
 
 export default meta;
 
-const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plain } = badgeStories({
+const { Primary, Success, Info, Warning, Error, Outline, Attention, Plain } = badgeStories({
   templateContainer,
   storyTemplates: (templates) => {
     const { badgeTemplate } = templates;
@@ -22,4 +22,4 @@ const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plai
   },
 });
 
-export { Attention, Danger, Error, Info, Outline, Plain, Primary, Success, Warning };
+export { Attention, Error, Info, Outline, Plain, Primary, Success, Warning };

--- a/storybook/src/components/badge/badge.css-stories.ts
+++ b/storybook/src/components/badge/badge.css-stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<BadgeArgs> = {
 
 export default meta;
 
-const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plain } = badgeStories({
+const { Primary, Success, Info, Warning, Error, Outline, Attention, Plain } = badgeStories({
   templateContainer,
   storyTemplates: (templates) => {
     const { badgeTemplate } = templates;
@@ -22,4 +22,4 @@ const { Primary, Success, Info, Warning, Error, Danger, Outline, Attention, Plai
   },
 });
 
-export { Attention, Danger, Error, Info, Outline, Plain, Primary, Success, Warning };
+export { Attention, Error, Info, Outline, Plain, Primary, Success, Warning };

--- a/storybook/src/example-pages/zoeken-in-lijst-cards.stories.ts
+++ b/storybook/src/example-pages/zoeken-in-lijst-cards.stories.ts
@@ -95,7 +95,7 @@ const ZoekenInLijstCards = examplePageStories((templates) => {
                         type: "checkbox",
                         id: "aanhanger-2",
                         name: "aanhanger",
-                        label: html`${badgeTemplate({ message: "Niet geldige oude wetgeving", status: "danger" })}`,
+                        label: html`${badgeTemplate({ message: "Niet geldige oude wetgeving", status: "error" })}`,
                         value: "fietsendrager",
                       },
                     ],

--- a/website/blog/2025-06-16-dso-toolkit-74.0.0.mdx
+++ b/website/blog/2025-06-16-dso-toolkit-74.0.0.mdx
@@ -9,6 +9,7 @@ Deze release bevat breaking changes voor de volgende componenten:
 - Banner
 - Modal
 - Legend Item
+- Badge
 
 <!-- truncate -->
 
@@ -69,4 +70,19 @@ In deze release hebben we de HTML structuur, props en event-emitters van het `Le
 
 ✅ >= 74.0.0
 <dso-legend-item active (dsoActiveChange)="..." [...]></dso-legend-item>
+```
+
+## Badge
+
+In deze release is in het component `badge` de status `danger` verwijderd inclusief de styling die daarbij hoort.
+Als alternatief kan de status `error` worden gebruikt. Deze heeft dezelfde achtergrond en tekst kleur als de
+`danger` status. Daarnaast is de kleur aangepast van de `info` status. Deze heeft nu een donkerblauwe achtergrond en
+witte tekst.
+
+```html
+❌ < 74.0.0
+<dso-badge status="danger"></dso-badge>
+
+✅ >= 74.0.0
+<dso-badge status="error"></dso-badge>
 ```


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
    - Info label heeft een nieuwe kleur, dus 2 diffs in HTML en Core
    - Danger label is verwijderd, dus 2 errors in HTML en Core dat de snapshot niet meer matchen 
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [ ] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
