### PR TITLE
#3221 [Task] Accordion Section: Button in Section Handle kleurt grasgroen als Section open is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Task
 * Build: Bundling Warning SOURCEMAP_BROKEN ([#3107](https://github.com/dso-toolkit/dso-toolkit/issues/3107))
+* Accordion Section: Button in Section Handle kleurt grasgroen als Section open is ([#3221](https://github.com/dso-toolkit/dso-toolkit/issues/3221))
 
 ## ⛱️ Release 77.0.0 - 2025-07-28
 

--- a/storybook/src/components/accordion/accordion.css-template.ts
+++ b/storybook/src/components/accordion/accordion.css-template.ts
@@ -87,8 +87,8 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
       function accordionSectionTemplate(
         accordion: Accordion<TemplateResult>,
         section: AccordionSection<TemplateResult>,
-        index: number,
       ): TemplateResult {
+        const hasNestedAccordion = section.content?.strings.includes("<dso-accordion") ?? false;
         const showSlideToggle = section.activatable && accordion.variant === "compact-black" && !accordion.reverseAlign;
 
         if (!section.heading) {
@@ -100,7 +100,7 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
             class="dso-accordion-section ${classMap({
               [`dso-${section.status}`]: !!section.status && !accordion.reverseAlign,
               "dso-open": !!section.open,
-              "dso-nested-accordion": index === 1,
+              "dso-nested-accordion": hasNestedAccordion,
               [`dso-accordion-wijzigactie-${section.wijzigactie}`]: !!section.wijzigactie,
               "dso-accordion-section-activate": !!showSlideToggle,
             })}"
@@ -118,7 +118,7 @@ export const cssAccordion: ComponentImplementation<Accordion<TemplateResult>> = 
             "dso-accordion-reverse-align": !!accordion.reverseAlign,
           })}"
         >
-          ${accordion.sections.map((section, index) => accordionSectionTemplate(accordion, section, index))}
+          ${accordion.sections.map((section) => accordionSectionTemplate(accordion, section))}
         </div>
       `;
     },


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
