### PR TITLE
#3285 [Task] Card: Afbeelding in Storybook Docs wordt niet getoond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Build: Bundling Warning SOURCEMAP_BROKEN ([#3107](https://github.com/dso-toolkit/dso-toolkit/issues/3107))
 * Accordion Section: Button in Section Handle kleurt grasgroen als Section open is ([#3221](https://github.com/dso-toolkit/dso-toolkit/issues/3221))
 * Deploy: script blijft niet-bestaande branches verwijderen ([#3270](https://github.com/dso-toolkit/dso-toolkit/issues/3270))
+* Card: Afbeelding in Storybook Docs wordt niet getoond ([#3285](https://github.com/dso-toolkit/dso-toolkit/issues/3285))
 
 ## ⛱️ Release 77.0.0 - 2025-07-28
 

--- a/packages/core/src/components/card/readme.md
+++ b/packages/core/src/components/card/readme.md
@@ -3,7 +3,7 @@
 Beware: clicking the heading link with property `href` set doesn't navigate to the URL set. This is caused 
 by the storybook implementation, which inhibits this normal behavior. Use developer tools to remove the Event 
 Listener `dsoCardClicked` to enable the navigation to the set `href`
-![img.png](../../../../dso-toolkit/storybook-assets/images/remove-dso-card-clicked.png)
+![img.png](images/remove-dso-card-clicked.png)
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
