### PR TITLE
#3345 [Fixed] Viewer Grid: Filter Panel blijft in DOM aanwezig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Header: marges rond Uitloggen ongelijk ([#3357](https://github.com/dso-toolkit/dso-toolkit/issues/3357))
+* Viewer Grid: Filter Panel blijft in DOM aanwezig ([#3345](https://github.com/dso-toolkit/dso-toolkit/issues/3345))
 
 ## 🌯 Release 79.1.0 - 2025-10-13
 

--- a/packages/core/src/components/viewer-grid/components/filter-panel.tsx
+++ b/packages/core/src/components/viewer-grid/components/filter-panel.tsx
@@ -1,21 +1,31 @@
-import { FunctionalComponent, h } from "@stencil/core";
+import { Fragment, FunctionalComponent, h } from "@stencil/core";
 
 export interface ViewerGridFilterPanelProps {
+  open: boolean;
   title?: string;
   ref: ((element: HTMLDialogElement | undefined) => void) | undefined;
   dsoCloseFilterPanel: (event: MouseEvent | Event) => void;
 }
 
-export const FilterPanel: FunctionalComponent<ViewerGridFilterPanelProps> = ({ title, ref, dsoCloseFilterPanel }) => (
+export const FilterPanel: FunctionalComponent<ViewerGridFilterPanelProps> = ({
+  open,
+  title,
+  ref,
+  dsoCloseFilterPanel,
+}) => (
   <dialog class="filter-panel" ref={ref}>
-    {title && <h3>{title}</h3>}
-    <dso-icon-button
-      class="dso-close"
-      icon="times"
-      variant="tertiary"
-      label="Sluiten"
-      onDsoClick={dsoCloseFilterPanel}
-    />
-    <slot name="filter-panel" />
+    {open && (
+      <Fragment>
+        {title && <h3>{title}</h3>}
+        <dso-icon-button
+          class="dso-close"
+          icon="times"
+          variant="tertiary"
+          label="Sluiten"
+          onDsoClick={dsoCloseFilterPanel}
+        />
+        <slot name="filter-panel" />
+      </Fragment>
+    )}
   </dialog>
 );

--- a/packages/core/src/components/viewer-grid/viewer-grid.tsx
+++ b/packages/core/src/components/viewer-grid/viewer-grid.tsx
@@ -316,6 +316,7 @@ export class ViewerGrid {
           )}
           {(!this.tabView || (this.tabView && this.activeTab === "search")) && (
             <FilterPanel
+              open={this.filterPanelOpen}
               title={this.filterPanelTitle}
               ref={(element) => (this.filterPanel = element)}
               dsoCloseFilterPanel={(e) => this.dsoCloseFilterPanel.emit({ originalEvent: e })}

--- a/storybook/cypress/e2e/viewer-grid.cy.ts
+++ b/storybook/cypress/e2e/viewer-grid.cy.ts
@@ -130,25 +130,31 @@ describe("Viewer Grid", () => {
     cy.visit(url);
 
     cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel").should("be.not.visible");
+    cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel h3").should("not.exist");
 
     cy.get("dso-viewer-grid.hydrated")
+      .invoke("attr", "filter-panel-title", "Titel van filterpaneel")
       .invoke("attr", "filter-panel-open", "")
       .shadow()
       .find(".filter-panel")
       .should("be.visible");
+
+    cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel h3").should("exist").and("be.visible");
 
     cy.get("dso-viewer-grid.hydrated")
       .invoke("attr", "filter-panel-open", null)
       .shadow()
       .find(".filter-panel")
       .should("be.not.visible");
+
+    cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel h3").should("not.exist");
   });
 
   it("shows the correct title for the filter panel", () => {
     cy.visit(url)
       .get("dso-viewer-grid.hydrated")
       .invoke("attr", "filter-panel-title", "Laten we gaan filteren")
-      .get("dso-viewer-grid.hydrated")
+      .invoke("attr", "filter-panel-open", "")
       .shadow()
       .find(".filter-panel h3")
       .should("have.text", "Laten we gaan filteren");


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
