### PR TITLE
#3375 [fixed] Onboarding Tip: `:popover-open` selector wordt in oude browsers niet ondersteund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * Header: marges rond Uitloggen ongelijk ([#3357](https://github.com/dso-toolkit/dso-toolkit/issues/3357))
 * Viewer Grid: Filter Panel blijft in DOM aanwezig ([#3345](https://github.com/dso-toolkit/dso-toolkit/issues/3345))
+* Onboarding Tip: `:popover-open` selector wordt in oude browsers niet ondersteund ([#3375](https://github.com/dso-toolkit/dso-toolkit/issues/3375))
 
 ## 🌯 Release 79.1.0 - 2025-10-13
 

--- a/packages/core/src/components/onboarding-tip/onboarding-tip.tsx
+++ b/packages/core/src/components/onboarding-tip/onboarding-tip.tsx
@@ -29,9 +29,17 @@ export class OnboardingTip implements ComponentInterface {
   @State()
   ready = false;
 
+  @State()
+  popoverOpen = false;
+
   componentDidRender() {
-    if (!this.host.matches(":popover-open")) {
+    if (!this.host.isConnected) {
+      return;
+    }
+
+    if (!this.popoverOpen) {
       this.host.showPopover();
+      this.popoverOpen = true;
     }
 
     if (!this.cleanUp && this.referenceElement && this.tipArrowRef instanceof HTMLElement) {
@@ -47,10 +55,10 @@ export class OnboardingTip implements ComponentInterface {
   }
 
   disconnectedCallback(): void {
-    if (this.host.matches(":popover-open")) {
+    if (this.popoverOpen) {
       this.host.hidePopover();
+      this.popoverOpen = false;
     }
-
     this.cleanUp?.();
     this.cleanUp = undefined;
   }


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [x] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
