### PR TITLE
#3424 [Changed] Legend Item: Meer opties niet weergeven bij uitstaan toggleslider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **BREAKING** Autosuggest: bij herfocus suggesties alleen tonen bij meerdere opties of één optie zonder exacte match ([#3244](https://github.com/dso-toolkit/dso-toolkit/issues/3244))
+* Legend Item: Meer opties niet weergeven bij uitstaan toggleslider ([#3424](https://github.com/dso-toolkit/dso-toolkit/issues/3424))
 
 ## 🏸 Release 83.1.0 - 2025-12-03
 

--- a/packages/core/src/components/legend-item/legend-item.tsx
+++ b/packages/core/src/components/legend-item/legend-item.tsx
@@ -115,7 +115,7 @@ export class LegendItem implements ComponentInterface {
           )}
 
           <div class="legend-item-right-content">
-            {hasOptions && !this.disabled && (
+            {this.active && hasOptions && !this.disabled && (
               <dso-icon-button
                 label="Opties"
                 icon="more"

--- a/storybook/cypress/e2e/legend-item.cy.ts
+++ b/storybook/cypress/e2e/legend-item.cy.ts
@@ -49,6 +49,16 @@ describe("Legend Item", () => {
       .should("not.be.disabled");
   });
 
+  it("should hide the edit button when the slider is not active", () => {
+    cy.get("@dsoLegendItem").invoke("prop", "active", false).shadow().find("#edit-button").should("not.exist");
+    cy.get("@dsoLegendItem").matchImageSnapshot(`${Cypress.currentTest.title}`);
+  });
+
+  it("should show the edit button when the slider is active", () => {
+    cy.get("@dsoLegendItem").invoke("prop", "active", true).shadow().find("#edit-button").should("be.visible");
+    cy.get("@dsoLegendItem").matchImageSnapshot(`${Cypress.currentTest.title}`);
+  });
+
   it("should show the options containing an input-range when clicked on edit-button", () => {
     cy.get("@dsoLegendItem")
       .find("div[slot='options'] dso-input-range")


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
    - 2 nieuwe snapshots erbij gezet
- [x] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
