### PR TITLE
#3468 [Fixed] Ozon Content: Toggletip van Begrip wordt niet getoond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * Search Bar: Zoek knop uitlijning en vormgeving is kapot ([#3462](https://github.com/dso-toolkit/dso-toolkit/issues/3462))
 * Document Component: Label verkeerd gepositioneerd achter titel in table-of-contents mode ([#3457](https://github.com/dso-toolkit/dso-toolkit/issues/3457))
+* Ozon Content: Toggletip van Begrip wordt niet getoond ([#3468](https://github.com/dso-toolkit/dso-toolkit/issues/3468))
 
 ## 🏸 Release 83.1.0 - 2025-12-03
 

--- a/packages/core/src/components/ozon-content/nodes/int-ref.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/int-ref.node.tsx
@@ -22,7 +22,7 @@ export class OzonContentIntRefNode implements OzonContentNode {
 
       if (
         !definitieXMLDocument ||
-        definitieXMLDocument.documentElement.tagName !== "Definitie" ||
+        definitieXMLDocument.documentElement.localName !== "Definitie" ||
         !definitieXMLDocument.documentElement.hasChildNodes()
       ) {
         return mapNodeToJsx(node.childNodes);

--- a/packages/dso-toolkit/src/components/ozon-content/ozon-content.content.ts
+++ b/packages/dso-toolkit/src/components/ozon-content/ozon-content.content.ts
@@ -10,12 +10,7 @@ interface OzonContentStory {
 
 export function begripResolver(ref: string, element: Element): XMLDocument | string | undefined {
   if ((ref === "eId_van_begrip" || ref === "chp_1__art_1.2__list_o_1__item_1") && element) {
-    return (
-      "<Definitie><Al>De snelle paarse vos eet enthousiast blauwe bananen onder de zingende regenboog, een" +
-      " veelbelovende dag om vuurwerk (zie <ExtRef soort='JCI' ref='jci1.3:c:BWBR0013360'>Vuurwerkbesluit</ExtRef>)" +
-      " te verkennen.</Al><Al>Ook keken de mensen graag naar het spectaculaire vuurwerk dat de avondhemel verlichtte" +
-      " met felle kleuren.</Al></Definitie>"
-    );
+    return "<ns4:Definitie xmlns:ns4='https://standaarden.overheid.nl/stop/imop/tekst/'><ns4:Al>De snelle paarse vos eet enthousiast blauwe bananen onder de zingende regenboog, een veelbelovende dag om vuurwerk (zie <ns4:ExtRef soort='JCI' ref='jci1.3:c:BWBR0013360'>Vuurwerkbesluit</ns4:ExtRef>) te verkennen.</ns4:Al> <ns4:Al>Ook keken de mensen graag naar het spectaculaire vuurwerk dat de avondhemel verlichtte met felle kleuren.</ns4:Al> </ns4:Definitie>";
   }
 
   return undefined;


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
