### PR TITLE
#3457 [Fixed] Document Component: Label verkeerd gepositioneerd achter titel in table-of-contents mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Search Bar: Zoek knop uitlijning en vormgeving is kapot ([#3462](https://github.com/dso-toolkit/dso-toolkit/issues/3462))
+* Document Component: Label verkeerd gepositioneerd achter titel in table-of-contents mode ([#3457](https://github.com/dso-toolkit/dso-toolkit/issues/3457))
 
 ## 🏸 Release 83.1.0 - 2025-12-03
 

--- a/packages/core/src/components/document-component/document-component.scss
+++ b/packages/core/src/components/document-component/document-component.scss
@@ -127,6 +127,12 @@
   }
 }
 
+:host(:not([not-collapsible])) {
+  dso-ozon-content[inline].kop::part(_kop) {
+    display: inline;
+  }
+}
+
 :host([mode="document"]:not([not-collapsible])) {
   --link-color: #{document-component.$heading-anchor-color};
   --link-hover-color: #{document-component.$heading-anchor-hover-color};
@@ -139,10 +145,6 @@
         color: var(--link-hover-color);
         text-decoration: underline;
       }
-    }
-
-    &[inline].kop::part(_kop) {
-      display: inline;
     }
   }
 


### PR DESCRIPTION

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
