### PR TITLE
#3461 [Changed] Ozon Content: voorkom markeren `figuur-titel` in Image Overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Ozon Content: voorkom markeren `figuur-titel` in Image Overlay ([#3461](https://github.com/dso-toolkit/dso-toolkit/issues/3461))
+
 ### Fixed
 * **BREAKING** Legend Item: accessible name van Slide Toggle niet gekoppeld met het zichtbare label ([#3487](https://github.com/dso-toolkit/dso-toolkit/issues/3487))
 

--- a/packages/core/src/components/ozon-content/nodes/bron.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/bron.node.tsx
@@ -6,7 +6,7 @@ import { OzonContentNode } from "../ozon-content-node.interface";
 export class OzonContentBronNode implements OzonContentNode {
   name = "Bron";
 
-  render(node: Element, { mapNodeToJsx }: OzonContentNodeContext) {
-    return <span class="dso-ozon-bron">{mapNodeToJsx(node.childNodes)}</span>;
+  render(node: Element, { mapNodeToJsx }: OzonContentNodeContext, ignoreMark: boolean) {
+    return <span class="dso-ozon-bron">{mapNodeToJsx(node.childNodes, ignoreMark)}</span>;
   }
 }

--- a/packages/core/src/components/ozon-content/nodes/fallback.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/fallback.node.tsx
@@ -8,7 +8,7 @@ export class OzonContentFallbackNode implements OzonContentNode {
   // This name does not match any elements
   name = ["<fallback>"];
 
-  render(node: Node, { mapNodeToJsx }: OzonContentNodeContext) {
-    return <span class={`fallback od-${getNodeName(node)}`}>{mapNodeToJsx(node.childNodes)}</span>;
+  render(node: Node, { mapNodeToJsx }: OzonContentNodeContext, ignoreMark: boolean) {
+    return <span class={`fallback od-${getNodeName(node)}`}>{mapNodeToJsx(node.childNodes, ignoreMark)}</span>;
   }
 }

--- a/packages/core/src/components/ozon-content/nodes/figuur.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/figuur.node.tsx
@@ -7,7 +7,8 @@ import { OzonContentNode } from "../ozon-content-node.interface";
 type BijschriftProps = {
   bijschrift?: IBijschrift;
   bron?: ChildNode;
-  mapNodeToJsx: (node: Node | NodeList | Node[]) => JSX.Element;
+  mapNodeToJsx: (node: Node | NodeList | Node[], mark?: boolean) => JSX.Element;
+  ignoreMark?: boolean;
 };
 
 interface IBijschrift {
@@ -24,16 +25,16 @@ interface Illustratie {
   alt: string | null;
 }
 
-const Bijschrift: FunctionalComponent<BijschriftProps> = ({ bijschrift, bron, mapNodeToJsx }) => {
+const Bijschrift: FunctionalComponent<BijschriftProps> = ({ bijschrift, bron, mapNodeToJsx, ignoreMark }) => {
   const bronText = bron && bron.textContent?.trim();
 
   return (
     <span class="figuur-bijschrift">
-      {bijschrift && bijschrift.inhoud && mapNodeToJsx(bijschrift.inhoud)}
+      {bijschrift && bijschrift.inhoud && mapNodeToJsx(bijschrift.inhoud, ignoreMark)}
       {bronText && (
         <Fragment>
           {`${bijschrift ? " " : ""}(bron: `}
-          {mapNodeToJsx(bron)})
+          {mapNodeToJsx(bron, ignoreMark)})
         </Fragment>
       )}
     </span>
@@ -115,13 +116,13 @@ export class OzonContentFiguurNode implements OzonContentNode {
           <dso-image-overlay wijzigactie={wijzigactie}>
             {titel && (
               <div slot="titel">
-                <span>{mapNodeToJsx(titel)}</span>
+                <span>{mapNodeToJsx(titel, true)}</span>
               </div>
             )}
             <img src={src ?? undefined} alt={illustratie.alt ?? titel?.textContent ?? illustratie.naam ?? undefined} />
             {(bijschrift || bron) && (
               <div slot="bijschrift">
-                <Bijschrift bijschrift={bijschrift} bron={bron} mapNodeToJsx={mapNodeToJsx} />
+                <Bijschrift bijschrift={bijschrift} bron={bron} mapNodeToJsx={mapNodeToJsx} ignoreMark />
               </div>
             )}
           </dso-image-overlay>

--- a/packages/core/src/components/ozon-content/nodes/text.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/text.node.tsx
@@ -7,8 +7,8 @@ import { OzonContentNode } from "../ozon-content-node.interface";
 export class OzonContentTextNode implements OzonContentNode {
   name = "#text";
 
-  render({ textContent }: Node, { mark, emitMarkItemHighlight }: OzonContentNodeContext) {
-    if (!mark || !textContent) {
+  render({ textContent }: Node, { mark, emitMarkItemHighlight }: OzonContentNodeContext, ignoreMark: boolean) {
+    if (ignoreMark || !mark || !textContent) {
       return <Fragment>{textContent}</Fragment>;
     }
 

--- a/packages/core/src/components/ozon-content/ozon-content-mapper.tsx
+++ b/packages/core/src/components/ozon-content/ozon-content-mapper.tsx
@@ -78,13 +78,18 @@ export class Mapper {
     );
   }
 
-  mapNodeToJsx(node: Node | Node[] | NodeList, context: OzonContentContext, path: Node[]): JSX.Element {
+  mapNodeToJsx(
+    node: Node | Node[] | NodeList,
+    context: OzonContentContext,
+    path: Node[],
+    ignoreMark?: boolean,
+  ): JSX.Element {
     if (node instanceof NodeList) {
-      return <Fragment>{Array.from(node).map((n) => this.mapNodeToJsx(n, context, path))}</Fragment>;
+      return <Fragment>{Array.from(node).map((n) => this.mapNodeToJsx(n, context, path, ignoreMark))}</Fragment>;
     }
 
     if (Array.isArray(node)) {
-      return <Fragment>{node.map((n) => this.mapNodeToJsx(n, context, path))}</Fragment>;
+      return <Fragment>{node.map((n) => this.mapNodeToJsx(n, context, path, ignoreMark))}</Fragment>;
     }
 
     const nodeName = getNodeName(node);
@@ -98,19 +103,23 @@ export class Mapper {
     const state = identity ? context.state[identity] : undefined;
     const setState = identity ? (s: unknown) => context.setState({ ...context.state, [identity]: s }) : undefined;
 
-    return mapper.render(node, {
-      inline: context.inline,
-      mark: context.mark,
-      mapNodeToJsx: (n) => this.mapNodeToJsx(n, context, [...path, node]),
-      emitClick: context.emitClick,
-      setState,
-      emitMarkItemHighlight: context.emitMarkItemHighlight,
-      state,
-      path,
-      urlResolver: context.urlResolver,
-      begripResolver: context.begripResolver,
-      annotated: context.annotated,
-    });
+    return mapper.render(
+      node,
+      {
+        inline: context.inline,
+        mark: context.mark,
+        mapNodeToJsx: (n, m) => this.mapNodeToJsx(n, context, [...path, node], m),
+        emitClick: context.emitClick,
+        setState,
+        emitMarkItemHighlight: context.emitMarkItemHighlight,
+        state,
+        path,
+        urlResolver: context.urlResolver,
+        begripResolver: context.begripResolver,
+        annotated: context.annotated,
+      },
+      ignoreMark,
+    );
   }
 
   transform(input: OzonContentInputType | undefined, context: OzonContentContext): JSX.Element {

--- a/packages/core/src/components/ozon-content/ozon-content-node-context.interface.ts
+++ b/packages/core/src/components/ozon-content/ozon-content-node-context.interface.ts
@@ -8,7 +8,7 @@ export interface OzonContentNodeContext<T = unknown> {
   inline: boolean;
   path: Node[];
   mark: MarkTextMarkFunction | undefined;
-  mapNodeToJsx(node: Node | Node[] | NodeList): JSX.Element;
+  mapNodeToJsx(node: Node | Node[] | NodeList, ignoreMark?: boolean): JSX.Element;
   emitClick(event: OzonContentClickEvent): void;
   state?: T;
   setState?(state: T): void;

--- a/packages/core/src/components/ozon-content/ozon-content-node.interface.ts
+++ b/packages/core/src/components/ozon-content/ozon-content-node.interface.ts
@@ -9,5 +9,5 @@ export interface OzonContentNode<T = unknown> {
 
   identify?(node: Node): string | undefined;
 
-  render(node: Node, context: OzonContentNodeContext<T>): JSX.Element;
+  render(node: Node, context: OzonContentNodeContext<T>, ignoreMark?: boolean): JSX.Element;
 }

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -426,17 +426,15 @@ describe("Ozon Content", () => {
       .should("have.css", "display", "block");
   });
 
-  it("should render Figuur as dso-image-overlay", () => {
-    cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--figuur");
+  describe("Figuur", () => {
+    beforeEach(() => {
+      cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--figuur");
 
-    cy.injectAxe();
-    cy.dsoCheckA11y("dso-ozon-content.hydrated");
-
-    cy.get("dso-ozon-content.hydrated")
-      .invoke(
-        "prop",
-        "content",
-        `
+      cy.get("dso-ozon-content.hydrated")
+        .invoke(
+          "prop",
+          "content",
+          `
         <Figuur
           eId="chp_13__subsec_13.7__art_13.72__table_o_1__img_o_1"
           wId="gm1979_2__chp_13__subsec_13.7__art_13.72__table_o_1__img_o_1"
@@ -454,24 +452,64 @@ describe("Ozon Content", () => {
           <Bron>Bron waaruit het figuur is overgenomen</Bron>
         </Figuur>
       `,
-      )
-      .get("dso-ozon-content.hydrated")
-      .shadow()
-      .find("dso-image-overlay.hydrated > img")
-      .should("have.attr", "src", "images/houtkachel-of-open-haard-infographic.jpg")
-      .and("have.attr", "alt", "Afbeelding 1")
-      .get("dso-ozon-content.hydrated")
-      .shadow()
-      .find(".dso-ozon-figuur")
-      .should("have.css", "--_dso-ozon-content-illustratie-aspect-ratio", "0.6405693950177936")
-      .and("have.css", "--_dso-ozon-content-illustratie-width", "29.519999999999996%")
-      .and("have.css", "--_dso-ozon-content-illustratie-uitlijning", "center")
-      .get("dso-ozon-content.hydrated")
-      .shadow()
-      .find(".dso-ozon-figuur > .figuur-bijschrift")
-      .should("have.text", "Bijschrift bij het figuur. (bron: Bron waaruit het figuur is overgenomen)");
+        )
+        .get("dso-ozon-content.hydrated")
+        .as("OzonContent")
+        .shadow()
+        .as("OzonContentShadow");
+    });
 
-    cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
+    it("renders Figuur as dso-image-overlay", () => {
+      cy.injectAxe();
+      cy.dsoCheckA11y("dso-ozon-content.hydrated");
+
+      cy.get("@OzonContentShadow")
+        .find("dso-image-overlay.hydrated > img")
+        .should("have.attr", "src", "images/houtkachel-of-open-haard-infographic.jpg")
+        .and("have.attr", "alt", "Afbeelding 1")
+        .get("@OzonContentShadow")
+        .find(".dso-ozon-figuur")
+        .should("have.css", "--_dso-ozon-content-illustratie-aspect-ratio", "0.6405693950177936")
+        .and("have.css", "--_dso-ozon-content-illustratie-width", "29.519999999999996%")
+        .and("have.css", "--_dso-ozon-content-illustratie-uitlijning", "center")
+        .get("@OzonContentShadow")
+        .find(".dso-ozon-figuur > .figuur-bijschrift")
+        .should("have.text", "Bijschrift bij het figuur. (bron: Bron waaruit het figuur is overgenomen)");
+
+      cy.get("@OzonContent").matchImageSnapshot();
+    });
+
+    it("only marks Titel and Bijschirft outside dso-image-overlay", () => {
+      cy.get("@OzonContent")
+        .then(
+          ($ozonContent: JQuery<HTMLDsoOzonContentElement>) =>
+            ($ozonContent[0].mark = (text) =>
+              text
+                .split(new RegExp(`(it)`, "gi"))
+                .map((item, index) => (isOdd(index) ? { text: item, highlight: index === 1 } : item))),
+        )
+        .get("@OzonContentShadow")
+        .find(".figuur-titel")
+        .should(
+          "have.html",
+          '<span class="fallback od-Titel">Afbeelding T<mark class="dso-highlight">it</mark>el</span>',
+        )
+        .get("@OzonContentShadow")
+        .find("dso-image-overlay + .figuur-bijschrift")
+        .should(
+          "have.html",
+          'Bijschrift bij het figuur. (bron: <span class="dso-ozon-bron">Bron waaru<mark class="dso-highlight">it</mark> het figuur is overgenomen</span>)',
+        )
+        .get("@OzonContentShadow")
+        .find("dso-image-overlay.hydrated .od-Titel")
+        .should("have.text", "Afbeelding Titel")
+        .get("@OzonContentShadow")
+        .find("dso-image-overlay.hydrated .figuur-bijschrift")
+        .should(
+          "have.html",
+          'Bijschrift bij het figuur. (bron: <span class="dso-ozon-bron">Bron waaruit het figuur is overgenomen</span>)',
+        );
+    });
   });
 
   it("should render Lijst element", () => {


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl

1 falende e2e test van Ozon Content ivm met groperen van 2 testen tbv van Figuur in 1 describe:
```1 failing
  1) Ozon Content
       Figuur
         renders Figuur as dso-image-overlay:
     Error: New snapshot: 'Ozon Content -- Figuur -- renders Figuur as dso-image-overlay' was added, but 'requireSnapshots' was set to true.
      ...
```
