### PR TITLE
#3576 [Fixed] Info Button: Dependency van dso-toolkit naar dso-toolkit-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * Button: Mode "on light" en "on dark" toevoegen aan de button varianten ([#3381](https://github.com/dso-toolkit/dso-toolkit/issues/3381))
 
+### Fixed
+* Info Button: Dependency van dso-toolkit naar dso-toolkit-core ([#3576](https://github.com/dso-toolkit/dso-toolkit/issues/3576))
+
 ### Task
 * CICD: addnab/docker-run-action verouderd ([#3557](https://github.com/dso-toolkit/dso-toolkit/issues/3557))
 

--- a/packages/dso-toolkit/src/components/info-button/info-button.args.ts
+++ b/packages/dso-toolkit/src/components/info-button/info-button.args.ts
@@ -1,14 +1,13 @@
-import { TooltipPlacement } from "@dso-toolkit/core/src";
 import { HandlerFunction } from "storybook/actions";
 import { ArgTypes } from "storybook/internal/types";
 
 import { argTypeAction } from "../../storybook";
 
-import { InfoButton } from "./info-button.models.js";
+import { InfoButton, InfoButtonTooltipPlacement } from "./info-button.models.js";
 
 export interface InfoButtonArgs {
   active: boolean;
-  toggletipPlacement: TooltipPlacement;
+  toggletipPlacement: InfoButtonTooltipPlacement;
   secondary: boolean;
   label: string;
   dsoToggle: HandlerFunction;

--- a/packages/dso-toolkit/src/components/info-button/info-button.models.ts
+++ b/packages/dso-toolkit/src/components/info-button/info-button.models.ts
@@ -1,8 +1,8 @@
-import { TooltipPlacement } from "@dso-toolkit/core/src";
+export type InfoButtonTooltipPlacement = "top" | "bottom" | "left" | "right";
 
 export interface InfoButton<TemplateFnReturnType> {
   active?: boolean;
-  toggletipPlacement?: TooltipPlacement;
+  toggletipPlacement?: InfoButtonTooltipPlacement;
   secondary?: boolean;
   label?: string;
   dsoToggle?: (e: CustomEvent<InfoButtonToggleEvent>) => void;


### PR DESCRIPTION


- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
