### PR TITLE
#3562 [Changed] Ozon Content: i-tje verwijderen bij verwijzing naar begrip (IntRef naar `<Begrip>`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * **BREAKING** Legend: Legend en Legend Item fuseren tot één component Legend ([#3490](https://github.com/dso-toolkit/dso-toolkit/issues/3490))
+* Ozon Content: i-tje verwijderen bij verwijzing naar begrip (IntRef naar `<Begrip>`) ([#3562](https://github.com/dso-toolkit/dso-toolkit/issues/3562))
 
 ### Fixed
 * Viewer Grid: Gesloten Filter Panel kan focus krijgen ([#3546](https://github.com/dso-toolkit/dso-toolkit/issues/3546))

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
@@ -104,10 +104,13 @@ export class ozonContentToggletip implements ComponentInterface {
           onKeyDown={this.keyDownHandler}
           ref={(element) => (this.container = element)}
         >
-          <span class="icon-container">
-            <slot name="label" />
-            <dso-icon icon={this.icon} />
-          </span>
+          {this.icon && (
+            <span class="icon-container">
+              <slot name="label" />
+              <dso-icon icon={this.icon} />
+            </span>
+          )}
+          {!this.icon && <slot name="label" />}
         </span>
         <Tooltip
           visible

--- a/packages/core/src/components/ozon-content/nodes/int-ref.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/int-ref.node.tsx
@@ -29,7 +29,7 @@ export class OzonContentIntRefNode implements OzonContentNode {
       }
 
       return (
-        <dso-ozon-content-toggletip icon="info">
+        <dso-ozon-content-toggletip>
           <span slot="label">{mapNodeToJsx(node.childNodes)}</span>
           {mapNodeToJsx(Array.from(definitieXMLDocument.documentElement.childNodes))}
         </dso-ozon-content-toggletip>


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl

Zoals verwacht een matchImageSnapshot Diff `Error: Image was 13.397435897435898% different from saved snapshot with 18810 different pixels.`
<img width="1950" height="216" alt="Ozon Content -- shows a toggletip on IntRef @scope=begrip diff" src="https://github.com/user-attachments/assets/3e1f4320-1440-44e9-a1c6-66f1a8ddb487" />
