### PR TITLE
#3201 [Task] Visueel regressietesten: Optimaliseer `failureThreshold`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Task
 * Document Component: types toevoegen ([#3500](https://github.com/dso-toolkit/dso-toolkit/issues/3500))
+* Visueel Regressietesten: Optimaliseer `failureThreshold` ([#3201](https://github.com/dso-toolkit/dso-toolkit/issues/3201))
 
 ## 🌹 Release 89.0.0 - 2026-03-02
 

--- a/storybook/cypress/e2e/map-controls.cy.ts
+++ b/storybook/cypress/e2e/map-controls.cy.ts
@@ -35,10 +35,7 @@ describe("Map Controls", () => {
       .get("dso-map-controls.hydrated")
       .shadow()
       .find(".toggle-visibility-button")
-      // The global setting for failureThreshold: 0.01 gives:
-      // Error: Image was 4.107744107744108% different from saved snapshot with 488 different pixels.
-      // So we override that value here
-      .matchImageSnapshot({ failureThreshold: 0.05 });
+      .matchImageSnapshot();
   });
 
   it("shows an Icon Button with Icon 'layers' and attribute label='Kaartlagen`", () => {

--- a/storybook/cypress/e2e/modal.cy.ts
+++ b/storybook/cypress/e2e/modal.cy.ts
@@ -23,7 +23,9 @@ describe("Modal", () => {
       .and("have.attr", "role", "document")
       .find("#close-modal")
       .shadow()
-      .find("button[aria-label='Sluiten']");
+      .find("button[aria-label='Sluiten'] > #tooltip")
+      .should("have.css", "opacity", "1")
+      .and("have.class", "visible");
 
     cy.matchImageSnapshot();
   });

--- a/storybook/cypress/e2e/tooltip.cy.ts
+++ b/storybook/cypress/e2e/tooltip.cy.ts
@@ -32,7 +32,7 @@ describe("Tooltip", () => {
   // Temporary test, this shouldn't be needed. Don't copy/paste this.
   it("should look ok", () => {
     prepareComponent();
-    cy.get("@dsoButton").matchImageSnapshot();
+    cy.get("@dsoButton").matchImageSnapshot({ failureThreshold: 0.08 });
   });
 
   it("should show tooltip on focus on button and hide on escape key", () => {

--- a/storybook/cypress/support/e2e.ts
+++ b/storybook/cypress/support/e2e.ts
@@ -28,7 +28,7 @@ Cypress.on("uncaught:exception", (_err, _runnable) => {
 });
 
 addMatchImageSnapshotCommand({
-  failureThreshold: 0,
+  failureThreshold: 0.04,
   failureThresholdType: "percent",
   padding: 16, // units.$u2 for buiten-elementse functionele styling
   customDiffDir: "cypress/snapshot-diff",


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
