### PR TITLE
#3403 [Fixed] Angular: Build faalt niet bij niet kloppende prop van a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Icon Button: HidePopover alleen aanroepen als de tooltip connected is met de DOM ([#3503](https://github.com/dso-toolkit/dso-toolkit/issues/3503))
+* Angular: Build faalt niet bij niet kloppende prop van angular-output-target componenten ([#3403](https://github.com/dso-toolkit/dso-toolkit/issues/3403))
 
 ### Task
 * Document Component: types toevoegen ([#3500](https://github.com/dso-toolkit/dso-toolkit/issues/3500))

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -24,6 +24,8 @@ export const config: Config = {
       outputType: "standalone",
       directivesProxyFile: "../../angular-workspace/projects/component-library/src/lib/stencil-generated/components.ts",
       directivesArrayFile: "../../angular-workspace/projects/component-library/src/lib/stencil-generated/index.ts",
+      /* Experimental: Enables type-checking and JSDoc in Angular templates via Angular Language Service. */
+      inlineProperties: true,
     }),
     reactOutputTarget({
       customElementsDir: "dist/components",


### PR DESCRIPTION
…ngular-output-target componenten

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
