### PR TITLE
#3423 [Changed] History Item: Current state toevoegen + kopkleur aanp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Next
 
 ### Changed
+* History Item: Current state toevoegen + kopkleur aanpassen en chevron ([#3423](https://github.com/dso-toolkit/dso-toolkit/issues/3423))
 * Icon: Nieuwe iconenset ([#2542](https://github.com/dso-toolkit/dso-toolkit/issues/2542))
 
 ### Fixed

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -735,6 +735,10 @@ export namespace Components {
     }
     interface DsoHistoryItem {
         /**
+          * Optional boolean indicating if this history item is the current/active one.
+         */
+        "current"?: boolean;
+        /**
           * The optional URL to which the History Item title links. Needs to be provided when slot `title` is used.
          */
         "href"?: string;
@@ -3505,6 +3509,10 @@ declare namespace LocalJSX {
     }
     interface DsoHistoryItem {
         /**
+          * Optional boolean indicating if this history item is the current/active one.
+         */
+        "current"?: boolean;
+        /**
           * The optional URL to which the History Item title links. Needs to be provided when slot `title` is used.
          */
         "href"?: string;
@@ -4606,6 +4614,7 @@ declare namespace LocalJSX {
     interface DsoHistoryItemAttributes {
         "type": HistoryItemType;
         "href": string;
+        "current": boolean;
     }
     interface DsoIconAttributes {
         "icon": IconAlias;

--- a/packages/core/src/components/history-item/history-item.scss
+++ b/packages/core/src/components/history-item/history-item.scss
@@ -10,6 +10,7 @@
   gap: units.$u1;
   inline-size: 100%;
   padding-block: units.$u2;
+  font-size: 16px;
 
   &:has(.history-item-title a:is(:hover, :focus-visible)) {
     background-color: history-item-variables.$background-color-hover;
@@ -79,5 +80,16 @@
 
   &:visited {
     color: history-item-variables.$title-anchor-color;
+  }
+}
+
+.current {
+  .title-current {
+    color: colors.$bosgroen;
+  }
+
+  .chevron-after-title {
+    margin-inline-start: 4px;
+    vertical-align: middle;
   }
 }

--- a/packages/core/src/components/history-item/history-item.tsx
+++ b/packages/core/src/components/history-item/history-item.tsx
@@ -53,6 +53,12 @@ export class HistoryItem implements ComponentInterface {
   href?: string;
 
   /**
+   * Optional boolean indicating if this history item is the current/active one.
+   */
+  @Prop({ reflect: true })
+  current?: boolean;
+
+  /**
    * Emitted when the History Item title is clicked.
    */
   @Event({ bubbles: false })
@@ -102,11 +108,29 @@ export class HistoryItem implements ComponentInterface {
             <dso-icon icon={this.typeIcons[this.type]} aria-hidden="true"></dso-icon>
             <slot name="status"></slot>
           </div>
-          {this.titleSlottedElement !== null && this.href && (
-            <div class="history-item-title">
-              <a href={this.href} class="title-anchor" onClick={(e) => this.clickEventHandler(e)}>
-                <slot name="title"></slot>
-              </a>
+          {this.titleSlottedElement !== null && this.current && (
+            <div
+              class={{
+                "history-item-title": true,
+                current: this.current,
+              }}
+            >
+              {this.href ? (
+                <a
+                  href={this.href}
+                  class={this.current ? "title-current title-anchor" : "title-anchor"}
+                  onClick={(e) => this.clickEventHandler(e)}
+                  aria-current={this.current ? "true" : undefined}
+                >
+                  <slot name="title"></slot>
+                  {this.current && <dso-icon icon="chevron-right" class="chevron-after-title" aria-hidden="true" />}
+                </a>
+              ) : (
+                <span class={this.current ? "title-current" : undefined}>
+                  <slot name="title"></slot>
+                  {this.current && <dso-icon icon="chevron-right" class="chevron-after-title" aria-hidden="true" />}
+                </span>
+              )}
             </div>
           )}
           {this.explanationSlottedElement !== null && (

--- a/packages/core/src/components/history-item/readme.md
+++ b/packages/core/src/components/history-item/readme.md
@@ -9,6 +9,7 @@
 
 | Property            | Attribute | Description                                                                                             | Type                                                                                                                       | Default     |
 | ------------------- | --------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `current`           | `current` | Optional boolean indicating if this history item is the current/active one.                             | `boolean \| undefined`                                                                                                     | `undefined` |
 | `href`              | `href`    | The optional URL to which the History Item title links. Needs to be provided when slot `title` is used. | `string \| undefined`                                                                                                      | `undefined` |
 | `type` _(required)_ | `type`    | The type of History Item                                                                                | `"besluit" \| "in-werking" \| "ontwerp" \| "tijdelijk-regelingdeel" \| "tijdelijk-regelingdeel-besluit" \| "waarschuwing"` | `undefined` |
 

--- a/packages/dso-toolkit/src/components/history-item/history-item.args.ts
+++ b/packages/dso-toolkit/src/components/history-item/history-item.args.ts
@@ -14,6 +14,7 @@ export interface HistoryItemArgs {
   href?: string;
   type: HistoryItemType;
   warning?: string;
+  current?: boolean;
   dsoClick: HandlerFunction;
 }
 
@@ -24,6 +25,7 @@ export const historyItemArgs: Omit<HistoryItemArgs, "href"> = {
   title: '"Voorbeschermingsregels hyperscale datacentra" opgenomen in plan',
   explanation: undefined,
   warning: undefined,
+  current: false,
   dsoClick: fn(),
 };
 
@@ -64,6 +66,11 @@ export const historyItemArgTypes: ArgTypes<HistoryItemArgs> = {
   warning: {
     control: {
       type: "text",
+    },
+  },
+  current: {
+    control: {
+      type: "boolean",
     },
   },
   dsoClick: argTypeAction(),

--- a/packages/dso-toolkit/src/components/history-item/history-item.models.ts
+++ b/packages/dso-toolkit/src/components/history-item/history-item.models.ts
@@ -14,6 +14,7 @@ export interface HistoryItem {
   href?: string;
   type: HistoryItemType;
   warning?: string;
+  current?: boolean;
   dsoClick?: (e: CustomEvent<HistoryItemClickEvent>) => void;
 }
 

--- a/storybook/cypress/e2e/history-item.cy.ts
+++ b/storybook/cypress/e2e/history-item.cy.ts
@@ -27,4 +27,13 @@ describe("History Item", () => {
       .its("args.0.detail.originalEvent")
       .should("exist");
   });
+
+  it("renders current state correctly", () => {
+    cy.get("dso-history-item[current]")
+      .shadow()
+      .within(() => {
+        cy.get(".history-item-title.current .title-current.title-anchor").should("exist");
+        cy.get(".chevron-after-title").should("exist");
+      });
+  });
 });

--- a/storybook/src/components/history-item/history-item.core-template.ts
+++ b/storybook/src/components/history-item/history-item.core-template.ts
@@ -9,9 +9,10 @@ export const coreHistoryItem: ComponentImplementation<HistoryItem> = {
   component: "historyItem",
   implementation: "core",
   template: () =>
-    function historyItemTemplate({ date, explanation, statusMessage, title, href, type, warning, dsoClick }) {
+    function historyItemTemplate({ date, explanation, statusMessage, title, href, type, current, warning, dsoClick }) {
       return html`<dso-history-item
         .type=${type}
+        .current=${current}
         href=${ifDefined(href)}
         @dsoClick=${(e: DsoHistoryItemCustomEvent<HistoryItemClickEvent>) => {
           if (!e.detail.isModifiedEvent) {


### PR DESCRIPTION
…assen en chevron

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [ ] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
