### PR TITLE
#3542 [Docs] Docs: Vermeldingen van "Aan de slag met de Omgevingswet weghalen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * Badge: Toggletip functionaliteit ([#3396](https://github.com/dso-toolkit/dso-toolkit/issues/3396))
 
+### Docs
+* Docs: Vermeldingen van "Aan de slag met de Omgevingswet" weghalen ([#3542](https://github.com/dso-toolkit/dso-toolkit/issues/3542))
+
 ## 🧞‍♂️ Release 90.0.0 - 2026-03-13
 
 ### Added

--- a/angular-workspace/components/info-button/info-button.content.ts
+++ b/angular-workspace/components/info-button/info-button.content.ts
@@ -1,14 +1,13 @@
 export const children = {
   template: `
     <div class="dso-rich-content">
-      <h2>Samenspel tussen wetgever en ontwikkelaars</h2>
+      <h2>
+        Introductie DSO
+      </h2>
       <p>
-        Het DSO wordt ontwikkeld door het programma
-        <a href="https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/">Aan de slag met de Omgevingswet</a>
-        in samenwerking met haar partners. De ontwikkeling vraagt een intensief samenspel tussen de wetgever en de
-        ontwikkelpartners van het DSO. Enerzijds moeten wetgever en de ontwikkelpartners zorgen dat alles wat in de wet-
-        en regelgeving wordt geregeld ook makkelijk toegankelijk is of kan worden. Anderzijds moeten zij zorgen dat
-        alles wat digitaal wordt gerealiseerd, ook juridisch verankerd is of kan worden.
+        Het <a href="https://iplo.nl/digitaal-stelsel/">Digitaal Stelsel Omgevingswet (DSO)</a> ondersteunt de uitvoering
+        van de Omgevingswet. Het bestaat uit lokale systemen van overheden en de onderdelen van de landelijke voorziening
+        (DSO-LV), zoals het Omgevingsloket.
       </p>
     </div>
   `,

--- a/angular-workspace/components/info-button/info-button.stories.ts
+++ b/angular-workspace/components/info-button/info-button.stories.ts
@@ -3,8 +3,8 @@ import { InfoButtonArgs, infoButtonMeta, infoButtonStories } from "dso-toolkit";
 
 import { DsoInfoButton } from "../../projects/component-library/src/public-api";
 import { templateContainer } from "../../templates";
-import { children } from "../toggletip/toggletip.content";
 
+import { children } from "./info-button.content";
 import readme from "./readme.md?raw";
 
 const meta: Meta<InfoButtonArgs> = {

--- a/angular-workspace/components/toggletip/toggletip.content.ts
+++ b/angular-workspace/components/toggletip/toggletip.content.ts
@@ -1,14 +1,13 @@
 export const children = {
   template: `
     <div class="dso-rich-content">
-      <h2>Samenspel tussen wetgever en ontwikkelaars</h2>
+      <h2>
+        Introductie DSO
+      </h2>
       <p>
-        Het DSO wordt ontwikkeld door het programma
-        <a href="https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/">Aan de slag met de Omgevingswet</a>
-        in samenwerking met haar partners. De ontwikkeling vraagt een intensief samenspel tussen de wetgever en de
-        ontwikkelpartners van het DSO. Enerzijds moeten wetgever en de ontwikkelpartners zorgen dat alles wat in de wet-
-        en regelgeving wordt geregeld ook makkelijk toegankelijk is of kan worden. Anderzijds moeten zij zorgen dat
-        alles wat digitaal wordt gerealiseerd, ook juridisch verankerd is of kan worden.
+        Het <a href="https://iplo.nl/digitaal-stelsel/">Digitaal Stelsel Omgevingswet (DSO)</a> ondersteunt de uitvoering
+        van de Omgevingswet. Het bestaat uit lokale systemen van overheden en de onderdelen van de landelijke voorziening
+        (DSO-LV), zoals het Omgevingsloket.
       </p>
     </div>
   `,

--- a/packages/react/src/components/info-button/info-button.content.tsx
+++ b/packages/react/src/components/info-button/info-button.content.tsx
@@ -2,14 +2,11 @@ import * as React from "react";
 
 export const children = (
   <div className="dso-rich-content">
-    <h2>Samenspel tussen wetgever en ontwikkelaars</h2>
+    <h2>Introductie DSO</h2>
     <p>
-      Het DSO wordt ontwikkeld door het programma{" "}
-      <a href="https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/">Aan de slag met de Omgevingswet</a> in
-      samenwerking met haar partners. De ontwikkeling vraagt een intensief samenspel tussen de wetgever en de
-      ontwikkelpartners van het DSO. Enerzijds moeten wetgever en de ontwikkelpartners zorgen dat alles wat in de wet-
-      en regelgeving wordt geregeld ook makkelijk toegankelijk is of kan worden. Anderzijds moeten zij zorgen dat alles
-      wat digitaal wordt gerealiseerd, ook juridisch verankerd is of kan worden.
+      Het <a href="https://iplo.nl/digitaal-stelsel/">Digitaal Stelsel Omgevingswet (DSO)</a> ondersteunt de uitvoering
+      van de Omgevingswet. Het bestaat uit lokale systemen van overheden en de onderdelen van de landelijke voorziening
+      (DSO-LV), zoals het Omgevingsloket.
     </p>
   </div>
 );

--- a/packages/react/src/components/toggletip/toggletip.content.tsx
+++ b/packages/react/src/components/toggletip/toggletip.content.tsx
@@ -2,14 +2,11 @@ import * as React from "react";
 
 export const children = (
   <div className="dso-rich-content">
-    <h2>Samenspel tussen wetgever en ontwikkelaars</h2>
+    <h2>Introductie DSO</h2>
     <p>
-      Het DSO wordt ontwikkeld door het programma{" "}
-      <a href="https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/">Aan de slag met de Omgevingswet</a> in
-      samenwerking met haar partners. De ontwikkeling vraagt een intensief samenspel tussen de wetgever en de
-      ontwikkelpartners van het DSO. Enerzijds moeten wetgever en de ontwikkelpartners zorgen dat alles wat in de wet-
-      en regelgeving wordt geregeld ook makkelijk toegankelijk is of kan worden. Anderzijds moeten zij zorgen dat alles
-      wat digitaal wordt gerealiseerd, ook juridisch verankerd is of kan worden.
+      Het <a href="https://iplo.nl/digitaal-stelsel/">Digitaal Stelsel Omgevingswet (DSO)</a> ondersteunt de uitvoering
+      van de Omgevingswet. Het bestaat uit lokale systemen van overheden en de onderdelen van de landelijke voorziening
+      (DSO-LV), zoals het Omgevingsloket.
     </p>
   </div>
 );

--- a/storybook/src/components/info-button/info-button.content.ts
+++ b/storybook/src/components/info-button/info-button.content.ts
@@ -5,17 +5,15 @@ import { Templates } from "../../templates";
 export function children({ linkTemplate, richContentTemplate }: Templates) {
   return richContentTemplate({
     children: html`
-      <h2>Samenspel tussen wetgever en ontwikkelaars</h2>
+      <h2>Introductie DSO</h2>
       <p>
-        Het DSO wordt ontwikkeld door het programma
+        Het
         ${linkTemplate({
-          label: "Aan de slag met de Omgevingswet",
-          url: "https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/",
+          label: "Digitaal Stelsel Omgevingswet (DSO)",
+          url: "https://iplo.nl/digitaal-stelsel/",
         })}
-        in samenwerking met haar partners. De ontwikkeling vraagt een intensief samenspel tussen de wetgever en de
-        ontwikkelpartners van het DSO. Enerzijds moeten wetgever en de ontwikkelpartners zorgen dat alles wat in de wet-
-        en regelgeving wordt geregeld ook makkelijk toegankelijk is of kan worden. Anderzijds moeten zij zorgen dat
-        alles wat digitaal wordt gerealiseerd, ook juridisch verankerd is of kan worden.
+        ondersteunt de uitvoering van de Omgevingswet. Het bestaat uit lokale systemen van overheden en de onderdelen
+        van de landelijke voorziening (DSO-LV), zoals het Omgevingsloket.
       </p>
     `,
   });

--- a/storybook/src/components/toggletip/toggletip.content.ts
+++ b/storybook/src/components/toggletip/toggletip.content.ts
@@ -5,17 +5,15 @@ import { Templates } from "../../templates";
 export function children({ linkTemplate, richContentTemplate }: Templates) {
   return richContentTemplate({
     children: html`
-      <h2>Samenspel tussen wetgever en ontwikkelaars</h2>
+      <h2>Introductie DSO</h2>
       <p>
-        Het DSO wordt ontwikkeld door het programma
+        Het
         ${linkTemplate({
-          label: "Aan de slag met de Omgevingswet",
-          url: "https://aandeslagmetdeomgevingswet.nl/digitaal-stelsel/",
+          label: "Digitaal Stelsel Omgevingswet (DSO)",
+          url: "https://iplo.nl/digitaal-stelsel/",
         })}
-        in samenwerking met haar partners. De ontwikkeling vraagt een intensief samenspel tussen de wetgever en de
-        ontwikkelpartners van het DSO. Enerzijds moeten wetgever en de ontwikkelpartners zorgen dat alles wat in de wet-
-        en regelgeving wordt geregeld ook makkelijk toegankelijk is of kan worden. Anderzijds moeten zij zorgen dat
-        alles wat digitaal wordt gerealiseerd, ook juridisch verankerd is of kan worden.
+        ondersteunt de uitvoering van de Omgevingswet. Het bestaat uit lokale systemen van overheden en de onderdelen
+        van de landelijke voorziening (DSO-LV), zoals het Omgevingsloket.
       </p>
     `,
   });

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -50,4 +50,4 @@ In de toolkit is er documentatie (bij enkele componenten nog in ontwikkeling) wa
 
 ## Disclaimer
 
-De DSO Toolkit is bedoeld voor gebruik binnen het programma Aan de slag met de Omgevingswet. Het is daarom niet toegestaan dat derden - zonder voorafgaande schriftelijke toestemming van het programma Aan de slag met de Omgevingswet - de informatie en/of de huisstijl kopiëren, vermenigvuldigen, bewerken of doorleveren anders dan voor persoonlijk, niet-commercieel gebruik.
+De DSO Toolkit is bedoeld voor gebruik binnen het <a href="https://iplo.nl/digitaal-stelsel/">Digitaal Stelsel Omgevingswet (DSO)</a>. Het is daarom niet toegestaan dat derden - zonder voorafgaande schriftelijke toestemming van het programma Digitaal Stelsel Omgevingswet (DSO) - de informatie en/of de huisstijl kopiëren, vermenigvuldigen, bewerken of doorleveren anders dan voor persoonlijk, niet-commercieel gebruik.


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Er zijn 2 diffjes bij info-button.cy.ts ivm gewijzigde contetn in de Tooltip:
  
<img width="3840" height="720" alt="should show the toggletip on left on click diff" src="https://github.com/user-attachments/assets/94e1a523-7550-4f4b-bcf7-e3376893fd3d" />
<img width="3840" height="720" alt="should show the toggletip on right on click diff" src="https://github.com/user-attachments/assets/057c0373-ea9d-4f1d-afcc-550e318497c5" />

- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
