### PR TITLE
#3586 [Fixed] Ozon Content: IntIoRef toggletip icon niet op juiste positie in Firefox 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Table: Bij vergroten van een tabel wordt de titel niet voorgelezen ([#3585](https://github.com/dso-toolkit/dso-toolkit/issues/3585))
+* Ozon Content: IntIoRef toggletip icon niet op juiste positie in Firefox ([#3586](https://github.com/dso-toolkit/dso-toolkit/issues/3586))
 
 ### Task
 * Segmented Button: Control `activeOption` werkt niet in Storybook ([#3639](https://github.com/dso-toolkit/dso-toolkit/issues/3639))

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
@@ -32,6 +32,7 @@ $icon-margin-inline-start: units.$u1 * 0.5;
   display: inline;
   overflow-wrap: break-word;
   user-select: text;
+  white-space: nowrap; // stylelint-disable-line declaration-property-value-disallowed-list -- No text wrap after icon
 
   &,
   &:hover,
@@ -42,17 +43,11 @@ $icon-margin-inline-start: units.$u1 * 0.5;
     text-underline-offset: 15%;
   }
 
+  .toggletip-label {
+    white-space: normal;
+  }
+
   dso-icon {
     margin-inline-start: $icon-margin-inline-start;
-    vertical-align: middle;
-  }
-}
-
-.icon-container {
-  position: relative;
-  padding-inline-end: units.$u3 + $icon-margin-inline-start;
-
-  dso-icon {
-    position: absolute;
   }
 }

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
@@ -106,10 +106,14 @@ export class ozonContentToggletip implements ComponentInterface {
           ref={(element) => (this.container = element)}
         >
           {this.icon && (
-            <span class="icon-container">
-              <slot name="label" />
+            <Fragment>
+              <span class="toggletip-label">
+                <slot name="label" />
+              </span>
+              {/* Word joiner: prevents a line break between label text and icon */}
+              {"\u2060"}
               <dso-icon icon={this.icon} />
-            </span>
+            </Fragment>
           )}
           {!this.icon && <slot name="label" />}
         </span>


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
