### PR TITLE
#3639 [Task] Segmented Button: Control `activeOption` werkt niet in Storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * Table: Bij vergroten van een tabel wordt de titel niet voorgelezen ([#3585](https://github.com/dso-toolkit/dso-toolkit/issues/3585))
 
+### Task
+* Segmented Button: Control `activeOption` werkt niet in Storybook ([#3639](https://github.com/dso-toolkit/dso-toolkit/issues/3639))
+
 ## 🦡 Release 90.1.0 - 2026-03-18
 
 ### Added

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1218,7 +1218,7 @@ export namespace Components {
     }
     interface DsoSegmentedButton {
         /**
-          * Index of the currently active option
+          * The currently active option
          */
         "activeOption": SegmentedButtonOption | undefined;
         /**
@@ -4191,7 +4191,7 @@ declare namespace LocalJSX {
     }
     interface DsoSegmentedButton {
         /**
-          * Index of the currently active option
+          * The currently active option
          */
         "activeOption": SegmentedButtonOption | undefined;
         /**

--- a/packages/core/src/components/segmented-button/readme.md
+++ b/packages/core/src/components/segmented-button/readme.md
@@ -13,7 +13,7 @@ Beperk het aantal segmenten, houd labels kort en consistent. Het component kan n
 
 | Property                    | Attribute    | Description                               | Type                                   | Default     |
 | --------------------------- | ------------ | ----------------------------------------- | -------------------------------------- | ----------- |
-| `activeOption` _(required)_ | --           | Index of the currently active option      | `SegmentedButtonOption \| undefined`   | `undefined` |
+| `activeOption` _(required)_ | --           | The currently active option               | `SegmentedButtonOption \| undefined`   | `undefined` |
 | `groupName`                 | `group-name` | Optional custom group name                | `string \| undefined`                  | `undefined` |
 | `label` _(required)_        | `label`      | Label for the segmented button group.     | `string \| undefined`                  | `undefined` |
 | `options` _(required)_      | --           | Options to render in the segmented button | `SegmentedButtonOption[] \| undefined` | `undefined` |

--- a/packages/core/src/components/segmented-button/segmented-button.tsx
+++ b/packages/core/src/components/segmented-button/segmented-button.tsx
@@ -33,10 +33,10 @@ export class SegmentedButton implements ComponentInterface {
    * Whether selection is required
    */
   @Prop({ reflect: true })
-  required?: boolean; // <dso-segmented-button required> | <dso-segmented-button>
+  required?: boolean;
 
   /**
-   * Index of the currently active option
+   * The currently active option
    */
   @Prop()
   activeOption!: SegmentedButtonOption | undefined;

--- a/packages/dso-toolkit/src/components/segmented-button/segmented-button.args.ts
+++ b/packages/dso-toolkit/src/components/segmented-button/segmented-button.args.ts
@@ -42,7 +42,7 @@ export const segmentedButtonArgTypes: ArgTypes<SegmentedButtonArgs> = {
     },
   },
   activeOption: {
-    options: [undefined, 0, 1, 2, 3, 4],
+    options: [undefined, 0, 1, 2, 3],
     control: {
       type: "select",
     },
@@ -63,6 +63,7 @@ export const segmentedButtonArgTypes: ArgTypes<SegmentedButtonArgs> = {
 export function segmentedButtonArgsMapper(a: SegmentedButtonArgs): SegmentedButton {
   return {
     ...a,
+    activeOption: a.activeOption !== undefined ? a.options[a.activeOption] : undefined,
     dsoChange: (event) => {
       a.dsoChange(event.detail);
     },

--- a/packages/dso-toolkit/src/components/segmented-button/segmented-button.models.ts
+++ b/packages/dso-toolkit/src/components/segmented-button/segmented-button.models.ts
@@ -5,7 +5,7 @@ export interface SegmentedButtonChangeEvent {
 
 export interface SegmentedButton {
   options: SegmentedButtonOption[];
-  activeOption?: number;
+  activeOption?: SegmentedButtonOption;
   dsoChange?: (event: CustomEvent<SegmentedButtonChangeEvent>) => void;
   segmentedAriaRequired?: boolean;
   segmentedAriaLabel?: string;

--- a/storybook/src/components/segmented-button/segmented-button.core-template.ts
+++ b/storybook/src/components/segmented-button/segmented-button.core-template.ts
@@ -1,8 +1,8 @@
 import { DsoSegmentedButtonCustomEvent, SegmentedButtonChangeEvent } from "@dso-toolkit/core";
+import type { SegmentedButton } from "dso-toolkit";
 import { html } from "lit-html";
 import { ifDefined } from "lit-html/directives/if-defined.js";
 
-import type { SegmentedButton } from "../../../../packages/dso-toolkit/src/components/segmented-button/segmented-button.models";
 import { ComponentImplementation } from "../../templates";
 
 export const coreSegmentedButton: ComponentImplementation<SegmentedButton> = {
@@ -19,7 +19,7 @@ export const coreSegmentedButton: ComponentImplementation<SegmentedButton> = {
       return html`
         <dso-segmented-button
           .options=${options}
-          active-option=${ifDefined(activeOption)}
+          .activeOption=${ifDefined(activeOption)}
           ?segmented-aria-required=${segmentedAriaRequired}
           segmented-aria-label=${ifDefined(segmentedAriaLabel)}
           @dsoChange=${statefulChangeHandler}


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
     - Er falen nu 2 tests van Segmented Button, omdat in deze PR het eerste segment WEL is geactiveerd:
     
<img width="1140" height="58" alt="segmented-button-disabled diff" src="https://github.com/user-attachments/assets/0cff842d-5b01-4e43-907d-37f28d9edad1" />
<img width="1140" height="58" alt="segmented-button diff" src="https://github.com/user-attachments/assets/5cee8b41-8920-433f-8738-c38bbaa48ea9" />

- [ ] ~De wijziging heeft een e2e test~
- [x] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
