### PR TITLE
#3636 [Changed] Document Component - Kenmerken en kaart paneel: Heading structuur kloppend maken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Document Component: Kenmerken en kaart paneel - Heading structuur kloppend maken ([#3636](https://github.com/dso-toolkit/dso-toolkit/issues/3636))
+
 ### Fixed
 * Info Button: WCAG - toggletip content wordt niet voorgelezen bij openen van de tooltip ([#3638](https://github.com/dso-toolkit/dso-toolkit/issues/3638))
 

--- a/packages/core/src/components/document-component/document-component.tsx
+++ b/packages/core/src/components/document-component/document-component.tsx
@@ -531,7 +531,12 @@ export class DocumentComponent implements ComponentInterface {
         )}
 
         {this.openAnnotation && (
-          <div class="annotation-container" part="_annotation-container">
+          <div
+            class="annotation-container"
+            part="_annotation-container"
+            role="dialog"
+            aria-labelledby="annotations-heading"
+          >
             <dso-panel
               id="annotations"
               onDsoCloseClick={(e) =>
@@ -543,7 +548,9 @@ export class DocumentComponent implements ComponentInterface {
               }
               closeButtonLabel="Kenmerken en kaartgegevens verbergen"
             >
-              <h2 slot="heading">Kenmerken en kaart</h2>
+              <h2 id="annotations-heading" slot="heading">
+                Kenmerken en kaart
+              </h2>
               <slot name="annotations" />
             </dso-panel>
           </div>


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
