### PR TITLE
#3659 [Fixed] Document Component: Tooltip bij noot wordt verplaatst tijdens scrollen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Scrollable: Scrollbar niet zichtbaar ([#3738](https://github.com/dso-toolkit/dso-toolkit/issues/3738))
 * Ozon Content: Toggletip bij IntRef Begrip en IntIoRef wordt niet voorgelezen ([#3592](https://github.com/dso-toolkit/dso-toolkit/issues/3592))
 * Label: Tooltip soms niet goed zichtbaar (bv in `document-panel` in Viewer Grid) ([#3600](https://github.com/dso-toolkit/dso-toolkit/issues/3600))
+* Document Component: Tooltip bij noot wordt verplaatst tijdens scrollen ([#3659](https://github.com/dso-toolkit/dso-toolkit/issues/3659))
 
 ### Removed
 * **BREAKING** Modal: Remove HTML/CSS implementatie ([#3320](https://github.com/dso-toolkit/dso-toolkit/issues/3320))

--- a/packages/core/src/components/document-component-demo/readme.md
+++ b/packages/core/src/components/document-component-demo/readme.md
@@ -50,7 +50,6 @@ graph TD;
   dso-ozon-content --> dso-icon
   dso-ozon-content --> dso-image-overlay
   dso-ozon-content --> dso-ozon-content-toggletip
-  dso-ozon-content --> dso-tooltip
   dso-ozon-content --> dso-table
   dso-image-overlay --> dso-icon-button
   dso-ozon-content-toggletip --> dso-icon

--- a/packages/core/src/components/document-component/readme.md
+++ b/packages/core/src/components/document-component/readme.md
@@ -86,7 +86,6 @@ graph TD;
   dso-ozon-content --> dso-icon
   dso-ozon-content --> dso-image-overlay
   dso-ozon-content --> dso-ozon-content-toggletip
-  dso-ozon-content --> dso-tooltip
   dso-ozon-content --> dso-table
   dso-image-overlay --> dso-icon-button
   dso-ozon-content-toggletip --> dso-icon

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
@@ -23,7 +23,7 @@ $icon-margin-inline-start: units.$u1 * 0.5;
   @include button.base($modifiers: false);
 
   border: 0;
-  color: var(--_dso-ozon-content-toggletip-color, colors.$donkerblauw);
+  color: var(--_dt-ozon-content-toggletip-color, colors.$donkerblauw);
   line-height: 1;
   padding: 0;
   background-color: transparent;
@@ -38,7 +38,7 @@ $icon-margin-inline-start: units.$u1 * 0.5;
   &:hover,
   &:focus-visible,
   &:active {
-    text-decoration-line: var(--_dso-ozon-content-toggletip-text-decoration, underline);
+    text-decoration-line: var(--_dt-ozon-content-toggletip-text-decoration, underline);
     text-decoration-style: dotted;
     text-underline-offset: 15%;
   }

--- a/packages/core/src/components/ozon-content/nodes/noot.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/noot.node.tsx
@@ -25,14 +25,12 @@ export class OzonContentNootNode implements OzonContentNode {
     const nootNummer = childNodes.find((n) => getNodeName(n) === "NootNummer")?.textContent ?? noteId;
 
     return (
-      <Fragment>
-        <sup>
-          <dso-ozon-content-toggletip class="toggle-note">
-            <span slot="label">{nootNummer}</span>
-            <span role="section">{mapNodeToJsx(Array.from(node.querySelectorAll(":scope > Al")))}</span>
-          </dso-ozon-content-toggletip>
-        </sup>
-      </Fragment>
+      <sup>
+        <dso-ozon-content-toggletip class="toggle-note">
+          <span slot="label">{nootNummer}</span>
+          <span role="section">{mapNodeToJsx(Array.from(node.querySelectorAll(":scope > Al")))}</span>
+        </dso-ozon-content-toggletip>
+      </sup>
     );
   }
 }

--- a/packages/core/src/components/ozon-content/nodes/noot.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/noot.node.tsx
@@ -13,7 +13,7 @@ export class OzonContentNootNode implements OzonContentNode {
     return "Noot";
   }
 
-  render(node: Element, { mapNodeToJsx, state: openNoteId, setState }: OzonContentNodeContext<string | undefined>) {
+  render(node: Element, { mapNodeToJsx }: OzonContentNodeContext<string | undefined>) {
     const noteId = node.getAttribute("id");
     if (!noteId) {
       console.error("Noot node without id", node);
@@ -21,28 +21,17 @@ export class OzonContentNootNode implements OzonContentNode {
       return <Fragment />;
     }
 
-    const noteControlsId = `dso-ozon-note-${noteId}`;
-
     const childNodes = Array.from(node.childNodes);
     const nootNummer = childNodes.find((n) => getNodeName(n) === "NootNummer")?.textContent ?? noteId;
 
     return (
       <Fragment>
         <sup>
-          <button
-            type="button"
-            class="toggle-note"
-            aria-describedby={noteControlsId}
-            onClick={() => setState?.(openNoteId === noteId ? undefined : noteId)}
-            onBlur={() => setState?.(undefined)}
-            aria-expanded={openNoteId === noteId ? "true" : "false"}
-          >
-            {nootNummer}
-          </button>
+          <dso-ozon-content-toggletip class="toggle-note">
+            <span slot="label">{nootNummer}</span>
+            <span role="section">{mapNodeToJsx(Array.from(node.querySelectorAll(":scope > Al")))}</span>
+          </dso-ozon-content-toggletip>
         </sup>
-        <dso-tooltip active={openNoteId === noteId} id={noteControlsId} stateless descriptive>
-          <span role="section">{mapNodeToJsx(Array.from(node.querySelectorAll(":scope > Al")))}</span>
-        </dso-tooltip>
       </Fragment>
     );
   }

--- a/packages/core/src/components/ozon-content/ozon-content.scss
+++ b/packages/core/src/components/ozon-content/ozon-content.scss
@@ -23,8 +23,9 @@
   display: inline;
 }
 
-button.toggle-note {
-  @include button-mixins.tertiary($modifiers: false);
+.toggle-note {
+  --_dt-ozon-content-toggletip-text-decoration: none;
+  --_dt-ozon-content-toggletip-color: #{colors.$grasgroen};
 }
 
 span[role="section"],

--- a/packages/core/src/components/ozon-content/ozon-content.tsx
+++ b/packages/core/src/components/ozon-content/ozon-content.tsx
@@ -121,7 +121,6 @@ const dependencies = () => {
       <dso-icon />
       <dso-image-overlay />
       <dso-ozon-content-toggletip />
-      <dso-tooltip />
       <dso-table />
     </Fragment>
   );

--- a/packages/core/src/components/ozon-content/readme.md
+++ b/packages/core/src/components/ozon-content/readme.md
@@ -36,7 +36,6 @@ Het Ozon Content component verwerkt XML die uit de Ozon API komt.
 - [dso-icon](../icon)
 - [dso-image-overlay](../image-overlay)
 - [dso-ozon-content-toggletip](./components/ozon-content-toggletip)
-- [dso-tooltip](../tooltip)
 - [dso-table](../table)
 
 ### Graph
@@ -45,7 +44,6 @@ graph TD;
   dso-ozon-content --> dso-icon
   dso-ozon-content --> dso-image-overlay
   dso-ozon-content --> dso-ozon-content-toggletip
-  dso-ozon-content --> dso-tooltip
   dso-ozon-content --> dso-table
   dso-image-overlay --> dso-icon-button
   dso-icon-button --> dso-icon

--- a/packages/core/src/components/tooltip/readme.md
+++ b/packages/core/src/components/tooltip/readme.md
@@ -49,12 +49,12 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [dso-ozon-content](../ozon-content)
+ - [dso-label](../label)
 
 ### Graph
 ```mermaid
 graph TD;
-  dso-ozon-content --> dso-tooltip
+  dso-label --> dso-tooltip
   style dso-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/dso-toolkit/src/components/delete/delete.mixins.scss
+++ b/packages/dso-toolkit/src/components/delete/delete.mixins.scss
@@ -6,7 +6,7 @@
 @mixin root($strikethrough: true) {
   @include set-colors.apply(colors.$rood-20, "delete");
 
-  --_dso-ozon-content-toggletip-color: #{colors.$zwart};
+  --_dt-ozon-content-toggletip-color: #{colors.$zwart};
 
   @if ($strikethrough) {
     @include strikethrough();
@@ -17,7 +17,7 @@
 @mixin strikethrough($_value: line-through) {
   text-decoration: $_value;
 
-  --_dso-ozon-content-toggletip-text-decoration: underline #{$_value};
+  --_dt-ozon-content-toggletip-text-decoration: underline #{$_value};
 
   // stylelint-disable media-feature-name-no-unknown -- counter line-through displaying as underline in firefox
   // http://browserhacks.com/#hack-48ca6fc2947b7850c571a2f69bdbffbd

--- a/packages/dso-toolkit/src/components/insert/insert.mixins.scss
+++ b/packages/dso-toolkit/src/components/insert/insert.mixins.scss
@@ -12,5 +12,5 @@
 
   box-shadow: insert-variables.$box-shadow;
 
-  --_dso-ozon-content-toggletip-color: #{colors.$zwart};
+  --_dt-ozon-content-toggletip-color: #{colors.$zwart};
 }

--- a/storybook/cypress/e2e/document-component.cy.ts
+++ b/storybook/cypress/e2e/document-component.cy.ts
@@ -288,6 +288,7 @@ describe("Document Component", () => {
           .find("dso-ozon-content.hydrated")
           .shadow()
           .find("dso-ozon-content-toggletip")
+          .eq(1)
           .shadow()
           .find(".toggletip-button")
           .realClick();

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -63,45 +63,68 @@ describe("Ozon Content", () => {
   });
 
   it("should open and close notes", () => {
-    function button(n: string) {
-      return cy.get("dso-ozon-content.hydrated").shadow().find(`button[aria-describedby="dso-ozon-note-${n}"]`);
-    }
-
-    function tooltip(n: string) {
-      return cy
-        .get("dso-ozon-content.hydrated")
-        .shadow()
-        .find(`sup:has(button[aria-describedby="dso-ozon-note-${n}"]) + dso-tooltip`);
-    }
-
     cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--inhoud-al-noot");
 
     cy.injectAxe();
     cy.dsoCheckA11y("dso-ozon-content.hydrated");
 
-    button("N6").should("have.attr", "aria-expanded", "false");
-    tooltip("N6").should("be.not.visible");
-    button("N7").should("have.attr", "aria-expanded", "false");
-    tooltip("N7").should("be.not.visible");
+    cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .first()
+      .shadow()
+      .find(".toggletip-button")
+      .realClick();
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .first()
+      .find("span[role=paragraph]")
+      .should("be.visible");
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .eq(1)
+      .find("span[role=paragraph]")
+      .should("be.not.visible");
 
     cy.get("dso-ozon-content.hydrated").matchImageSnapshot();
 
-    button("N7").click();
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .first()
+      .shadow()
+      .find(".toggletip-button")
+      .realClick();
 
-    button("N6").should("have.attr", "aria-expanded", "false");
-    tooltip("N6").should("be.not.visible");
-    button("N7").should("have.attr", "aria-expanded", "true");
-    tooltip("N7").should("be.visible");
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .first()
+      .find("span[role=paragraph]")
+      .should("be.not.visible");
 
-    // The wait equals the tooltip transition-duration of 0.15s
-    cy.get("dso-ozon-content.hydrated").wait(150).matchImageSnapshot(`${Cypress.currentTest.title} -- visible notes`);
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .eq(1)
+      .shadow()
+      .find(".toggletip-button")
+      .realClick();
 
-    button("N7").click();
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .eq(1)
+      .find("span[role=paragraph]")
+      .should("be.visible");
 
-    button("N6").should("have.attr", "aria-expanded", "false");
-    tooltip("N6").should("be.not.visible");
-    button("N7").should("have.attr", "aria-expanded", "false");
-    tooltip("N7").should("be.not.visible");
+    cy.get("dso-ozon-content.hydrated").matchImageSnapshot(`${Cypress.currentTest.title} -- visible notes`);
   });
 
   it("should render unknown element to span", () => {


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Deze diff ziet er goed uit. De master liet geen Tooltip zien. In deze branch wel ivm de veravngen van <dso-tooltip> door <dso-ozon-content-toggletip>
  
<img width="3000" height="376" alt="Ozon Content -- should open and close notes diff" src="https://github.com/user-attachments/assets/e7693265-65d6-4b70-82bd-00ba79434ee6" />

- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
