### PR TITLE
#3592 [Fixed] Ozon Content: Toggletip bij IntRef Begrip en IntIoRef wordt niet voorgelezen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Link: Deel inhoud wordt buiten container geplaatst door lange content ([#3591](https://github.com/dso-toolkit/dso-toolkit/issues/3591))
 * Icon Button: ResizeObserver loop completed with undelivered notifications ([#3567](https://github.com/dso-toolkit/dso-toolkit/issues/3567))
 * Scrollable: Scrollbar niet zichtbaar ([#3738](https://github.com/dso-toolkit/dso-toolkit/issues/3738))
+* Ozon Content: Toggletip bij IntRef Begrip en IntIoRef wordt niet voorgelezen ([#3592](https://github.com/dso-toolkit/dso-toolkit/issues/3592))
 
 ### Task
 * Package Manager: Gebruik pnpm ipv Yarn ([#3717](https://github.com/dso-toolkit/dso-toolkit/issues/3717))

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
@@ -15,10 +15,6 @@ $icon-margin-inline-start: units.$u1 * 0.5;
   --_dt-rich-content-margin-block: #{units.$u1};
 }
 
-.sr-only {
-  @include utilities.sr-only();
-}
-
 ::slotted(:not([slot="label"])) {
   cursor: default !important;
 }

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.scss
@@ -15,6 +15,10 @@ $icon-margin-inline-start: units.$u1 * 0.5;
   --_dt-rich-content-margin-block: #{units.$u1};
 }
 
+.sr-only {
+  @include utilities.sr-only();
+}
+
 ::slotted(:not([slot="label"])) {
   cursor: default !important;
 }

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
@@ -27,6 +27,12 @@ export class ozonContentToggletip implements ComponentInterface {
   @State()
   active = false;
 
+  /**
+   * Tooltip announcement for screen readers
+   */
+  @State()
+  announcement = "";
+
   @Listen("click", { target: "window" })
   handleWindowClick(event: MouseEvent) {
     if (!this.active) return;
@@ -49,6 +55,14 @@ export class ozonContentToggletip implements ComponentInterface {
 
   private toggle = () => {
     this.active = !this.active;
+
+    if (this.active) {
+      const tooltipText = this.tooltip?.textContent?.trim();
+      const fallbackText = this.host.textContent?.replace(this.host.id, "").trim() || "";
+      this.announcement = tooltipText || fallbackText;
+    } else {
+      this.announcement = "";
+    }
   };
 
   private keyDownHandler = (event: KeyboardEvent) => {
@@ -100,22 +114,20 @@ export class ozonContentToggletip implements ComponentInterface {
         <span
           class="toggletip-button"
           role="button"
-          tabindex={0}
+          tabIndex={0}
+          aria-expanded={this.active.toString()}
           onClick={this.toggle}
           onKeyDown={this.keyDownHandler}
           ref={(element) => (this.container = element)}
         >
+          <slot name="label" />
           {this.icon && (
             <Fragment>
-              <span class="toggletip-label">
-                <slot name="label" />
-              </span>
               {/* Word joiner: prevents a line break between label text and icon */}
               {"\u2060"}
               <dso-icon icon={this.icon} />
             </Fragment>
           )}
-          {!this.icon && <slot name="label" />}
         </span>
         <Tooltip
           tipElementRef={(element) => (this.tooltip = element)}
@@ -123,6 +135,9 @@ export class ozonContentToggletip implements ComponentInterface {
         >
           <slot />
         </Tooltip>
+        <div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
+          {this.announcement}
+        </div>
       </Fragment>
     );
   }

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
@@ -27,12 +27,6 @@ export class ozonContentToggletip implements ComponentInterface {
   @State()
   active = false;
 
-  /**
-   * Tooltip announcement for screen readers
-   */
-  @State()
-  announcement = "";
-
   @Listen("click", { target: "window" })
   handleWindowClick(event: MouseEvent) {
     if (!this.active) return;
@@ -55,14 +49,6 @@ export class ozonContentToggletip implements ComponentInterface {
 
   private toggle = () => {
     this.active = !this.active;
-
-    if (this.active) {
-      const tooltipText = this.tooltip?.textContent?.trim();
-      const fallbackText = this.host.textContent?.replace(this.host.id, "").trim() || "";
-      this.announcement = tooltipText || fallbackText;
-    } else {
-      this.announcement = "";
-    }
   };
 
   private keyDownHandler = (event: KeyboardEvent) => {
@@ -112,32 +98,34 @@ export class ozonContentToggletip implements ComponentInterface {
     return (
       <Fragment>
         <span
+          aria-describedby={this.active ? "toggletip-tooltip" : undefined}
+          aria-expanded={this.active.toString()}
           class="toggletip-button"
           role="button"
           tabIndex={0}
-          aria-expanded={this.active.toString()}
           onClick={this.toggle}
           onKeyDown={this.keyDownHandler}
           ref={(element) => (this.container = element)}
         >
-          <slot name="label" />
           {this.icon && (
             <Fragment>
+              <span class="toggletip-label">
+                <slot name="label" />
+              </span>
               {/* Word joiner: prevents a line break between label text and icon */}
               {"\u2060"}
               <dso-icon icon={this.icon} />
             </Fragment>
           )}
+          {!this.icon && <slot name="label" />}
         </span>
         <Tooltip
+          id="toggletip-tooltip"
           tipElementRef={(element) => (this.tooltip = element)}
           tipArrowElementRef={(element) => (this.tooltipArrow = element)}
         >
           <slot />
         </Tooltip>
-        <div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
-          {this.announcement}
-        </div>
       </Fragment>
     );
   }

--- a/packages/core/src/functional-components/tooltip/tooltip.functional-component.tsx
+++ b/packages/core/src/functional-components/tooltip/tooltip.functional-component.tsx
@@ -1,12 +1,13 @@
 import { FunctionalComponent, h } from "@stencil/core";
 
 interface TooltipProps {
+  id?: string;
   tipElementRef: (ref: HTMLDivElement | undefined) => void;
   tipArrowElementRef: (ref: HTMLSpanElement | undefined) => void;
 }
 
-export const Tooltip: FunctionalComponent<TooltipProps> = ({ tipElementRef, tipArrowElementRef }, children) => (
-  <div popover="manual" class="dso-tooltip" ref={tipElementRef}>
+export const Tooltip: FunctionalComponent<TooltipProps> = ({ id, tipElementRef, tipArrowElementRef }, children) => (
+  <div id={id} popover="manual" class="dso-tooltip" ref={tipElementRef}>
     <span class="tooltip-arrow" ref={tipArrowElementRef}></span>
     <div class="tooltip-inner">{children}</div>
   </div>

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -1,6 +1,26 @@
 import { isOdd } from "../support/is-odd";
 
 describe("Ozon Content", () => {
+  it("should have correct ARIA attributes on toggletip", () => {
+    cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--int-ref-begrip");
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .shadow()
+      .find(".toggletip-button")
+      .should("have.attr", "aria-expanded");
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .shadow()
+      .find(".sr-only")
+      .should("have.attr", "role", "status")
+      .and("have.attr", "aria-live", "polite")
+      .and("have.attr", "aria-atomic", "true");
+  });
+
   it("emits click with node='IntRef' on click of IntRef Link", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--int-ref");
 

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -1,26 +1,6 @@
 import { isOdd } from "../support/is-odd";
 
 describe("Ozon Content", () => {
-  it("should have correct ARIA attributes on toggletip", () => {
-    cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--int-ref-begrip");
-
-    cy.get("dso-ozon-content.hydrated")
-      .shadow()
-      .find("dso-ozon-content-toggletip")
-      .shadow()
-      .find(".toggletip-button")
-      .should("have.attr", "aria-expanded");
-
-    cy.get("dso-ozon-content.hydrated")
-      .shadow()
-      .find("dso-ozon-content-toggletip")
-      .shadow()
-      .find(".sr-only")
-      .should("have.attr", "role", "status")
-      .and("have.attr", "aria-live", "polite")
-      .and("have.attr", "aria-atomic", "true");
-  });
-
   it("emits click with node='IntRef' on click of IntRef Link", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--int-ref");
 
@@ -56,7 +36,23 @@ describe("Ozon Content", () => {
       .find("dso-ozon-content-toggletip")
       .shadow()
       .find(".toggletip-button")
+      .should("have.attr", "aria-expanded", "false")
+      .and("not.have.attr", "aria-describedby");
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .shadow()
+      .find(".toggletip-button")
       .realClick();
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .shadow()
+      .find(".toggletip-button")
+      .should("have.attr", "aria-expanded", "true")
+      .and("have.attr", "aria-describedby", "toggletip-tooltip");
 
     cy.get("dso-ozon-content.hydrated")
       .shadow()


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
