### PR TITLE
#3645 [Changed] Viewer Grid: Main panel op tablet te groot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Viewer Grid: Main panel op tablet te groot ([#3645](https://github.com/dso-toolkit/dso-toolkit/issues/3645))
+
 ## ⌚ Release 95.0.0 - 2026-05-05
 
 ### Changed

--- a/packages/core/src/components/viewer-grid/viewer-grid.scss
+++ b/packages/core/src/components/viewer-grid/viewer-grid.scss
@@ -217,7 +217,7 @@ button {
   }
 }
 
-@media screen and (min-width: #{media-query-breakpoints.$screen-sm-min + units.$u5}) {
+@media screen and (min-width: #{media-query-breakpoints.$screen-md-min + units.$u5}) {
   :host([main-size="small"]) .dso-main-panel,
   :host([document-panel-size="small"]) .dso-document-panel {
     flex-basis: core-viewer-grid-variables.$small;
@@ -320,7 +320,7 @@ button {
   }
 }
 
-@media screen and (max-width: #{media-query-breakpoints.$screen-xs-max + units.$u5 + 0.99}) {
+@media screen and (max-width: #{media-query-breakpoints.$screen-sm-max + units.$u5 + 0.99}) {
   @include navbar.root();
 
   .dso-navbar {

--- a/packages/core/src/components/viewer-grid/viewer-grid.tsx
+++ b/packages/core/src/components/viewer-grid/viewer-grid.tsx
@@ -31,7 +31,7 @@ function isDsoViewerGridComponent(element: Element): element is HTMLDsoViewerGri
 
 const buttonWidth = 40;
 
-const tabViewBreakpoint = 768 + buttonWidth;
+const tabViewBreakpoint = 992 + buttonWidth;
 
 const minMapElementWidth = 440;
 

--- a/storybook/cypress/e2e/viewer-grid.cy.ts
+++ b/storybook/cypress/e2e/viewer-grid.cy.ts
@@ -283,7 +283,7 @@ describe("Viewer Grid", () => {
   });
 
   it("should have the correct aria-label on the filter panel", () => {
-    cy.visit("http://localhost:45000/iframe.html?id=core-viewer-grid--viewer-grid");
+    cy.visit(url);
     cy.get("dso-viewer-grid.hydrated")
       .invoke("attr", "filter-panel-title", "Filter toegankelijkheidstest")
       .invoke("attr", "filter-panel-open", "");
@@ -294,7 +294,7 @@ describe("Viewer Grid", () => {
   });
 
   it("should render h3 with sr-only class when no title is provided", () => {
-    cy.visit("http://localhost:45000/iframe.html?id=core-viewer-grid--viewer-grid");
+    cy.visit(url);
     cy.get("dso-viewer-grid.hydrated").invoke("attr", "filter-panel-open", "");
     cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel h3").should("have.class", "sr-only");
   });

--- a/storybook/cypress/e2e/viewer-grid.cy.ts
+++ b/storybook/cypress/e2e/viewer-grid.cy.ts
@@ -3,8 +3,12 @@ const urlOverlayClosed = `${url}&args=overlayOpen:false`;
 const urlOverlayOpened = `${url}&args=overlayOpen:true`;
 
 describe("Viewer Grid", () => {
+  beforeEach(() => {
+    cy.viewport(1280, 600);
+  });
+
   // ToDo: Fix the 'matches snapshots -- filter-panel-open - small viewport` in #3199
-  it.skip("matches snapshots", () => {
+  it("matches snapshots", () => {
     cy.visit(url);
 
     cy.get("dso-viewer-grid.hydrated")
@@ -13,7 +17,7 @@ describe("Viewer Grid", () => {
       .invoke("attr", "main-panel-expanded", "")
       .invoke("attr", "document-panel-open", "")
       .invoke("attr", "document-panel-size", "small")
-      .matchImageSnapshot();
+      .matchImageSnapshot(`${Cypress.currentTest.titlePath.join(" - ")} -- filter-panel-open-false - large viewport`);
 
     cy.get("@viewer-grid")
       .invoke("attr", "main-size", "medium")
@@ -22,18 +26,18 @@ describe("Viewer Grid", () => {
       .invoke("attr", "filter-panel-title", "De titel van het filter paneel")
       .invoke("attr", "filter-panel-open", true)
       .wait(250)
-      .matchImageSnapshot(`${Cypress.currentTest.title}" -- filter-panel-open - large viewport`);
+      .matchImageSnapshot(`${Cypress.currentTest.titlePath.join(" - ")} -- filter-panel-open-true - large viewport`);
 
-    cy.viewport(900, 600)
+    cy.viewport(1124, 600)
       .wait(250)
       .get("@viewer-grid")
-      .matchImageSnapshot(`${Cypress.currentTest.title}" -- filter-panel-open - medium viewport`);
+      .matchImageSnapshot(`${Cypress.currentTest.titlePath.join(" - ")} -- filter-panel-open - medium viewport`);
 
-    cy.viewport(800, 600)
+    cy.viewport(1024, 600)
       .get("@viewer-grid")
       .invoke("attr", "active-tab", "search")
       .wait(250)
-      .matchImageSnapshot(`${Cypress.currentTest.title}" -- filter-panel-open - small viewport`);
+      .matchImageSnapshot(`${Cypress.currentTest.titlePath.join(" - ")} -- filter-panel-open - small viewport`);
   });
 
   it("should be accessible (overlay closed)", () => {
@@ -277,23 +281,38 @@ describe("Viewer Grid", () => {
       .should("exist")
       .and("be.visible");
   });
-});
 
-it("should have the correct aria-label on the filter panel", () => {
-  cy.visit("http://localhost:45000/iframe.html?id=core-viewer-grid--viewer-grid");
-  cy.get("dso-viewer-grid.hydrated")
-    .invoke("attr", "filter-panel-title", "Filter toegankelijkheidstest")
-    .invoke("attr", "filter-panel-open", "");
-  cy.get("dso-viewer-grid.hydrated")
-    .shadow()
-    .find(".filter-panel")
-    .should("have.attr", "aria-label", "Filter toegankelijkheidstest");
-});
+  it("should have the correct aria-label on the filter panel", () => {
+    cy.visit("http://localhost:45000/iframe.html?id=core-viewer-grid--viewer-grid");
+    cy.get("dso-viewer-grid.hydrated")
+      .invoke("attr", "filter-panel-title", "Filter toegankelijkheidstest")
+      .invoke("attr", "filter-panel-open", "");
+    cy.get("dso-viewer-grid.hydrated")
+      .shadow()
+      .find(".filter-panel")
+      .should("have.attr", "aria-label", "Filter toegankelijkheidstest");
+  });
 
-it("should render h3 with sr-only class when no title is provided", () => {
-  cy.visit("http://localhost:45000/iframe.html?id=core-viewer-grid--viewer-grid");
-  cy.get("dso-viewer-grid.hydrated").invoke("attr", "filter-panel-open", "");
-  cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel h3").should("have.class", "sr-only");
+  it("should render h3 with sr-only class when no title is provided", () => {
+    cy.visit("http://localhost:45000/iframe.html?id=core-viewer-grid--viewer-grid");
+    cy.get("dso-viewer-grid.hydrated").invoke("attr", "filter-panel-open", "");
+    cy.get("dso-viewer-grid.hydrated").shadow().find(".filter-panel h3").should("have.class", "sr-only");
+  });
+
+  const stories = ["document-panel", "filter-panel", "viewer-grid"];
+
+  for (const story of stories) {
+    it(`should be accessible (${story})`, () => {
+      cy.visit(`http://localhost:45000/iframe.html?id=core-viewer-grid--${story}`);
+      cy.injectAxe();
+      cy.dsoCheckA11y("dso-viewer-grid.hydrated");
+    });
+
+    it(`matches imageSnapshot (${story})`, () => {
+      cy.visit(`http://localhost:45000/iframe.html?id=core-viewer-grid--${story}`);
+      cy.get("dso-viewer-grid.hydrated").matchImageSnapshot(`${Cypress.currentTest.title} - ${story}`);
+    });
+  }
 });
 
 function shrink() {

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -359,11 +359,5 @@
     "selector": ".dso-tile-grid",
     "stories": ["tile-grid"],
     "type": "html-css"
-  },
-  {
-    "name": "viewer-grid",
-    "selector": "dso-viewer-grid",
-    "stories": ["document-panel", "filter-panel", "viewer-grid"],
-    "type": "core"
   }
 ]

--- a/storybook/cypress/fixtures/image-snapshot-voorbeeldpaginas.json
+++ b/storybook/cypress/fixtures/image-snapshot-voorbeeldpaginas.json
@@ -29,6 +29,7 @@
   "voorbeeldpagina-s-toepassingen-samenwerken-samenwerken-gegevens--samenwerken-gegevens",
   "voorbeeldpagina-s-toepassingen-stelselcatalogus-begrippen--begrippen",
   "voorbeeldpagina-s-toepassingen-vergunningscheck-landingspagina--landingspagina",
+  "voorbeeldpagina-s-toepassingen-vergunningscheck-resultaat--resultaat",
   "voorbeeldpagina-s-typografie--typografie",
   "voorbeeldpagina-s-zoeken-in-lijst-cards--zoeken-in-lijst-cards"
 ]


### PR DESCRIPTION
Dit is de 1e PR voor dit issue. Deze PR was al gemerged in master, maar bleek nog een onvolkomenheid te bevatten mbt de voorbeeldpagina's voor Regels op de Kaart, waarin Viewer Grid, op de te kleine default viewport van Cypress in de tabbed view werd getoond. Daardoor faalde er 2 image-snapshot-voorbeeldpaginas testen. Ik heb de merge-commit van die deze PR uit master verwijderd en vervolgens de branch hersteld en mijn aanpassingen opgenomen in een nieuwe PR: https://github.com/dso-toolkit/dso-toolkit/pull/3770.

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
