### PR TITLE
#3747 [Fixed] Button: Variant `tertiary` heeft onterecht `margin-inline-start: -8px;`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * Viewer Grid: Main panel op tablet te groot ([#3645](https://github.com/dso-toolkit/dso-toolkit/issues/3645))
 
+### Fixed
+* Button: Variant `tertiary` heeft onterecht `margin-inline-start: -8px;` ([#3747](https://github.com/dso-toolkit/dso-toolkit/issues/3747))
+
 ## ⌚ Release 95.0.0 - 2026-05-05
 
 ### Changed

--- a/packages/dso-toolkit/src/components/button/button.mixins.scss
+++ b/packages/dso-toolkit/src/components/button/button.mixins.scss
@@ -76,7 +76,7 @@
     > span {
       @include utilities.sr-only();
     }
-  } @else {
+  } @else if $variant != tertiary {
     dso-icon:has(+ span:not(.sr-only)) {
       margin-inline-start: units.$u1 * -1;
     }


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
    - Er zijn 4 diffs ontstaan door deze aanpassing.
    
<img width="3000" height="152" alt="Ozon Content -- IntIoRef -- shows a toggletip diff" src="https://github.com/user-attachments/assets/b5549e80-c2ea-4186-8a5f-5e400a48bf07" />

<img width="3000" height="319" alt="core-table--sorted-descending diff" src="https://github.com/user-attachments/assets/68f163e8-f608-4cdb-9c87-8228f211b0c1" />

<img width="3000" height="319" alt="core-table--sorted-ascending diff" src="https://github.com/user-attachments/assets/942d9e43-4f99-4479-b73c-39f55d706f8a" />

<img width="3000" height="80" alt="html-css-button-row--alle-button-varianten diff" src="https://github.com/user-attachments/assets/0d7e54d2-116f-43c0-9af1-552459b6ebb8" />

- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
