### PR TITLE
#3509 [Fixed] Modal: Mouseup buiten modal na Mousedown binnen de modal  sluit de modal onverwacht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Button: Variant `tertiary` heeft onterecht `margin-inline-start: -8px;` ([#3747](https://github.com/dso-toolkit/dso-toolkit/issues/3747))
+* Modal: Mouseup buiten modal na Mousedown binnen de modal sluit de modal onverwacht ([#3509](https://github.com/dso-toolkit/dso-toolkit/issues/3509))
 
 ## ⌚ Release 95.0.0 - 2026-05-05
 

--- a/packages/core/src/components/modal/modal.tsx
+++ b/packages/core/src/components/modal/modal.tsx
@@ -14,6 +14,8 @@ import { ModalCloseEvent } from "./modal.interfaces";
 })
 export class Modal implements ComponentInterface {
   private htmlDialogElement?: HTMLDialogElement;
+  private startedMouseDownOutsideDialog = false;
+  private endedMouseUpOutsideDialog = false;
 
   @Element()
   host!: HTMLDsoModalElement;
@@ -95,12 +97,20 @@ export class Modal implements ComponentInterface {
     (this.returnFocus ?? this.returnFocusElement)?.focus();
   }
 
+  private handleDialogMouseDown(e: MouseEvent) {
+    this.startedMouseDownOutsideDialog = e.target === this.htmlDialogElement;
+  }
+
+  private handleDialogMouseUp(e: MouseEvent) {
+    this.endedMouseUpOutsideDialog = e.target === this.htmlDialogElement;
+  }
+
   private handleDialogClick(e: MouseEvent) {
     if (!this.closable) {
       return;
     }
 
-    if (e.target === this.htmlDialogElement) {
+    if (this.startedMouseDownOutsideDialog && this.endedMouseUpOutsideDialog && e.target === this.htmlDialogElement) {
       this.dsoClose.emit({ originalEvent: e });
     }
   }
@@ -123,6 +133,8 @@ export class Modal implements ComponentInterface {
         aria-modal="true"
         aria-labelledby={this.ariaId}
         ref={(element) => (this.htmlDialogElement = element)}
+        onMouseDown={(e) => this.handleDialogMouseDown(e)}
+        onMouseUp={(e) => this.handleDialogMouseUp(e)}
         onClick={(e) => this.handleDialogClick(e)}
         onKeyDown={(e) => this.blockEscapeKey(e)}
       >

--- a/storybook/cypress/e2e/modal.cy.ts
+++ b/storybook/cypress/e2e/modal.cy.ts
@@ -95,6 +95,22 @@ describe("Modal", () => {
     cy.get("dso-modal:focus-within").realPress("Escape").get("@dsoCloseListener").should("have.been.calledOnce");
   });
 
+  it("should not emit dsoClose when mousedown starts in dialog and click ends outside", () => {
+    cy.get("@dsoModal").find(".dso-body").trigger("mousedown", { force: true });
+    cy.get("@dsoModal").find(".dso-modal").trigger("mouseup", "topLeft", { force: true });
+    cy.get("@dsoModal").find(".dso-modal").trigger("click", "topLeft", { force: true });
+
+    cy.get("@dsoCloseListener").should("not.have.been.called");
+  });
+
+  it("should not emit dsoClose when mousedown starts outside and mouseup ends in dialog", () => {
+    cy.get("@dsoModal").find(".dso-modal").trigger("mousedown", "topLeft", { force: true });
+    cy.get("@dsoModal").find(".dso-body").trigger("mouseup", { force: true });
+    cy.get("@dsoModal").find(".dso-modal").trigger("click", "topLeft", { force: true });
+
+    cy.get("@dsoCloseListener").should("not.have.been.called");
+  });
+
   it("should not emit dsoClose on escape press if closable is false", () => {
     cy.get("dso-modal.hydrated").invoke("prop", "closable", false);
     cy.realPress("Escape");


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [x] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
