### PR TITLE
#3670 [Deprecated] Attachments Counter: Deprecate HTML/CSS implementatie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Deprecated
 * Alert: Deprecate HTML/CSS implementatie ([#3668](https://github.com/dso-toolkit/dso-toolkit/issues/3668))
+* Attachments Counter: Deprecate HTML/CSS implementatie ([#3670](https://github.com/dso-toolkit/dso-toolkit/issues/3670))
 
 ## 🩵 Release 95.1.0 - 2026-05-18
 

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -62,7 +62,7 @@
     "type": "html-css"
   },
   {
-    "name": "attachments-counter",
+    "name": "attachments-counter-deprecated",
     "selector": ".dso-attachments",
     "stories": ["attachments-counter"],
     "type": "html-css"

--- a/storybook/src/components/attachments-counter/attachments-counter.css-stories.ts
+++ b/storybook/src/components/attachments-counter/attachments-counter.css-stories.ts
@@ -6,7 +6,7 @@ import { templateContainer } from "../../templates";
 
 const meta: Meta<AttachmentsCounterArgs> = {
   ...attachmentsCounterMeta({ readme }),
-  title: "HTML|CSS/Attachments Counter",
+  title: "HTML|CSS/Attachments Counter (Deprecated)",
 };
 
 export default meta;

--- a/storybook/src/components/attachments-counter/attachments-counter.css-template.ts
+++ b/storybook/src/components/attachments-counter/attachments-counter.css-template.ts
@@ -8,10 +8,10 @@ export const cssAttachmentsCounter: ComponentImplementation<AttachmentsCounter> 
   implementation: "html-css",
   template: () =>
     function attachmentsCounterTemplate({ count }) {
-      return html`
+      return html`<!-- START DEPRECATED: use <dso-attachments-counter> -->
         <span class="dso-attachments">
           ${count} <span class="sr-only">${count !== 1 ? "bijlagen" : "bijlage"}</span>
         </span>
-      `;
+        <!-- END DEPRECATED -->`;
     },
 };

--- a/website/blog/2026-05-19-dso-toolkit-95.2.0.mdx
+++ b/website/blog/2026-05-19-dso-toolkit-95.2.0.mdx
@@ -4,9 +4,10 @@ authors: [iterox]
 
 # DSO Toolkit v95.2.0 ⛱️
 
-Deze release bevat een **deprecation** voor het volgende component:
+Deze release bevat 2 **deprecation**s voor de volgende componenten:
 
 - Alert (HTML/CSS implementatie)
+- Attachements Counter (HTML/CSS implementatie)
 
 <!-- truncate -->
 
@@ -40,4 +41,21 @@ Gebruik de Core implementatie van Alert.
     </button>
   </div>
 </dso-alert>
+```
+
+## Attachments Counter (HTML/CSS implementatie)
+
+De HTML/CSS implementatie van het component `Attachments Counter` is deprecated. In een toekomstige **BREAKING**
+release zal de HTML/CSS implementatie verwijderd worden.
+
+### Migratiepad
+
+Gebruik de Core implementatie van `Attachments Counter`.
+
+```html
+❌
+<span class="dso-attachments"> 3 <span class="sr-only">bijlagen</span> </span>
+
+✅
+<dso-attachments-counter count="3"></dso-attachments-counter>
 ```

--- a/website/docs/components/attachments-counter.mdx
+++ b/website/docs/components/attachments-counter.mdx
@@ -2,7 +2,15 @@ import { StorybookComponent } from "@site/src/components/StorybookComponent";
 
 # Attachments Counter
 
-<StorybookComponent variant="attachments-counter" />
+<StorybookComponent variant="attachments-counter" implementations={["core", "angular", "react"]} />
+
+De HTML/CSS implementatie is **Deprecated**:
+
+<StorybookComponent
+  variant="attachments-counter"
+  name="attachments-counter-deprecated"
+  implementations={["html-css"]}
+/>
 
 De Attachments Counter is een teller voor bijlagen. Deze wordt getoond met het aantal bijlagen en het paperclip-icoon. Het geeft aan hoeveel bijlagen er zijn toegevoegd die bekeken of gedownload kunnen worden.
 


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
    - Door de toeveging van deprecated: `Error: New snapshot: 'html-css-attachments-counter-deprecated--attachments-counter' was added, but 'requireSnapshots' was set to true.` ✅
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
