### PR TITLE
#3732 [Changed]  WCAG Map Controls: Region met kaartlagen moet een duidelijke naam krijgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Map Controls: WCAG Region met kaartlagen moet een duidelijke naam krijgen ([#3732](https://github.com/dso-toolkit/dso-toolkit/issues/3732))
+
 ### Deprecated
 * Info: Deprecate HTML/CSS Implementatie ([#3571](https://github.com/dso-toolkit/dso-toolkit/issues/3571))
 

--- a/packages/core/src/components/map-controls/map-controls.tsx
+++ b/packages/core/src/components/map-controls/map-controls.tsx
@@ -73,8 +73,6 @@ export class MapControls implements ComponentInterface {
   watchOpen(open: boolean) {
     if (open) {
       this.hideContent = false;
-
-      setTimeout(() => this.#closeButtonElement?.focus(), transitionDuration);
     } else {
       setTimeout(() => {
         this.hideContent = true;
@@ -108,9 +106,10 @@ export class MapControls implements ComponentInterface {
 
   private text = i18n(() => this.host, translations);
 
-  #closeButtonElement: HTMLDsoIconButtonElement | undefined;
   #toggleButtonElement: HTMLButtonElement | undefined;
   #toggleIconButtonElement: HTMLDsoIconButtonElement | undefined;
+  #mapLayerPanelId = "maplayer-panel";
+  #mapLayerTitleId = "maplayer-title";
 
   render() {
     return (
@@ -119,6 +118,8 @@ export class MapControls implements ComponentInterface {
           label={this.text("layersButton")}
           icon="layers"
           variant="map"
+          aria-controls={this.#mapLayerPanelId}
+          aria-expanded={this.open}
           tooltipPlacement="left"
           class="toggle-visibility-icon-button"
           onDsoClick={(e) => this.toggleVisibility(e.detail.originalEvent)}
@@ -127,6 +128,8 @@ export class MapControls implements ComponentInterface {
         <button
           type="button"
           class="dso-map toggle-visibility-button"
+          aria-controls={this.#mapLayerPanelId}
+          aria-expanded={this.open}
           onClick={(e) => this.toggleVisibility(e)}
           ref={(element) => (this.#toggleButtonElement = element)}
         >
@@ -151,16 +154,22 @@ export class MapControls implements ComponentInterface {
             disabled={this.disableZoom === "out" || this.disableZoom === "both"}
           />
         </dso-button-group>
-        <section hidden={this.hideContent}>
+        <section
+          id={this.#mapLayerPanelId}
+          hidden={this.hideContent}
+          role="region"
+          aria-labelledby={this.#mapLayerTitleId}
+        >
           <header>
-            <h2>{this.text("title")}</h2>
+            <h2 id={this.#mapLayerTitleId} tabIndex={-1}>
+              {this.text("title")}
+            </h2>
             <dso-icon-button
               class="close-button"
               label={this.text("hidePanel", { title: this.text("title") })}
               icon="cross"
               variant="tertiary"
               onDsoClick={(e) => this.toggleVisibility(e.detail.originalEvent)}
-              ref={(element) => (this.#closeButtonElement = element)}
             />
           </header>
           <dso-scrollable>

--- a/packages/core/src/components/map-controls/map-controls.tsx
+++ b/packages/core/src/components/map-controls/map-controls.tsx
@@ -108,8 +108,8 @@ export class MapControls implements ComponentInterface {
 
   #toggleButtonElement: HTMLButtonElement | undefined;
   #toggleIconButtonElement: HTMLDsoIconButtonElement | undefined;
-  #mapLayerPanelId = "maplayer-panel";
-  #mapLayerTitleId = "maplayer-title";
+  #mapLayersPanelId = "map-layers-panel";
+  #mapLayersTitleId = "map-layers-title";
 
   render() {
     return (
@@ -118,7 +118,7 @@ export class MapControls implements ComponentInterface {
           label={this.text("layersButton")}
           icon="layers"
           variant="map"
-          aria-controls={this.#mapLayerPanelId}
+          aria-controls={this.#mapLayersPanelId}
           aria-expanded={this.open}
           tooltipPlacement="left"
           class="toggle-visibility-icon-button"
@@ -128,7 +128,7 @@ export class MapControls implements ComponentInterface {
         <button
           type="button"
           class="dso-map toggle-visibility-button"
-          aria-controls={this.#mapLayerPanelId}
+          aria-controls={this.#mapLayersPanelId}
           aria-expanded={this.open}
           onClick={(e) => this.toggleVisibility(e)}
           ref={(element) => (this.#toggleButtonElement = element)}
@@ -155,13 +155,13 @@ export class MapControls implements ComponentInterface {
           />
         </dso-button-group>
         <section
-          id={this.#mapLayerPanelId}
+          id={this.#mapLayersPanelId}
           hidden={this.hideContent}
           role="region"
-          aria-labelledby={this.#mapLayerTitleId}
+          aria-labelledby={this.#mapLayersPanelId}
         >
           <header>
-            <h2 id={this.#mapLayerTitleId} tabIndex={-1}>
+            <h2 id={this.#mapLayersTitleId} tabIndex={-1}>
               {this.text("title")}
             </h2>
             <dso-icon-button


### PR DESCRIPTION

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
