### PR TITLE
#3675 [Removed] Card Grid & Card List: Remove (Fix Card Container)

### DIFF
--- a/packages/core/src/components/card-container/readme.md
+++ b/packages/core/src/components/card-container/readme.md
@@ -1,6 +1,6 @@
 # `<dso-card-container>`
 
-
+Een Card Container bevat een lijst of een grid van Cards, Document Cards of Plekinfo Cards.
 
 <!-- Auto Generated Below -->
 

--- a/packages/dso-toolkit/src/components/card-container/card-container.models.ts
+++ b/packages/dso-toolkit/src/components/card-container/card-container.models.ts
@@ -1,8 +1,10 @@
-import { Card } from "../card/card.models.js";
+import { Card } from "../card";
+import { DocumentCard } from "../document-card";
+import { PlekinfoCard } from "../plekinfo-card";
 
 export interface CardContainer<TemplateFnReturnType> {
   mode: CardContainerMode;
-  cards: Card<TemplateFnReturnType>[];
+  cards: (Card<TemplateFnReturnType> | DocumentCard<TemplateFnReturnType> | PlekinfoCard<TemplateFnReturnType>)[];
 }
 
 export type CardContainerMode = "list" | "grid";

--- a/packages/dso-toolkit/src/components/card-container/card-container.models.ts
+++ b/packages/dso-toolkit/src/components/card-container/card-container.models.ts
@@ -4,7 +4,7 @@ import { PlekinfoCard } from "../plekinfo-card";
 
 export interface CardContainer<TemplateFnReturnType> {
   mode: CardContainerMode;
-  cards: (Card<TemplateFnReturnType> | DocumentCard<TemplateFnReturnType> | PlekinfoCard<TemplateFnReturnType>)[];
+  cards: Card<TemplateFnReturnType>[] | DocumentCard<TemplateFnReturnType>[] | PlekinfoCard<TemplateFnReturnType>[];
 }
 
 export type CardContainerMode = "list" | "grid";

--- a/packages/dso-toolkit/src/components/card/card.models.ts
+++ b/packages/dso-toolkit/src/components/card/card.models.ts
@@ -1,8 +1,9 @@
-import { Button } from "../button/button.models.js";
+import { isObject } from "../../utils/is-object";
+import { Button } from "../button";
 import { InfoButton } from "../info-button";
-import { Label } from "../label/label.models.js";
-import { Link } from "../link/link.models.js";
-import { Selectable } from "../selectable/selectable.models.js";
+import { Label } from "../label";
+import { Link } from "../link";
+import { Selectable } from "../selectable";
 import { SlideToggle } from "../slide-toggle";
 
 export interface Card<TemplateFnReturnType> {
@@ -20,4 +21,8 @@ export interface CardClickEvent {
   originalEvent: MouseEvent;
   /** True when user selected the page holding Ctrl, Alt or other modifiers. Can be used to determine navigation. */
   isModifiedEvent: boolean;
+}
+
+export function isCardInterface<TemplateFnReturnType>(object: unknown): object is Card<TemplateFnReturnType> {
+  return isObject(object) && !("targetBlank" in object) && !("status" in object);
 }

--- a/packages/dso-toolkit/src/components/document-card/document-card.models.ts
+++ b/packages/dso-toolkit/src/components/document-card/document-card.models.ts
@@ -1,3 +1,4 @@
+import { isObject } from "../../utils/is-object";
 import { Badge } from "../badge";
 import { InfoButton } from "../info-button";
 import { Label } from "../label";
@@ -19,4 +20,10 @@ export interface DocumentCardClickEvent {
   originalEvent: MouseEvent;
   /** True when user selected the page holding Ctrl, Alt or other modifiers. Can be used to determine navigation. */
   isModifiedEvent: boolean;
+}
+
+export function isDocumentCardInterface<TemplateFnReturnType>(
+  object: unknown,
+): object is DocumentCard<TemplateFnReturnType> {
+  return isObject(object) && "status" in object;
 }

--- a/packages/dso-toolkit/src/components/plekinfo-card/plekinfo-card.models.ts
+++ b/packages/dso-toolkit/src/components/plekinfo-card/plekinfo-card.models.ts
@@ -1,5 +1,6 @@
-import { Label } from "../label/label.models.js";
-import { Renvooi } from "../renvooi/renvooi.models.js";
+import { isObject } from "../../utils/is-object";
+import { Label } from "../label";
+import { Renvooi } from "../renvooi";
 import { SlideToggle } from "../slide-toggle";
 
 export interface PlekinfoCard<TemplateFnReturnType> {
@@ -22,3 +23,9 @@ export interface PlekinfoCardClickEvent {
 }
 
 export type PlekinfoWijzigactie = "voegtoe" | "verwijder";
+
+export function isPlekinfoCardInterface<TemplateFnReturnType>(
+  object: unknown,
+): object is PlekinfoCard<TemplateFnReturnType> {
+  return isObject(object) && "targetBlank" in object;
+}

--- a/packages/react/src/components/card-container/card-container.react-template.tsx
+++ b/packages/react/src/components/card-container/card-container.react-template.tsx
@@ -1,10 +1,10 @@
-import { CardContainer } from "dso-toolkit";
-import React, { JSX } from "react";
+import { CardContainer, isCardInterface } from "dso-toolkit";
+import React from "react";
 
 import { DsoCardContainer } from "../../components";
 import { ComponentImplementation } from "../../templates";
 
-export const reactCardContainer: ComponentImplementation<CardContainer<JSX.Element>> = {
+export const reactCardContainer: ComponentImplementation<CardContainer<React.JSX.Element>> = {
   component: "cardContainer",
   implementation: "react",
   template: ({ cardTemplate }) =>
@@ -12,7 +12,11 @@ export const reactCardContainer: ComponentImplementation<CardContainer<JSX.Eleme
       return (
         <DsoCardContainer mode={mode}>
           {cards.map((card, index) =>
-            mode === "list" ? <li key={index}>{cardTemplate(card)}</li> : cardTemplate(card),
+            mode === "list" ? (
+              <li key={index}>{isCardInterface(card) && cardTemplate(card)}</li>
+            ) : (
+              isCardInterface(card) && cardTemplate(card)
+            ),
           )}
         </DsoCardContainer>
       );

--- a/storybook/src/components/card-container/card-container.core-template.ts
+++ b/storybook/src/components/card-container/card-container.core-template.ts
@@ -1,17 +1,36 @@
-import { CardContainer } from "dso-toolkit";
-import { TemplateResult, html } from "lit-html";
+import {
+  Card,
+  CardContainer,
+  DocumentCard,
+  PlekinfoCard,
+  isCardInterface,
+  isDocumentCardInterface,
+  isPlekinfoCardInterface,
+} from "dso-toolkit";
+import { TemplateResult, html, nothing } from "lit-html";
 
-import { ComponentImplementation } from "../../templates";
+import { ComponentImplementation, Templates } from "../../templates";
 
 export const coreCardContainer: ComponentImplementation<CardContainer<TemplateResult>> = {
   component: "cardContainer",
   implementation: "core",
-  template: ({ cardTemplate }) =>
+  template: (templates) =>
     function cardContainerTemplate({ mode, cards }) {
       return html`
         <dso-card-container mode=${mode}>
-          ${cards.map((card) => (mode === "list" ? html`<li>${cardTemplate(card)}</li>` : cardTemplate(card)))}
+          ${cards.map((card) =>
+            mode === "list" ? html`<li>${template(card, templates)}</li>` : template(card, templates),
+          )}
         </dso-card-container>
       `;
     },
 };
+
+function template(
+  card: Card<TemplateResult> | DocumentCard<TemplateResult> | PlekinfoCard<TemplateResult>,
+  { cardTemplate, documentCardTemplate, plekinfoCardTemplate }: Templates,
+): TemplateResult {
+  return html` ${isCardInterface(card) ? cardTemplate(card) : nothing}
+  ${isDocumentCardInterface(card) ? documentCardTemplate(card) : nothing}
+  ${isPlekinfoCardInterface(card) ? plekinfoCardTemplate(card) : nothing}`;
+}

--- a/storybook/src/components/card-container/card-container.core-template.ts
+++ b/storybook/src/components/card-container/card-container.core-template.ts
@@ -29,8 +29,16 @@ export const coreCardContainer: ComponentImplementation<CardContainer<TemplateRe
 function template(
   card: Card<TemplateResult> | DocumentCard<TemplateResult> | PlekinfoCard<TemplateResult>,
   { cardTemplate, documentCardTemplate, plekinfoCardTemplate }: Templates,
-): TemplateResult {
-  return html` ${isCardInterface(card) ? cardTemplate(card) : nothing}
-  ${isDocumentCardInterface(card) ? documentCardTemplate(card) : nothing}
-  ${isPlekinfoCardInterface(card) ? plekinfoCardTemplate(card) : nothing}`;
+): TemplateResult | typeof nothing {
+  if (isCardInterface(card)) {
+    return cardTemplate(card);
+  }
+  if (isDocumentCardInterface(card)) {
+    return documentCardTemplate(card);
+  }
+  if (isPlekinfoCardInterface(card)) {
+    return plekinfoCardTemplate(card);
+  }
+
+  return nothing;
 }

--- a/storybook/src/example-pages/toepassingen/regels-op-de-kaart/documenten.stories.ts
+++ b/storybook/src/example-pages/toepassingen/regels-op-de-kaart/documenten.stories.ts
@@ -27,7 +27,7 @@ const Documenten = examplePageStories((templates) => {
     linkTemplate,
     bannerTemplate,
     buttonTemplate,
-    documentCardTemplate,
+    cardContainerTemplate,
     documentHeaderTemplate,
     highlightBoxTemplate,
     iconTemplate,
@@ -104,13 +104,7 @@ const Documenten = examplePageStories((templates) => {
               variant: "tertiary",
               icon: { icon: "chevron-up" },
             })}
-            ${navbarTemplate(mainSubmenu)}
-
-            <ul class="dso-card-list">
-              ${documentCardList.map((documentCardItem) => {
-                return html`<li>${documentCardTemplate(documentCardItem)}</li>`;
-              })}
-            </ul>
+            ${navbarTemplate(mainSubmenu)} ${cardContainerTemplate({ mode: "list", cards: documentCardList })}
           `,
           map: html`
             ${mapMessageTemplate({

--- a/website/docs/components/cards.mdx
+++ b/website/docs/components/cards.mdx
@@ -72,7 +72,7 @@ Een Card mag uitsluitend in een [Card List](./card-container#card-list) of [Card
 
 ### With Toggletip
 
-<StorybookComponent name="card" implementations={["core", "react"]} variant="with-toggletip" />
+<StorybookComponent name="card" implementations={["core", "react"]} variant="with-info-button-with-toggletip" />
 
 ## Document Card
 


### PR DESCRIPTION
#3675 Card Grid & Card List: Remove is reeds in master gemerged, maar nog niet gereleased.

Ik heb echter iets over het hoofd gezien.

Dat is dat in de Voorbeeldpagina Toepassingen - Regels op de kaart - Documenten nog een instantie van de HTML/CSS implementatie van Card List  vóórkomt.

```html
<ul class="dso-card-list">
  ${documentCardList.map((documentCardItem) => {
    return html`<li>${documentCardTemplate(documentCardItem)}</li>`;
  })}
</ul>
```

Dat ziet er nu dus zo uit (links):

<img width="990" height="831" alt="Screenshot 2026-05-26 at 14 40 47" src="https://github.com/user-attachments/assets/b2d1159b-059b-4c3a-9e59-3162371d3025" />

Het zijn Document Card’s die getoond worden.
Voorheen in de HTML/CSS implementatie van Card List. En nu dus in de Core implementatie van Card Container. Echter staat het model van Card Container alléén Cards toe. Ik heb even in de codebase van de Viewer gekeken en zij stoppen Document Cards en Plekinfo Cards in Card Container.

Ik heb dus wat aanpassingen moeten doen aan de modellen van Card Container om dit recht te breien.

---

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht: zie hierboven.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - ~Danger tevreden~. Zie [deze comment](https://github.com/dso-toolkit/dso-toolkit/pull/3795#issuecomment-4544349832).
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~taleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
