### PR TITLE
#3854 [Added] Autosuggest: Statusbericht "Een moment geduld" tijdens laden van suggesties toegankelijk maken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Added
+* Autosuggest: Statusbericht "Een moment geduld" tijdens laden van suggesties toegankelijk maken ([#3854](https://github.com/dso-toolkit/dso-toolkit/issues/3854))
+
 ## 🍖 Release 99.3.0 - 2026-07-27
 
 ### Added

--- a/packages/core/src/components/autosuggest/autosuggest.tsx
+++ b/packages/core/src/components/autosuggest/autosuggest.tsx
@@ -718,6 +718,10 @@ export class Autosuggest {
   }
 
   private getAutosuggestStatus() {
+    if (this.loading && this.showLoading) {
+      return this.loadingLabel;
+    }
+
     if (this.notFound) {
       return `"${this.inputValue}" is niet gevonden.`;
     }
@@ -824,12 +828,12 @@ export class Autosuggest {
                     ))}
                 </div>
               </dso-scrollable>
-              <div class="sr-only" aria-live="polite" aria-atomic="true">
-                {this.getAutosuggestStatus()}
-              </div>
             </>
           )
         )}
+        <div class="sr-only" aria-live="polite" aria-atomic="true">
+          {showListbox || (this.loading && this.showLoading) ? this.getAutosuggestStatus() : undefined}
+        </div>
       </>
     );
   }

--- a/storybook/cypress/e2e/autosuggest.cy.ts
+++ b/storybook/cypress/e2e/autosuggest.cy.ts
@@ -265,6 +265,7 @@ describe("Autosuggest", () => {
     cy.wait(200);
     cy.get("dso-autosuggest.hydrated").find("div[role='listbox']").should("not.exist");
     cy.get("dso-autosuggest.hydrated").find("dso-progress-indicator").should("be.visible");
+    cy.get("dso-autosuggest.hydrated").find("[aria-live='polite']").should("contain.text", "Een moment geduld.");
   });
 
   it("should remove progress indicator when loading attribute is removed", () => {


### PR DESCRIPTION


- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [x] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
