### PR TITLE
#3860 [Fixed] Cards: CardClick event wordt niet afgevuurd wanneer NVDA aan staat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 * Packages: Patch Stencil runtime tegen Null is not an object (evaluating 'e.__insertBefore') in Safari ([#3826](https://github.com/dso-toolkit/dso-toolkit/issues/3826))
+* Cards: CardClick event wordt niet afgevuurd wanneer NVDA aan staat ([#3860](https://github.com/dso-toolkit/dso-toolkit/issues/3860))
 
 ## 💯 Release 100.0.0 - 2026-08-10
 

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -59,12 +59,25 @@ export class Card implements ComponentInterface {
     delete this.mutationObserver;
   }
 
+  /**
+   * Emits the click event for clicks on the heading anchor and for clicks dispatched directly on the host.
+   * The latter happens when screen readers such as NVDA (in browse mode) activate the link via the accessibility
+   * API, which dispatches a synthetic click on the shadow host instead of the anchor in the shadow DOM.
+   * Clicks from other (slotted) elements are ignored.
+   */
   private clickEventHandler(e: MouseEvent) {
-    if (!(e.target instanceof HTMLElement) || !this.href) {
+    if (!this.href) {
       return;
     }
 
-    return this.dsoCardClick.emit({ originalEvent: e, isModifiedEvent: isModifiedEvent(e) });
+    const composedPath = e.composedPath();
+    const anchor = this.host.shadowRoot?.querySelector("a.heading-anchor");
+
+    if (composedPath[0] !== this.host && !(anchor && composedPath.includes(anchor))) {
+      return;
+    }
+
+    this.dsoCardClick.emit({ originalEvent: e, isModifiedEvent: isModifiedEvent(e) });
   }
 
   get selectableSlottedElement() {
@@ -79,32 +92,26 @@ export class Card implements ComponentInterface {
     const isSelectable = this.selectableSlottedElement !== null;
 
     return (
-      <Host is-selectable={isSelectable}>
+      <Host is-selectable={isSelectable} onClick={(e: MouseEvent) => this.clickEventHandler(e)}>
         <div class="dso-card-container">
           <div class="dso-card-selectable" hidden={!isSelectable}>
             <slot name="selectable" />
           </div>
           <div class="dso-card-heading">
             {(this.mode === "extern" && (
-              <a
-                href={this.href}
-                class="heading-anchor"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => this.clickEventHandler(e)}
-              >
+              <a href={this.href} class="heading-anchor" target="_blank" rel="noopener noreferrer">
                 <slot name="heading" />
                 <dso-icon icon="external-link"></dso-icon>
                 <span class="sr-only">(Opent andere website in nieuw tabblad)</span>
               </a>
             )) ||
               (this.mode === "download" && (
-                <a href={this.href} class="heading-anchor" onClick={(e) => this.clickEventHandler(e)}>
+                <a href={this.href} class="heading-anchor">
                   <slot name="heading" />
                   <dso-icon icon="download"></dso-icon>
                 </a>
               )) || (
-                <a href={this.href} class="heading-anchor" onClick={(e) => this.clickEventHandler(e)}>
+                <a href={this.href} class="heading-anchor">
                   <slot name="heading" />
                   <dso-icon icon="chevron-right"></dso-icon>
                 </a>

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -117,19 +117,19 @@ export class Card implements ComponentInterface {
             {(this.mode === "extern" && (
               <a href={this.href} class="heading-anchor" target="_blank" rel="noopener noreferrer">
                 <slot name="heading" />
-                <dso-icon icon="external-link"></dso-icon>
+                <dso-icon icon="external-link" aria-hidden="true"></dso-icon>
                 <span class="sr-only">(Opent andere website in nieuw tabblad)</span>
               </a>
             )) ||
               (this.mode === "download" && (
                 <a href={this.href} class="heading-anchor">
                   <slot name="heading" />
-                  <dso-icon icon="download"></dso-icon>
+                  <dso-icon icon="download" aria-hidden="true"></dso-icon>
                 </a>
               )) || (
                 <a href={this.href} class="heading-anchor">
                   <slot name="heading" />
-                  <dso-icon icon="chevron-right"></dso-icon>
+                  <dso-icon icon="chevron-right" aria-hidden="true"></dso-icon>
                 </a>
               )}
             {this.interactionsSlottedElement !== null && <slot name="interactions" />}

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -59,11 +59,27 @@ export class Card implements ComponentInterface {
     delete this.mutationObserver;
   }
 
+  componentWillRender(): void {
+    this.ensureSlottedHeadingIsClickable();
+  }
+
   /**
-   * Emits the click event for clicks on the heading anchor and for clicks dispatched directly on the host.
-   * The latter happens when screen readers such as NVDA (in browse mode) activate the link via the accessibility
-   * API, which dispatches a synthetic click on the shadow host instead of the anchor in the shadow DOM.
-   * Clicks from other (slotted) elements are ignored.
+   * Workaround for NVDA with Chromium: activating (Enter) an anchor inside shadow DOM in browse mode fails
+   * because Chromium's IAccessible2 implementation cannot resolve shadow DOM elements
+   * (see https://github.com/nvaccess/nvda/issues/17845). Marking the slotted heading element as clickable makes
+   * NVDA dispatch the click on that light DOM element instead, which bubbles through the slot to the anchor.
+   */
+  private ensureSlottedHeadingIsClickable(): void {
+    const heading = this.host.querySelector<HTMLElement>("[slot='heading']");
+
+    if (heading && !heading.onclick) {
+      heading.onclick = () => undefined;
+    }
+  }
+
+  /**
+   * Emits the click event for clicks that originate from the heading anchor (including slotted content inside it)
+   * or from the host itself. Clicks from other (slotted) elements are ignored.
    */
   private clickEventHandler(e: MouseEvent) {
     if (!this.href) {

--- a/packages/core/src/components/document-card/document-card.tsx
+++ b/packages/core/src/components/document-card/document-card.tsx
@@ -104,7 +104,7 @@ export class DocumentCard implements ComponentInterface {
           <div class="dso-document-card-heading">
             <a href={this.href} class="heading-anchor">
               <span class="icon-container">
-                <dso-icon icon="chevron-right" />
+                <dso-icon icon="chevron-right" aria-hidden="true" />
                 <slot name="heading" />
               </span>
             </a>

--- a/packages/core/src/components/document-card/document-card.tsx
+++ b/packages/core/src/components/document-card/document-card.tsx
@@ -52,11 +52,27 @@ export class DocumentCard implements ComponentInterface {
     delete this.mutationObserver;
   }
 
+  componentWillRender(): void {
+    this.ensureSlottedHeadingIsClickable();
+  }
+
   /**
-   * Emits the click event for clicks on the heading anchor and for clicks dispatched directly on the host.
-   * The latter happens when screen readers such as NVDA (in browse mode) activate the link via the accessibility
-   * API, which dispatches a synthetic click on the shadow host instead of the anchor in the shadow DOM.
-   * Clicks from other (slotted) elements are ignored.
+   * Workaround for NVDA with Chromium: activating (Enter) an anchor inside shadow DOM in browse mode fails
+   * because Chromium's IAccessible2 implementation cannot resolve shadow DOM elements
+   * (see https://github.com/nvaccess/nvda/issues/17845). Marking the slotted heading element as clickable makes
+   * NVDA dispatch the click on that light DOM element instead, which bubbles through the slot to the anchor.
+   */
+  private ensureSlottedHeadingIsClickable(): void {
+    const heading = this.host.querySelector<HTMLElement>("[slot='heading']");
+
+    if (heading && !heading.onclick) {
+      heading.onclick = () => undefined;
+    }
+  }
+
+  /**
+   * Emits the click event for clicks that originate from the heading anchor (including slotted content inside it)
+   * or from the host itself. Clicks from other (slotted) elements are ignored.
    */
   private clickEventHandler(e: MouseEvent) {
     if (!this.href) {

--- a/packages/core/src/components/document-card/document-card.tsx
+++ b/packages/core/src/components/document-card/document-card.tsx
@@ -1,4 +1,4 @@
-import { Component, ComponentInterface, Element, Event, EventEmitter, Prop, forceUpdate, h } from "@stencil/core";
+import { Component, ComponentInterface, Element, Event, EventEmitter, Host, Prop, forceUpdate, h } from "@stencil/core";
 
 import { isModifiedEvent } from "../../utils/is-modified-event";
 
@@ -52,12 +52,25 @@ export class DocumentCard implements ComponentInterface {
     delete this.mutationObserver;
   }
 
+  /**
+   * Emits the click event for clicks on the heading anchor and for clicks dispatched directly on the host.
+   * The latter happens when screen readers such as NVDA (in browse mode) activate the link via the accessibility
+   * API, which dispatches a synthetic click on the shadow host instead of the anchor in the shadow DOM.
+   * Clicks from other (slotted) elements are ignored.
+   */
   private clickEventHandler(e: MouseEvent) {
-    if (!(e.target instanceof HTMLElement) || !this.href) {
+    if (!this.href) {
       return;
     }
 
-    return this.dsoDocumentCardClick.emit({ originalEvent: e, isModifiedEvent: isModifiedEvent(e) });
+    const composedPath = e.composedPath();
+    const anchor = this.host.shadowRoot?.querySelector("a.heading-anchor");
+
+    if (composedPath[0] !== this.host && !(anchor && composedPath.includes(anchor))) {
+      return;
+    }
+
+    this.dsoDocumentCardClick.emit({ originalEvent: e, isModifiedEvent: isModifiedEvent(e) });
   }
 
   get metaSlottedElement() {
@@ -70,24 +83,26 @@ export class DocumentCard implements ComponentInterface {
 
   render() {
     return (
-      <div class="dso-document-card-container">
-        <div class="dso-document-card-heading">
-          <a href={this.href} class="heading-anchor" onClick={(e) => this.clickEventHandler(e)}>
-            <span class="icon-container">
-              <dso-icon icon="chevron-right" />
-              <slot name="heading" />
-            </span>
-          </a>
+      <Host onClick={(e: MouseEvent) => this.clickEventHandler(e)}>
+        <div class="dso-document-card-container">
+          <div class="dso-document-card-heading">
+            <a href={this.href} class="heading-anchor">
+              <span class="icon-container">
+                <dso-icon icon="chevron-right" />
+                <slot name="heading" />
+              </span>
+            </a>
+          </div>
+          <div class="dso-document-card-type">
+            <slot name="type" />
+          </div>
+          <div class="dso-document-card-status">
+            {this.metaSlottedElement !== null && <slot name="meta" />}
+            <slot name="status" />
+            {this.interactionsSlottedElement !== null && <slot name="interactions" />}
+          </div>
         </div>
-        <div class="dso-document-card-type">
-          <slot name="type" />
-        </div>
-        <div class="dso-document-card-status">
-          {this.metaSlottedElement !== null && <slot name="meta" />}
-          <slot name="status" />
-          {this.interactionsSlottedElement !== null && <slot name="interactions" />}
-        </div>
-      </div>
+      </Host>
     );
   }
 }

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.tsx
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.tsx
@@ -153,11 +153,11 @@ export class PlekinfoCard implements ComponentInterface {
                 {"\u2060"}
                 {this.targetBlank ? (
                   <>
-                    <dso-icon icon="external-link" />
+                    <dso-icon icon="external-link" aria-hidden="true" />
                     <span class="sr-only">(Opent andere website in nieuw tabblad)</span>
                   </>
                 ) : (
-                  <dso-icon icon="chevron-right" />
+                  <dso-icon icon="chevron-right" aria-hidden="true" />
                 )}
               </a>
             ) : (

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.tsx
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.tsx
@@ -80,11 +80,27 @@ export class PlekinfoCard implements ComponentInterface {
     delete this.mutationObserver;
   }
 
+  componentWillRender(): void {
+    this.ensureSlottedHeadingIsClickable();
+  }
+
   /**
-   * Emits the click event for clicks on the heading anchor and for clicks dispatched directly on the host.
-   * The latter happens when screen readers such as NVDA (in browse mode) activate the link via the accessibility
-   * API, which dispatches a synthetic click on the shadow host instead of the anchor in the shadow DOM.
-   * Clicks from other (slotted) elements are ignored.
+   * Workaround for NVDA with Chromium: activating (Enter) an anchor inside shadow DOM in browse mode fails
+   * because Chromium's IAccessible2 implementation cannot resolve shadow DOM elements
+   * (see https://github.com/nvaccess/nvda/issues/17845). Marking the slotted heading element as clickable makes
+   * NVDA dispatch the click on that light DOM element instead, which bubbles through the slot to the anchor.
+   */
+  private ensureSlottedHeadingIsClickable(): void {
+    const heading = this.host.querySelector<HTMLElement>("[slot='heading']");
+
+    if (heading && !heading.onclick) {
+      heading.onclick = () => undefined;
+    }
+  }
+
+  /**
+   * Emits the click event for clicks that originate from the heading anchor (including slotted content inside it)
+   * or from the host itself. Clicks from other (slotted) elements are ignored.
    */
   private clickEventHandler(e: MouseEvent) {
     if (!this.href) {

--- a/packages/core/src/components/plekinfo-card/plekinfo-card.tsx
+++ b/packages/core/src/components/plekinfo-card/plekinfo-card.tsx
@@ -80,12 +80,25 @@ export class PlekinfoCard implements ComponentInterface {
     delete this.mutationObserver;
   }
 
+  /**
+   * Emits the click event for clicks on the heading anchor and for clicks dispatched directly on the host.
+   * The latter happens when screen readers such as NVDA (in browse mode) activate the link via the accessibility
+   * API, which dispatches a synthetic click on the shadow host instead of the anchor in the shadow DOM.
+   * Clicks from other (slotted) elements are ignored.
+   */
   private clickEventHandler(e: MouseEvent) {
-    if (!(e.target instanceof HTMLElement) || !this.href) {
+    if (!this.href) {
       return;
     }
 
-    return this.dsoPlekinfoCardClick.emit({ originalEvent: e, isModifiedEvent: isModifiedEvent(e) });
+    const composedPath = e.composedPath();
+    const anchor = this.host.shadowRoot?.querySelector("a.heading-anchor");
+
+    if (composedPath[0] !== this.host && !(anchor && composedPath.includes(anchor))) {
+      return;
+    }
+
+    this.dsoPlekinfoCardClick.emit({ originalEvent: e, isModifiedEvent: isModifiedEvent(e) });
   }
 
   get symbolSlottedElement() {
@@ -104,7 +117,7 @@ export class PlekinfoCard implements ComponentInterface {
     const hasSymbol = this.symbolSlottedElement !== null;
 
     return (
-      <Host has-symbol={hasSymbol}>
+      <Host has-symbol={hasSymbol} onClick={(e: MouseEvent) => this.clickEventHandler(e)}>
         <WrapWijzigactie wijzigactie={this.wijzigactie} class="dso-plekinfo-card-container">
           <div class="dso-plekinfo-card-symbol" hidden={!hasSymbol}>
             <slot name="symbol" />
@@ -116,7 +129,6 @@ export class PlekinfoCard implements ComponentInterface {
                 target={this.targetBlank ? "_blank" : undefined}
                 rel={this.targetBlank ? "noopener noreferrer" : undefined}
                 class="heading-anchor"
-                onClick={(e) => this.clickEventHandler(e)}
               >
                 <span class="heading-content">
                   <slot name="heading" />

--- a/storybook/cypress/e2e/card.cy.ts
+++ b/storybook/cypress/e2e/card.cy.ts
@@ -34,11 +34,24 @@ describe("Card", () => {
   });
 
   it("should call dsoCardClick event when a screen reader dispatches a click on the host", () => {
-    // NVDA in browse mode activates links via the accessibility API, which dispatches a
-    // synthetic click on the shadow host instead of the anchor in the shadow DOM.
     cy.get("dso-card.hydrated")
       .then(($card) => {
         $card[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      })
+      .get("@dsoCardClickListener")
+      .should("have.been.calledOnce");
+  });
+
+  it("should call dsoCardClick event when a screen reader dispatches a click on the slotted heading", () => {
+    // NVDA in browse mode cannot activate the anchor in the shadow DOM directly
+    // (https://github.com/nvaccess/nvda/issues/17845). The component marks the slotted heading as clickable so
+    // NVDA dispatches the click on that element.
+    cy.get("dso-card.hydrated")
+      .find("[slot='heading']")
+      .then(($heading) => {
+        expect($heading[0]?.onclick, "slotted heading should be marked clickable for NVDA").to.be.a("function");
+
+        $heading[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, composed: true }));
       })
       .get("@dsoCardClickListener")
       .should("have.been.calledOnce");

--- a/storybook/cypress/e2e/card.cy.ts
+++ b/storybook/cypress/e2e/card.cy.ts
@@ -33,6 +33,17 @@ describe("Card", () => {
       .should("have.been.calledOnce");
   });
 
+  it("should call dsoCardClick event when a screen reader dispatches a click on the host", () => {
+    // NVDA in browse mode activates links via the accessibility API, which dispatches a
+    // synthetic click on the shadow host instead of the anchor in the shadow DOM.
+    cy.get("dso-card.hydrated")
+      .then(($card) => {
+        $card[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      })
+      .get("@dsoCardClickListener")
+      .should("have.been.calledOnce");
+  });
+
   it("should not call dsoCardClick on click on info button with toggletip", () => {
     cy.get("dso-card.hydrated")
       .find("div[slot='interactions']")

--- a/storybook/cypress/e2e/document-card.cy.ts
+++ b/storybook/cypress/e2e/document-card.cy.ts
@@ -26,11 +26,24 @@ describe("Document Card", () => {
   });
 
   it("should call dsoDocumentCardClick event when a screen reader dispatches a click on the host", () => {
-    // NVDA in browse mode activates links via the accessibility API, which dispatches a
-    // synthetic click on the shadow host instead of the anchor in the shadow DOM.
     cy.get("dso-document-card.hydrated")
       .then(($card) => {
         $card[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      })
+      .get("@dsoDocumentCardClickListener")
+      .should("have.been.calledOnce");
+  });
+
+  it("should call dsoDocumentCardClick event when a screen reader dispatches a click on the slotted heading", () => {
+    // NVDA in browse mode cannot activate the anchor in the shadow DOM directly
+    // (https://github.com/nvaccess/nvda/issues/17845). The component marks the slotted heading as clickable so
+    // NVDA dispatches the click on that element.
+    cy.get("dso-document-card.hydrated")
+      .find("[slot='heading']")
+      .then(($heading) => {
+        expect($heading[0]?.onclick, "slotted heading should be marked clickable for NVDA").to.be.a("function");
+
+        $heading[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, composed: true }));
       })
       .get("@dsoDocumentCardClickListener")
       .should("have.been.calledOnce");

--- a/storybook/cypress/e2e/document-card.cy.ts
+++ b/storybook/cypress/e2e/document-card.cy.ts
@@ -25,6 +25,17 @@ describe("Document Card", () => {
       .should("have.been.calledOnce");
   });
 
+  it("should call dsoDocumentCardClick event when a screen reader dispatches a click on the host", () => {
+    // NVDA in browse mode activates links via the accessibility API, which dispatches a
+    // synthetic click on the shadow host instead of the anchor in the shadow DOM.
+    cy.get("dso-document-card.hydrated")
+      .then(($card) => {
+        $card[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      })
+      .get("@dsoDocumentCardClickListener")
+      .should("have.been.calledOnce");
+  });
+
   it("should show different background-color when active='true'", () => {
     cy.get("dso-document-card.hydrated")
       .invoke("prop", "active", true)

--- a/storybook/cypress/e2e/plekinfo-card.cy.ts
+++ b/storybook/cypress/e2e/plekinfo-card.cy.ts
@@ -26,11 +26,24 @@ describe("Plekinfo Card", () => {
   });
 
   it("should call dsoPlekinfoCardClick event when a screen reader dispatches a click on the host", () => {
-    // NVDA in browse mode activates links via the accessibility API, which dispatches a
-    // synthetic click on the shadow host instead of the anchor in the shadow DOM.
     cy.get("dso-plekinfo-card.hydrated")
       .then(($card) => {
         $card[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      })
+      .get("@dsoPlekinfoCardClickListener")
+      .should("have.been.calledOnce");
+  });
+
+  it("should call dsoPlekinfoCardClick event when a screen reader dispatches a click on the slotted heading", () => {
+    // NVDA in browse mode cannot activate the anchor in the shadow DOM directly
+    // (https://github.com/nvaccess/nvda/issues/17845). The component marks the slotted heading as clickable so
+    // NVDA dispatches the click on that element.
+    cy.get("dso-plekinfo-card.hydrated")
+      .find("[slot='heading']")
+      .then(($heading) => {
+        expect($heading[0]?.onclick, "slotted heading should be marked clickable for NVDA").to.be.a("function");
+
+        $heading[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, composed: true }));
       })
       .get("@dsoPlekinfoCardClickListener")
       .should("have.been.calledOnce");

--- a/storybook/cypress/e2e/plekinfo-card.cy.ts
+++ b/storybook/cypress/e2e/plekinfo-card.cy.ts
@@ -25,6 +25,17 @@ describe("Plekinfo Card", () => {
       .should("have.been.calledOnce");
   });
 
+  it("should call dsoPlekinfoCardClick event when a screen reader dispatches a click on the host", () => {
+    // NVDA in browse mode activates links via the accessibility API, which dispatches a
+    // synthetic click on the shadow host instead of the anchor in the shadow DOM.
+    cy.get("dso-plekinfo-card.hydrated")
+      .then(($card) => {
+        $card[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      })
+      .get("@dsoPlekinfoCardClickListener")
+      .should("have.been.calledOnce");
+  });
+
   it("should show different background-color when active='true'", () => {
     cy.get("dso-plekinfo-card.hydrated")
       .invoke("prop", "active", true)


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
