### PR TITLE
#3899 [Changed] Document Header: WCAG bevindingen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Changed
 * Document Component: WCAG bevinding inhoudsopgave gebruik headings ([#3874](https://github.com/dso-toolkit/dso-toolkit/issues/3874))
+* Document Header: WCAG bevindingen ([#3899](https://github.com/dso-toolkit/dso-toolkit/issues/3899))
 
 ### Fixed
 * Viewer Grid: Filterpaneel wordt niet getoond op smalle viewport ([#3906](https://github.com/dso-toolkit/dso-toolkit/issues/3906))

--- a/packages/core/src/components/viewer-grid/viewer-grid.scss
+++ b/packages/core/src/components/viewer-grid/viewer-grid.scss
@@ -27,6 +27,30 @@
   }
 }
 
+:host(:not([print])) {
+  display: flex;
+  flex-direction: column;
+  block-size: 100dvh;
+  overflow: clip;
+  position: relative;
+
+  .viewer-grid-columns {
+    display: flex;
+    overflow: hidden;
+    flex-grow: 1;
+    min-block-size: 0;
+  }
+
+  .dso-main-panel,
+  .dso-document-panel {
+    min-block-size: 0;
+
+    .content {
+      overflow-y: auto;
+    }
+  }
+}
+
 button {
   @include button.element();
 }
@@ -275,12 +299,6 @@ slot[name="legend"] {
   }
 
   :host(:not([print])) {
-    display: flex;
-    flex-direction: column;
-    block-size: 100vh;
-    overflow: clip;
-    position: relative;
-
     .dso-main-panel.compact,
     .dso-main-panel.expanded {
       flex-basis: unset;
@@ -289,19 +307,9 @@ slot[name="legend"] {
       inline-size: 440px;
     }
 
-    .viewer-grid-columns {
-      display: flex;
-      overflow: hidden;
-      flex-grow: 1;
-    }
-
     .dso-main-panel,
     .dso-document-panel {
       box-shadow: units.$u1 * 0.25 0 units.$u1 0 rgba(0, 0, 0, 0.4);
-
-      .content {
-        overflow-y: auto;
-      }
     }
 
     .filter-panel {
@@ -354,6 +362,19 @@ slot[name="legend"] {
   }
 
   :host(:not([print])) {
+    .viewer-grid-columns {
+      flex-direction: column;
+    }
+
+    .dso-main-panel,
+    .dso-document-panel,
+    .map-area {
+      flex: 1;
+      inline-size: 100%;
+      max-inline-size: none;
+      min-inline-size: 0;
+    }
+
     .map {
       position: relative;
       inset: auto;

--- a/packages/dso-toolkit/src/components/document-header/document-header.scss
+++ b/packages/dso-toolkit/src/components/document-header/document-header.scss
@@ -54,52 +54,54 @@
   }
 
   &.dso-document-header-sticky {
-    position: sticky;
-    inset-inline-start: 0;
-    inset-block-start: 0;
-    padding-block: 0 calc(#{units.$u1} * 0.5);
-    border-block-start: document-header-variables.$sticky-border-width-style colors.$grijs-5;
+    @media (min-width: #{document-header-variables.$sticky-min-width}) {
+      position: sticky;
+      inset-inline-start: 0;
+      inset-block-start: 0;
+      padding-block: 0 calc(#{units.$u1} * 0.5);
+      border-block-start: document-header-variables.$sticky-border-width-style colors.$grijs-5;
 
-    &.dso-variant-ontwerp {
-      border-block-start: document-header-variables.$sticky-border-width-style colors.$geel;
-    }
+      &.dso-variant-ontwerp {
+        border-block-start: document-header-variables.$sticky-border-width-style colors.$geel;
+      }
 
-    &.dso-variant-besluitversie {
-      border-block-start: document-header-variables.$sticky-border-width-style colors.$bosgroen;
-    }
+      &.dso-variant-besluitversie {
+        border-block-start: document-header-variables.$sticky-border-width-style colors.$bosgroen;
+      }
 
-    #{typography.$headings} {
-      margin-block-end: 0;
+      #{typography.$headings} {
+        margin-block-end: 0;
 
-      button {
-        align-items: center;
-        justify-content: space-between;
-        background-color: transparent;
-        display: flex;
-        text-align: start;
-        inline-size: 100%;
+        button {
+          align-items: center;
+          justify-content: space-between;
+          background-color: transparent;
+          display: flex;
+          text-align: start;
+          inline-size: 100%;
 
-        &::after {
-          @include di.base("chevron-up-bosgroen");
+          &::after {
+            @include di.base("chevron-up-bosgroen");
 
-          content: "";
-          display: inline-block;
-        }
+            content: "";
+            display: inline-block;
+          }
 
-        span {
-          display: inline-block;
-          margin-inline-end: units.$u1;
-          max-inline-size: calc(100% - #{units.$u2 * 2});
-          overflow: hidden;
-          text-overflow: ellipsis; // stylelint-disable-line declaration-property-value-disallowed-list -- We don't want wrapping in sticky document-header: full text in initial (scroll=0) position
-          white-space: nowrap; // stylelint-disable-line declaration-property-value-disallowed-list -- We don't want wrapping in sticky document-header: full text in initial (scroll=0) position
+          span {
+            display: inline-block;
+            margin-inline-end: units.$u1;
+            max-inline-size: calc(100% - #{units.$u2 * 2});
+            overflow: hidden;
+            text-overflow: ellipsis; // stylelint-disable-line declaration-property-value-disallowed-list -- We don't want wrapping in sticky document-header: full text in initial (scroll=0) position
+            white-space: nowrap; // stylelint-disable-line declaration-property-value-disallowed-list -- We don't want wrapping in sticky document-header: full text in initial (scroll=0) position
+          }
         }
       }
-    }
 
-    .dso-document-header-container,
-    .dso-document-header-status {
-      display: none;
+      .dso-document-header-container,
+      .dso-document-header-status {
+        display: none;
+      }
     }
   }
 

--- a/packages/dso-toolkit/src/components/document-header/document-header.scss
+++ b/packages/dso-toolkit/src/components/document-header/document-header.scss
@@ -55,7 +55,7 @@
   }
 
   &.dso-document-header-sticky {
-    @media (min-width: #{document-header-variables.$sticky-min-width}) {
+    @media (min-width: document-header-variables.$sticky-min-width) {
       z-index: zindex.$document-header-sticky;
       position: sticky;
       inset-inline-start: 0;

--- a/packages/dso-toolkit/src/components/document-header/document-header.scss
+++ b/packages/dso-toolkit/src/components/document-header/document-header.scss
@@ -4,6 +4,7 @@
 @use "../../variables/units";
 @use "../../variables/colors";
 @use "../../variables/typography";
+@use "../../variables/zindex";
 @use "../button";
 @use "../../variables/icon";
 
@@ -55,6 +56,7 @@
 
   &.dso-document-header-sticky {
     @media (min-width: #{document-header-variables.$sticky-min-width}) {
+      z-index: zindex.$document-header-sticky;
       position: sticky;
       inset-inline-start: 0;
       inset-block-start: 0;

--- a/packages/dso-toolkit/src/components/document-header/document-header.scss
+++ b/packages/dso-toolkit/src/components/document-header/document-header.scss
@@ -91,9 +91,6 @@
             display: inline-block;
             margin-inline-end: units.$u1;
             max-inline-size: calc(100% - #{units.$u2 * 2});
-            overflow: hidden;
-            text-overflow: ellipsis; // stylelint-disable-line declaration-property-value-disallowed-list -- We don't want wrapping in sticky document-header: full text in initial (scroll=0) position
-            white-space: nowrap; // stylelint-disable-line declaration-property-value-disallowed-list -- We don't want wrapping in sticky document-header: full text in initial (scroll=0) position
           }
         }
       }

--- a/packages/dso-toolkit/src/components/document-header/document-header.variables.scss
+++ b/packages/dso-toolkit/src/components/document-header/document-header.variables.scss
@@ -1,3 +1,4 @@
 @use "../../variables/units";
 
 $sticky-border-width-style: units.$u1 * 0.5 solid;
+$sticky-min-width: 850px;

--- a/packages/dso-toolkit/src/components/viewer-grid/viewer-grid.args.ts
+++ b/packages/dso-toolkit/src/components/viewer-grid/viewer-grid.args.ts
@@ -3,7 +3,7 @@ import { ArgTypes } from "storybook/internal/types";
 
 import { argTypeAction } from "../../storybook";
 
-import { Tab, ViewerGrid, ViewerGridPanelSize } from "./viewer-grid.models.js";
+import { ViewerGrid, ViewerGridPanelSize, ViewerGridTab } from "./viewer-grid.models.js";
 import { ViewerGridTemplates } from "./viewer-grid.stories-of.js";
 
 const panelSizes = ["small", "medium", "large"];
@@ -15,7 +15,7 @@ export interface ViewerGridArgs {
   documentPanelOpen?: boolean;
   print?: boolean;
   mainSize: ViewerGridPanelSize;
-  activeTab?: Tab;
+  activeTab?: ViewerGridTab;
   documentPanelSize: ViewerGridPanelSize;
   mainPanelExpanded?: boolean;
   mainPanelHidden?: boolean;

--- a/packages/dso-toolkit/src/components/viewer-grid/viewer-grid.models.ts
+++ b/packages/dso-toolkit/src/components/viewer-grid/viewer-grid.models.ts
@@ -5,7 +5,7 @@ export interface ViewerGrid<TemplateFnReturnType> {
   documentPanelOpen?: boolean;
   print?: boolean;
   mainSize?: ViewerGridPanelSize;
-  activeTab?: Tab;
+  activeTab?: ViewerGridTab;
   documentPanelSize?: ViewerGridPanelSize;
   mainPanelExpanded?: boolean;
   mainPanelHidden?: boolean;
@@ -26,7 +26,7 @@ export interface ViewerGrid<TemplateFnReturnType> {
 }
 
 export type ViewerGridPanelSize = "small" | "medium" | "large";
-export type Tab = "search" | "map" | "document" | "main";
+export type ViewerGridTab = "search" | "map" | "document";
 
 export interface ViewerGridChangeSizeEvent {
   currentSize: ViewerGridPanelSize;
@@ -38,7 +38,7 @@ export interface ViewerGridChangeSizeAnimationEndEvent {
 }
 
 export interface ViewerGridActiveTabSwitchEvent {
-  tab: Tab;
+  tab: ViewerGridTab;
 }
 
 export interface ViewerGridMainExpandEvent {

--- a/packages/dso-toolkit/src/variables/zindex.scss
+++ b/packages/dso-toolkit/src/variables/zindex.scss
@@ -28,3 +28,5 @@ $image-overlay: 20;
 $shopping-cart: 2;
 
 $survey-rating: 1000;
+
+$document-header-sticky: 10;

--- a/storybook/cypress/e2e/document-header.cy.ts
+++ b/storybook/cypress/e2e/document-header.cy.ts
@@ -1,0 +1,34 @@
+describe("Document Header", () => {
+  beforeEach(() => {
+    cy.viewport(1280, 600);
+  });
+
+  const stickyStories = ["sticky", "sticky-besluitversie", "sticky-ontwerp"];
+  const stories = ["default", "default-besluitversie", "default-ontwerp", ...stickyStories];
+
+  for (const story of stories) {
+    it(`should be accessible (${story})`, () => {
+      cy.visit(`http://localhost:45000/iframe.html?id=html-css-document-header--${story}`);
+      cy.injectAxe();
+      cy.dsoCheckA11y(".dso-document-header");
+    });
+
+    it(`matches imageSnapshot (${story})`, () => {
+      cy.visit(`http://localhost:45000/iframe.html?id=html-css-document-header--${story}`);
+      cy.get(".dso-document-header").matchImageSnapshot(`${Cypress.currentTest.titlePath.join(" -- ")}`);
+    });
+  }
+
+  describe("Below 850px", () => {
+    beforeEach(() => {
+      cy.viewport(849, 600);
+    });
+
+    for (const story of stickyStories) {
+      it(`matches imageSnapshot (${story})`, () => {
+        cy.visit(`http://localhost:45000/iframe.html?id=html-css-document-header--${story}`);
+        cy.get(".dso-document-header").matchImageSnapshot(`${Cypress.currentTest.titlePath.join(" -- ")}`);
+      });
+    }
+  });
+});

--- a/storybook/cypress/fixtures/image-snapshot-components.json
+++ b/storybook/cypress/fixtures/image-snapshot-components.json
@@ -104,19 +104,6 @@
     "type": "html-css"
   },
   {
-    "name": "document-header",
-    "selector": ".dso-document-header",
-    "stories": [
-      "default",
-      "default-besluitversie",
-      "default-ontwerp",
-      "sticky",
-      "sticky-besluitversie",
-      "sticky-ontwerp"
-    ],
-    "type": "html-css"
-  },
-  {
     "name": "footer",
     "type": "html-css",
     "stories": ["footer"],

--- a/storybook/src/example-pages/toepassingen/regels-op-de-kaart/documenten.stories.ts
+++ b/storybook/src/example-pages/toepassingen/regels-op-de-kaart/documenten.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/web-components-vite";
-import { kaartlagenTabItem, legendArgs, legendaTabItem } from "dso-toolkit";
+import { ViewerGridTab, kaartlagenTabItem, legendArgs, legendaTabItem } from "dso-toolkit";
 import { html, nothing } from "lit-html";
 import { classMap } from "lit-html/directives/class-map.js";
 
@@ -30,8 +30,10 @@ const Documenten = examplePageStories<{
   filterPanelOpen: boolean;
   mainPanelOpen: boolean;
   legendOpen: boolean;
+  sticky: boolean;
+  activeTab: ViewerGridTab;
 }>(
-  (templates, { print, filterPanelOpen, mainPanelOpen, legendOpen }) => {
+  (templates, { print, filterPanelOpen, mainPanelOpen, legendOpen, sticky, activeTab }) => {
     const {
       accordionTemplate,
       linkTemplate,
@@ -64,7 +66,7 @@ const Documenten = examplePageStories<{
           overflow-y: hidden;
         }
 
-        .demo-main > dso-viewer-grid {
+        .demo-main > dso-viewer-grid:not([print]) {
           block-size: 100%;
         }
 
@@ -104,6 +106,7 @@ const Documenten = examplePageStories<{
 
         <main class="demo-main ${classMap({ print })}">
           ${viewerGridTemplate({
+            activeTab,
             filterPanelOpen,
             filterPanelTitle: "Filter op kenmerken",
             mainPanelExpanded: true,
@@ -214,6 +217,7 @@ const Documenten = examplePageStories<{
                 owner: "",
                 featuresContent: featuresContent(templates),
                 advancedSelect,
+                sticky,
               })}
               ${navbarTemplate(documentPanelSubmenu)}
               ${highlightBoxTemplate({
@@ -269,19 +273,30 @@ const Documenten = examplePageStories<{
     argTypes: {
       print: {
         control: { type: "boolean" },
-        table: { category: "Settings" },
+        table: { category: "Viewer Grid" },
       },
       filterPanelOpen: {
         control: { type: "boolean" },
-        table: { category: "Settings" },
+        table: { category: "Viewer Grid" },
       },
       mainPanelOpen: {
         control: { type: "boolean" },
-        table: { category: "Settings" },
+        table: { category: "Viewer Grid" },
       },
       legendOpen: {
         control: { type: "boolean" },
-        table: { category: "Settings" },
+        table: { category: "Legend" },
+      },
+      sticky: {
+        control: { type: "boolean" },
+        table: { category: "Document Header" },
+      },
+      activeTab: {
+        options: [undefined, "search", "map", "document"],
+        control: {
+          type: "select",
+        },
+        table: { category: "Viewer Grid" },
       },
     },
     args: {
@@ -289,6 +304,8 @@ const Documenten = examplePageStories<{
       filterPanelOpen: true,
       mainPanelOpen: true,
       legendOpen: true,
+      sticky: false,
+      activeTab: "document",
     },
   },
 );


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits:
  - 1e commit: CHANGELOG entry
  - 2e commit: Niet sticky onder 850px
  - 3e commit: Titel niet afbreken.
  - 4e commit: e2e test
  - 5e commit: Viewer Grid fix voor scrollgedrag in tab document tbv etaleren van de non-stickyness van Document Header op de voorbeeld pagina Toepassingen - Regels op de Kaart - Documenten - Documenten
  - 6e commit: sticky Document Header toegevoegd aan z-index register, zodat de sticky vorm altijd boven de eronder wegscrollende content blijft.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - In de nieuwe `document-header.cy.ts` worden nu 9 nieuwe screenshots gemaakt. De screenshot diff van Viewer Grid kan verklaard worden door de scss wijzigingen van de 5e commit. Kort gezegd: het is geen inhoudelijk verschil maar een hoogte-/vulverschil: het paneel vult nu verticaal de hele viewport (wit) in plaats van te stoppen bij de content (grijs).
  
<img width="2352" height="632" alt="Viewer Grid -- Filter Panel -- tab view -- toggle -- open diff" src="https://github.com/user-attachments/assets/e9cd1b02-db60-4ca7-8856-b86d6dfaa4ca" />

  - de diff van Viewer Grid wordt veroorzaakt door de fix en verbetering de 5e commit
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl

## Toelichting

Om het niet langer sticky zijn van de Document Header binnen Storybook te kunnen etaleren is de voorbeeld pagina Toepassingen - Regels op de Kaart - Documenten - Documenten. Er zijn twee controls aan deze voorbeeldpagina toegevoegd:

- sticky: om het sticky gedrag van Document Header aan/uit te kunnen zetten (default uit)
- activeTab: om op viewport < 1032px, wanneer Viewer Grid in de tabbed view rendert, de actieve Tab in te kunnen stellen (default document).

Wat bleek: de inhoud van het document-panel van het Viewer Grid wilde niet scrollen in de tabbed view. De 5e commit bevat de fix hiervoor. 

### Samenvatting van de scrollfix

De wijziging bestaat uit een herstructurering (verplaatsen + verbeteren), niet enkel toevoegingen:

1. Full-height flex-basis losgetrokken uit de media-query → naar globaal :host (regel 30–52, nieuw)
- Voorheen stond display:flex / block-size:100vh / overflow:clip én .viewer-grid-columns { flex-grow:1 } én .content { overflow-y:auto } binnen de min-width-media-query (regel 258 e.v.), dus alleen op grote schermen.
- Nu staan ze onvoorwaardelijk op :host(:not([print])), zodat de scroll-keten óók onder 1032px geldt.
- Twee inhoudelijke verbeteringen daarbij:
  - block-size: 100vh → 100dvh (correcte hoogte op mobiel met dynamische browserbalken).
  - min-block-size: 0 toegevoegd op .viewer-grid-columns én op .dso-main-panel, .dso-document-panel — dé sleutel waardoor flex-items kleiner mogen worden dan hun content en er dus intern gescrold wordt i.p.v. de pagina op te rekken.

2. Tab-view (< 1032px) verticaal stapelen + panelen laten vullen (regel 364–376, nieuw)
Binnen de bestaande media-query max-width: screen-sm-max + u5 + 0.99 (≈ < 1032px):

```scss
    .viewer-grid-columns { flex-direction: column; }
    .dso-main-panel,
    .dso-document-panel,
    .map-area { flex: 1; inline-size: 100%; max-inline-size: none; min-inline-size: 0; }
```
    
Hierdoor krijgt het document-panel in tab view de resterende verticale ruimte (flex: 1) en mag het krimpen (min-inline-size: 0), zodat zijn .content met overflow-y: auto een eigen scrollgebied vormt.

Netto effect: de overflow-y: auto-scroll-keten die eerst alleen op desktop actief was, geldt nu ook in de tabbed view onder 1032px, met min-block-size: 0 als cruciale toevoeging en 100dvh voor correcte mobiele hoogte.

