### PR TITLE
#3865 [Changed] Document Component: `markFn` markeert onterecht tekst in tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Document Component: `markFn` markeert onterecht tekst in tooltip ([#3865](https://github.com/dso-toolkit/dso-toolkit/issues/3865))
+
 ### Removed
 * **BREAKING** Info: Remove HTML/CSS implementatie ([#3679](https://github.com/dso-toolkit/dso-toolkit/issues/3679))
 

--- a/packages/core/src/components/ozon-content/nodes/int-io-ref.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/int-io-ref.node.tsx
@@ -44,7 +44,7 @@ export class OzonContentIntIoRefNode implements OzonContentNode {
               href={href ?? undefined}
               title="Opent andere website in nieuw tabblad"
             >
-              <span>{mapNodeToJsx(node.childNodes)}</span>
+              <span>{mapNodeToJsx(node.childNodes, true)}</span>
               <dso-icon icon="external-link" />
             </a>
           </span>

--- a/packages/core/src/components/ozon-content/nodes/int-ref.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/int-ref.node.tsx
@@ -31,7 +31,7 @@ export class OzonContentIntRefNode implements OzonContentNode {
       return (
         <dso-ozon-content-toggletip>
           <span slot="label">{mapNodeToJsx(node.childNodes)}</span>
-          {mapNodeToJsx(Array.from(definitieXMLDocument.documentElement.childNodes))}
+          {mapNodeToJsx(Array.from(definitieXMLDocument.documentElement.childNodes), true)}
         </dso-ozon-content-toggletip>
       );
     }

--- a/packages/core/src/components/ozon-content/nodes/noot.node.tsx
+++ b/packages/core/src/components/ozon-content/nodes/noot.node.tsx
@@ -28,7 +28,7 @@ export class OzonContentNootNode implements OzonContentNode {
       <sup>
         <dso-ozon-content-toggletip class="toggle-note">
           <span slot="label">{nootNummer}</span>
-          <span role="section">{mapNodeToJsx(Array.from(node.querySelectorAll(":scope > Al")))}</span>
+          <span role="section">{mapNodeToJsx(Array.from(node.querySelectorAll(":scope > Al")), true)}</span>
         </dso-ozon-content-toggletip>
       </sup>
     );

--- a/packages/core/src/components/ozon-content/ozon-content-mapper.tsx
+++ b/packages/core/src/components/ozon-content/ozon-content-mapper.tsx
@@ -108,7 +108,7 @@ export class Mapper {
       {
         inline: context.inline,
         mark: context.mark,
-        mapNodeToJsx: (n, m) => this.mapNodeToJsx(n, context, [...path, node], m),
+        mapNodeToJsx: (n, m = ignoreMark) => this.mapNodeToJsx(n, context, [...path, node], m),
         emitClick: context.emitClick,
         setState,
         emitMarkItemHighlight: context.emitMarkItemHighlight,

--- a/storybook/cypress/e2e/document-component.cy.ts
+++ b/storybook/cypress/e2e/document-component.cy.ts
@@ -85,19 +85,22 @@ describe("Document Component", () => {
         .map((item, index) => (isOdd(index) ? { text: item, highlight: source === "kop" && index === 1 } : item));
 
     cy.get("@document-component")
-      .then(
-        ($documentComponent: JQuery<HTMLDsoDocumentComponentElement>) =>
-          ($documentComponent[0].mark = cy.spy(marker).as("marker")),
-      )
+      .then(($documentComponent: JQuery<HTMLDsoDocumentComponentElement>) => {
+        const element = $documentComponent.get(0);
+        if (!element) {
+          throw new Error("dso-document-component not found");
+        }
+
+        element.mark = cy.spy(marker).as("marker");
+      })
       .get("@marker")
       .invoke("getCalls")
-      .should("have.length", 5)
-      .then((calls) => calls.map((c) => c.args))
+      .should("have.length", 4)
+      .then((calls: { args: [string, string] }[]) => calls.map((call) => call.args))
       .should("have.deep.members", [
         ["Artikel", "kop"],
         ["13.12c", "kop"],
         ["NootInKop III ", "kop"],
-        ["Thomas en Eric test 3.", "kop"],
         ["Opschrift", "kop"],
       ]);
   });

--- a/storybook/cypress/e2e/ozon-content.cy.ts
+++ b/storybook/cypress/e2e/ozon-content.cy.ts
@@ -123,6 +123,42 @@ describe("Ozon Content", () => {
       .should("be.visible");
   });
 
+  it("does not mark begrip definitie inside IntRef toggletip, but marks the label", () => {
+    const createMarkFn = (searchTerm: string) => (text: string) =>
+      text
+        .split(new RegExp(`(${searchTerm})`, "gi"))
+        .map((item, index) => (index % 2 !== 0 ? { text: item, highlight: true } : item));
+
+    cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--int-ref-begrip");
+
+    // 1. Verify definition body does not contain marks when matching text exists
+    cy.get<HTMLDsoOzonContentElement>("dso-ozon-content.hydrated").then(($el) => {
+      if ($el[0]) {
+        $el[0].mark = createMarkFn("vuurwerk");
+      }
+    });
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip")
+      .find(":not([slot])")
+      .find("mark")
+      .should("not.exist");
+
+    // 2. Verify visible label trigger is marked
+    cy.get<HTMLDsoOzonContentElement>("dso-ozon-content.hydrated").then(($el) => {
+      if ($el[0]) {
+        $el[0].mark = createMarkFn("aanwijzingsbesluit");
+      }
+    });
+
+    cy.get("dso-ozon-content.hydrated")
+      .shadow()
+      .find("dso-ozon-content-toggletip span[slot=label]")
+      .find("mark")
+      .should("exist");
+  });
+
   it("should render unknown element to span", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-ozon-content--al");
 


### PR DESCRIPTION

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
