### PR TITLE
#3915 [Fixed] Header: ResizeObserver loop completed with undelivered notifications bij openen dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * **BREAKING** Info: Remove HTML/CSS implementatie ([#3679](https://github.com/dso-toolkit/dso-toolkit/issues/3679))
 * **BREAKING** List: Remove `ol.dso-list-ordered-action` selector ([#3655](https://github.com/dso-toolkit/dso-toolkit/issues/3655))
 
+### Fixed
+* Header: ResizeObserver loop completed with undelivered notifications bij openen dropdown menu ([#3915](https://github.com/dso-toolkit/dso-toolkit/issues/3915))
+
 ## 🫆 Release 99.5.0 - 2026-08-05
 
 ### Changed

--- a/packages/core/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/core/src/components/dropdown-menu/dropdown-menu.tsx
@@ -88,6 +88,8 @@ export class DropdownMenu implements ComponentInterface {
 
   private cleanUp: ReturnType<typeof autoUpdate> | undefined;
   private popoverElement: HTMLDivElement | undefined;
+  private popoverFrameId?: number;
+  private pendingPopoverConstraints?: { availableWidth: number; availableHeight: number };
 
   private dropdownMenuTabbables(withButton: boolean): DropdownMenuTabbable[] {
     const menuItems = this.host.isConnected
@@ -102,11 +104,35 @@ export class DropdownMenu implements ComponentInterface {
   }
 
   componentDidRender() {
-    if (this.button && this.popoverElement && !this.cleanUp) {
+    // Only position the popover while it is open. autoUpdate runs on its own ResizeObserver;
+    // keeping it active on a closed (hidden) popover computes bogus constraints that force a
+    // same-frame correction on the next open.
+    if (this.open && this.button && this.popoverElement && !this.cleanUp) {
       const element = this.popoverElement;
       const referenceElement = this.button;
+      let initialUpdate = true;
 
-      this.cleanUp = autoUpdate(referenceElement, element, () => {
+      const applyPopoverStyles = (x: number, y: number) => {
+        if (!element.isConnected) {
+          return;
+        }
+
+        if (this.pendingPopoverConstraints) {
+          const scrollElement = element.querySelector<HTMLElement>("dso-scrollable") ?? element;
+
+          Object.assign(scrollElement.style, {
+            maxHeight: `${this.pendingPopoverConstraints.availableHeight}px`,
+            maxInlineSize: `${this.pendingPopoverConstraints.availableWidth}px`,
+          });
+        }
+
+        Object.assign(element.style, {
+          left: `${x}px`,
+          top: `${y}px`,
+        });
+      };
+
+      const autoUpdateCleanUp = autoUpdate(referenceElement, element, () => {
         computePosition(referenceElement, element, {
           strategy: "fixed",
           middleware: [
@@ -115,25 +141,47 @@ export class DropdownMenu implements ComponentInterface {
               padding: 2,
             }),
             size({
-              apply({ availableHeight, availableWidth, elements }) {
-                const scrollElement =
-                  elements.floating.querySelector<HTMLElement>("dso-scrollable") ?? elements.floating;
-
-                Object.assign(scrollElement.style, {
-                  maxHeight: `${availableHeight}px`,
-                  maxInlineSize: `${availableWidth}px`,
-                });
+              apply: ({ availableHeight, availableWidth }) => {
+                // No direct DOM writes here: this callback runs inside the autoUpdate
+                // ResizeObserver cycle and would trigger "ResizeObserver loop completed
+                // with undelivered notifications". The constraints are applied together
+                // with the position, see applyPopoverStyles.
+                this.pendingPopoverConstraints = { availableWidth, availableHeight };
               },
             }),
           ],
           placement: "bottom-start",
         }).then(({ x, y }) => {
-          Object.assign(element.style, {
-            left: `${x}px`,
-            top: `${y}px`,
+          if (initialUpdate) {
+            // The first update runs outside the ResizeObserver cycle and is applied
+            // directly so the popover does not show up unpositioned.
+            initialUpdate = false;
+            applyPopoverStyles(x, y);
+
+            return;
+          }
+
+          // Defer DOM writes until the next frame so ResizeObserver notifications can
+          // settle before the popover mutates its own layout again.
+          if (this.popoverFrameId !== undefined) {
+            cancelAnimationFrame(this.popoverFrameId);
+          }
+
+          this.popoverFrameId = requestAnimationFrame(() => {
+            this.popoverFrameId = undefined;
+            applyPopoverStyles(x, y);
           });
         });
       });
+
+      this.cleanUp = () => {
+        if (this.popoverFrameId !== undefined) {
+          cancelAnimationFrame(this.popoverFrameId);
+          this.popoverFrameId = undefined;
+        }
+
+        autoUpdateCleanUp();
+      };
     }
   }
 

--- a/packages/core/src/components/header/header.tsx
+++ b/packages/core/src/components/header/header.tsx
@@ -142,6 +142,10 @@ export class Header implements ComponentInterface {
 
   private resizeFrameId?: number;
 
+  private popoverFrameId?: number;
+
+  private pendingPopoverConstraints?: { availableWidth: number; availableHeight: number };
+
   private tabInPopup(tabbables: FocusableElement[], direction: number) {
     const currentIndex = tabbables.findIndex((e) => e === getActiveElement());
 
@@ -353,10 +357,34 @@ export class Header implements ComponentInterface {
       this.visibleMenuItemsCount = this.calculateOverflowMenuItemCount(this.navElement);
     }
 
-    if (this.popoverElement && !this.cleanUp && this.dropdownButtonElement) {
+    // Only position the popover while it is open. autoUpdate runs on its own ResizeObserver;
+    // keeping it active on a closed (hidden) popover computes bogus constraints that force a
+    // same-frame correction on the next open.
+    if (this.open && this.popoverElement && !this.cleanUp && this.dropdownButtonElement) {
       const element = this.popoverElement;
+      let initialUpdate = true;
 
-      this.cleanUp = autoUpdate(this.dropdownButtonElement, element, () => {
+      const applyPopoverStyles = (x: number, y: number) => {
+        if (!element.isConnected) {
+          return;
+        }
+
+        if (this.pendingPopoverConstraints) {
+          const scrollElement = element.querySelector<HTMLElement>(".dropdown-menu-options") ?? element;
+
+          Object.assign(scrollElement.style, {
+            maxHeight: `${this.pendingPopoverConstraints.availableHeight}px`,
+            maxInlineSize: `${this.pendingPopoverConstraints.availableWidth}px`,
+          });
+        }
+
+        Object.assign(element.style, {
+          left: `${x}px`,
+          top: `${y}px`,
+        });
+      };
+
+      const autoUpdateCleanUp = autoUpdate(this.dropdownButtonElement, element, () => {
         if (this.dropdownButtonElement) {
           computePosition(this.dropdownButtonElement, element, {
             strategy: "fixed",
@@ -366,26 +394,48 @@ export class Header implements ComponentInterface {
                 padding: this.dropdownOptionsOffset,
               }),
               size({
-                apply({ availableHeight, availableWidth, elements }) {
-                  const scrollElement =
-                    elements.floating.querySelector<HTMLElement>(".dropdown-menu-options") ?? elements.floating;
-
-                  Object.assign(scrollElement.style, {
-                    maxHeight: `${availableHeight}px`,
-                    maxInlineSize: `${availableWidth}px`,
-                  });
+                apply: ({ availableHeight, availableWidth }) => {
+                  // No direct DOM writes here: this callback runs inside the autoUpdate
+                  // ResizeObserver cycle and would trigger "ResizeObserver loop completed
+                  // with undelivered notifications". The constraints are applied together
+                  // with the position, see applyPopoverStyles.
+                  this.pendingPopoverConstraints = { availableWidth, availableHeight };
                 },
               }),
             ],
             placement: this.isCompact ? "bottom-end" : "bottom-start",
           }).then(({ x, y }) => {
-            Object.assign(element.style, {
-              left: `${x}px`,
-              top: `${y}px`,
+            if (initialUpdate) {
+              // The first update runs outside the ResizeObserver cycle and is applied
+              // directly so the popover does not show up unpositioned.
+              initialUpdate = false;
+              applyPopoverStyles(x, y);
+
+              return;
+            }
+
+            // Defer DOM writes until the next frame so ResizeObserver notifications can
+            // settle before the popover mutates its own layout again.
+            if (this.popoverFrameId !== undefined) {
+              cancelAnimationFrame(this.popoverFrameId);
+            }
+
+            this.popoverFrameId = requestAnimationFrame(() => {
+              this.popoverFrameId = undefined;
+              applyPopoverStyles(x, y);
             });
           });
         }
       });
+
+      this.cleanUp = () => {
+        if (this.popoverFrameId !== undefined) {
+          cancelAnimationFrame(this.popoverFrameId);
+          this.popoverFrameId = undefined;
+        }
+
+        autoUpdateCleanUp();
+      };
     }
   }
 

--- a/storybook/cypress/e2e/dropdown-menu.cy.ts
+++ b/storybook/cypress/e2e/dropdown-menu.cy.ts
@@ -62,6 +62,33 @@ describe("Dropdown menu - anchors", () => {
     cy.get("@menuitems").should("not.be.visible");
   });
 
+  it("should not trigger ResizeObserver loop errors when toggling the menu", () => {
+    cy.window().then((win) => {
+      const winWithErrors = win as Window & { __resizeObserverLoopErrors?: string[] };
+      winWithErrors.__resizeObserverLoopErrors = [];
+
+      win.addEventListener("error", (event) => {
+        if (event.message.includes("ResizeObserver loop")) {
+          winWithErrors.__resizeObserverLoopErrors?.push(event.message);
+        }
+      });
+    });
+
+    cy.get("@button").should("be.visible").focus().click();
+    cy.get("@menuitems").should("be.visible");
+    cy.wait(100);
+
+    cy.get("@button").click();
+    cy.get("@menuitems").should("not.be.visible");
+    cy.wait(100);
+
+    cy.get("@button").click();
+    cy.get("@menuitems").should("be.visible");
+    cy.wait(100);
+
+    cy.window().its("__resizeObserverLoopErrors").should("be.empty");
+  });
+
   it("matches snapshots", () => {
     cy.get("dso-dropdown-menu.hydrated").matchImageSnapshot(`type=link -- ${Cypress.currentTest.title} -- not open`);
 

--- a/storybook/cypress/e2e/header.cy.ts
+++ b/storybook/cypress/e2e/header.cy.ts
@@ -91,6 +91,34 @@ describe("Header", () => {
       });
   }
 
+  it("should not trigger ResizeObserver loop errors when toggling the compact menu", () => {
+    cy.viewport(500, 800)
+      .get<HTMLDsoHeaderElement>("dso-header.hydrated")
+      .then(($header) => setMenuItems($header, defaultMenuItems));
+
+    cy.window().then((win) => {
+      const winWithErrors = win as Window & { __resizeObserverLoopErrors?: string[] };
+      winWithErrors.__resizeObserverLoopErrors = [];
+
+      win.addEventListener("error", (event) => {
+        if (event.message.includes("ResizeObserver loop")) {
+          winWithErrors.__resizeObserverLoopErrors?.push(event.message);
+        }
+      });
+    });
+
+    cy.get("dso-header[is-compact].hydrated").shadow().find(".dropdown-menu > button").as("menuButton");
+
+    cy.get("@menuButton").click().should("have.attr", "aria-expanded", "true");
+    cy.wait(100);
+    cy.get("@menuButton").click().should("have.attr", "aria-expanded", "false");
+    cy.wait(100);
+    cy.get("@menuButton").click().should("have.attr", "aria-expanded", "true");
+    cy.wait(100);
+
+    cy.window().its("__resizeObserverLoopErrors").should("be.empty");
+  });
+
   it("matches snapshot (all menuitems visible)", () => {
     cy.viewport(1400, 660)
       .get<HTMLDsoHeaderElement>("dso-header.hydrated")

--- a/storybook/cypress/support/e2e.ts
+++ b/storybook/cypress/support/e2e.ts
@@ -16,6 +16,8 @@
 // Import commands.js using ES2015 syntax:
 import "./commands";
 
+import "./resize-observer-loop-guard";
+
 import "cypress-axe";
 import "cypress-real-events";
 

--- a/storybook/cypress/support/resize-observer-loop-guard.ts
+++ b/storybook/cypress/support/resize-observer-loop-guard.ts
@@ -1,0 +1,26 @@
+// Fails a test when the browser reports "ResizeObserver loop completed with undelivered
+// notifications" during that test. Chrome does not print this error to the console and
+// Cypress does not treat it as an uncaught exception, so without this guard it goes
+// unnoticed in CI while error trackers in consuming applications do log it.
+//
+// Note: a failure in an afterEach hook makes Cypress skip the remaining tests in the
+// spec file. That is acceptable for this guard: one hit should fail the run.
+const resizeObserverLoopErrors: string[] = [];
+
+Cypress.on("window:before:load", (win) => {
+  win.addEventListener("error", (event) => {
+    if (typeof event.message === "string" && event.message.includes("ResizeObserver loop")) {
+      resizeObserverLoopErrors.push(event.message);
+    }
+  });
+});
+
+beforeEach(() => {
+  resizeObserverLoopErrors.length = 0;
+});
+
+afterEach(() => {
+  if (resizeObserverLoopErrors.length > 0) {
+    throw new Error(`ResizeObserver loop error(s) during this test:\n${resizeObserverLoopErrors.join("\n")}`);
+  }
+});


### PR DESCRIPTION
Fixes #3915

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Naast de Header is ook Dropdown Menu aangepast: die kreeg in dezelfde commit (#3844) dezelfde size-middleware en heeft hetzelfde risico. Preventief meegenomen, zie het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- [x] Etaleren/aanpassen van een nieuw component op de website
- [x] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl

## Oorzaak

De size-middleware uit #3844 schrijft in `apply` synchroon `maxHeight` en `maxInlineSize`, binnen de autoUpdate-cyclus van floating-ui. Die cyclus draait op een eigen ResizeObserver die de popover observeert, dus de writes veranderen de maat van het geobserveerde element binnen dezelfde observer-aflevering. Daarnaast startte `componentDidRender` autoUpdate ook bij een gesloten popover, waardoor er constraints op een verborgen element werden berekend. Bij elke opening was dan een correctie binnen hetzelfde frame nodig: de melding bij elke klik. Details en metingen staan in het issue.

## Fix

Zelfde patroon als `position-tooltip.function.ts` (#3715), in Header en Dropdown Menu:

1. autoUpdate start alleen bij een open popover en wordt bij sluiten opgeruimd. De constraints worden daardoor op de zichtbare popover berekend en zijn nu correct.
2. De size-middleware schrijft niet meer direct; constraints en positie worden samen toegepast in `applyPopoverStyles`.
3. De eerste positionering na openen gebeurt direct (die draait buiten de observer-cyclus en voorkomt een ongepositioneerde eerste frame); vervolg-updates gaan via `requestAnimationFrame`, met annulering in de cleanup.

## Tests

- Regressietests in `header.cy.ts` en `dropdown-menu.cy.ts`: menu openen en sluiten mag geen ResizeObserver-loop-events opleveren. De header-test faalt op de code zonder fix (twee gevangen meldingen bij twee openingen) en slaagt met fix. Het scenario vereist een smal viewport (500x800), want de fout treedt pas op als een verweesde constraint knelt; de bestaande compact-tests op 1000x660 raakten hem daardoor niet.
- Globale afvang in `cypress/support/resize-observer-loop-guard.ts`: elke test faalt voortaan zodra deze melding tijdens de test optreedt. Zonder deze afvang is deze foutklasse onzichtbaar in CI: Chrome print de melding niet in de console en de bestaande `uncaught:exception`-afvang (#3288) dempt exceptions. Let op: een treffer in de afterEach-hook laat Cypress de rest van het spec-bestand overslaan; dat is bedoeld fail-fast-gedrag.
- Volledige e2e-suite lokaal doorgedraaid onder de afvang: nul treffers in 63 specs. Lokale image-snapshot-verschillen (DPI-schaling) staan los van deze wijziging.
- Het doel van #3844 blijft intact: op een laag viewport knelt het menu op de beschikbare hoogte en scrollt de lijst binnen `dso-scrollable` (geverifieerd op 500x300, max-height 211px, scroll actief).