### PR TITLE
#3826 [Fixed] Packages: Patch Stencil runtime tegen Null is not an object (evaluating 'e.__insertBefore') in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * Table: Koppel knop vergroten aan tabel ([#3905](https://github.com/dso-toolkit/dso-toolkit/issues/3905))
 
+### Fixed
+* Packages: Patch Stencil runtime tegen Null is not an object (evaluating 'e.__insertBefore') in Safari ([#3826](https://github.com/dso-toolkit/dso-toolkit/issues/3826))
+
 ## 💯 Release 100.0.0 - 2026-08-10
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ WORKDIR /usr/src/app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
+COPY patches ./patches
+
 COPY angular-workspace/package.json ./angular-workspace/package.json
 COPY packages/core/package.json ./packages/core/package.json
 COPY packages/dso-toolkit/package.json ./packages/dso-toolkit/package.json

--- a/patches/@stencil__core@4.43.5.patch
+++ b/patches/@stencil__core@4.43.5.patch
@@ -1,0 +1,39 @@
+diff --git a/internal/client/index.js b/internal/client/index.js
+index 618869d33d53763792fefed6130ffc6e11146afa..bd35dd52649b4b3902b843369486905a96270e0b 100644
+--- a/internal/client/index.js
++++ b/internal/client/index.js
+@@ -3014,7 +3014,7 @@ var insertBefore = (parent, newNode, reference, isInitialLoad) => {
+       return newNode;
+     }
+   }
+-  if (parent.__insertBefore) {
++  if (parent != null && parent.__insertBefore) {
+     return parent.__insertBefore(newNode, reference);
+   } else {
+     return parent == null ? void 0 : parent.insertBefore(newNode, reference);
+diff --git a/internal/hydrate/index.js b/internal/hydrate/index.js
+index cafa1ce5ac59433308c892fea651d469a4e4b72f..1aab72c690ca13bb5438668cf9e35c0105295656 100644
+--- a/internal/hydrate/index.js
++++ b/internal/hydrate/index.js
+@@ -3018,7 +3018,7 @@ var insertBefore = (parent, newNode, reference, isInitialLoad) => {
+       return newNode;
+     }
+   }
+-  if (parent.__insertBefore) {
++  if (parent != null && parent.__insertBefore) {
+     return parent.__insertBefore(newNode, reference);
+   } else {
+     return parent == null ? void 0 : parent.insertBefore(newNode, reference);
+diff --git a/internal/testing/index.js b/internal/testing/index.js
+index d16dde2b1d3024ebbbbc788c79c30158685c4b40..71eaa9dc91e523b569738ffeb75211276ab9d76d 100644
+--- a/internal/testing/index.js
++++ b/internal/testing/index.js
+@@ -5006,7 +5006,7 @@ var insertBefore = (parent, newNode, reference, isInitialLoad) => {
+       return newNode;
+     }
+   }
+-  if (parent.__insertBefore) {
++  if (parent != null && parent.__insertBefore) {
+     return parent.__insertBefore(newNode, reference);
+   } else {
+     return parent == null ? void 0 : parent.insertBefore(newNode, reference);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,37 +169,40 @@ catalogs:
       version: 10.5.4
 
 overrides:
+  '@angular-devkit/build-angular>http-proxy-middleware': ^3.0.7
+  '@angular-devkit/build-angular>webpack-dev-server': ^5.2.6
+  '@angular-devkit/core>ajv': '>=8.18.0'
   '@babel/core': ^7.29.6
+  '@hono/node-server': ^2.0.5
+  '@stencil/eslint-plugin>jsdom': ~25
+  axios: ^1.18.0
+  body-parser: ^2.3.0
   esbuild: '>=0.28.1'
+  fast-uri: ^3.1.4
   form-data: '>=4.0.6'
+  gray-matter>js-yaml: ^3.15.0
+  gulp-cheerio>cheerio: ^1.1.2
+  hono@<4.12.27: ^4.12.27
   joi: '>=17.13.4'
+  node-gyp>undici: ^6.27.0
   nth-check: '>=2.0.1'
-  picomatch: '>=4.0.4'
   piscina: '>=5.2.0'
+  picomatch: '>=4.0.4'
+  postcss: ^8.5.23
   qs: '>=6.15.2'
   serialize-javascript: '>=7.0.5'
   shell-quote: '>=1.8.4'
+  svgo: ^4.0.2
+  tar: ^7.5.19
   tmp: '>=0.2.7'
   undici: ^7.28.0
   uuid: '>=11.1.1'
   vite: ^8.1.2
   webpack: 5.105.2
-  '@angular-devkit/build-angular>http-proxy-middleware': ^3.0.7
-  '@angular-devkit/build-angular>webpack-dev-server': ^5.2.6
-  '@angular-devkit/core>ajv': '>=8.18.0'
-  '@stencil/eslint-plugin>jsdom': ~25
-  gray-matter>js-yaml: ^3.15.0
-  gulp-cheerio>cheerio: ^1.1.2
-  node-gyp>undici: ^6.27.0
   webpack-dev-server>http-proxy-middleware: ^2.0.10
-  '@hono/node-server': ^2.0.5
-  hono@<4.12.27: ^4.12.27
-  axios: ^1.18.0
-  body-parser: ^2.3.0
-  fast-uri: ^3.1.4
-  svgo: ^4.0.2
-  tar: ^7.5.19
-  postcss: ^8.5.23
+
+patchedDependencies:
+  '@stencil/core@4.43.5': 34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1
 
 importers:
 
@@ -307,7 +310,7 @@ importers:
     devDependencies:
       '@stencil/eslint-plugin':
         specifier: ^1.4.0
-        version: 1.4.0(@stencil/core@4.43.5)(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 1.4.0(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -430,10 +433,10 @@ importers:
         version: 1.8.0
       '@stencil/core':
         specifier: 'catalog:'
-        version: 4.43.5
+        version: 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
       '@stencil/store':
         specifier: ^2.2.2
-        version: 2.2.2(@stencil/core@4.43.5)
+        version: 2.2.2(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -458,13 +461,13 @@ importers:
     devDependencies:
       '@stencil/angular-output-target':
         specifier: ^1.4.1
-        version: 1.4.1(@stencil/core@4.43.5)
+        version: 1.4.1(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))
       '@stencil/react-output-target':
         specifier: 'catalog:'
-        version: 1.6.1(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.6.1(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@stencil/sass':
         specifier: ^3.3.2
-        version: 3.3.2(@stencil/core@4.43.5)
+        version: 3.3.2(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))
       '@types/debounce':
         specifier: ^1.2.4
         version: 1.2.4
@@ -641,7 +644,7 @@ importers:
     dependencies:
       '@stencil/react-output-target':
         specifier: 'catalog:'
-        version: 1.6.1(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.6.1(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@dso-toolkit/core':
         specifier: workspace:*
@@ -651,7 +654,7 @@ importers:
         version: 5.5.9
       '@stencil/core':
         specifier: 'catalog:'
-        version: 4.43.5
+        version: 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
       '@storybook/addon-a11y':
         specifier: catalog:storybook
         version: 10.5.4(storybook@10.5.4(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
@@ -17861,11 +17864,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stencil/angular-output-target@1.4.1(@stencil/core@4.43.5)':
+  '@stencil/angular-output-target@1.4.1(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))':
     dependencies:
-      '@stencil/core': 4.43.5
+      '@stencil/core': 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
 
-  '@stencil/core@4.43.5':
+  '@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)':
     optionalDependencies:
       '@rollup/rollup-darwin-arm64': 4.44.0
       '@rollup/rollup-darwin-x64': 4.44.0
@@ -17876,9 +17879,9 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.44.0
       '@rollup/rollup-win32-x64-msvc': 4.44.0
 
-  '@stencil/eslint-plugin@1.4.0(@stencil/core@4.43.5)(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@stencil/eslint-plugin@1.4.0(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@stencil/core': 4.43.5
+      '@stencil/core': 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
       eslint-utils: 3.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
       jsdom: 25.0.1(supports-color@7.2.0)
       tsutils: 3.21.0(typescript@5.9.3)
@@ -17894,10 +17897,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stencil/react-output-target@1.6.1(@stencil/core@4.43.5)(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@stencil/react-output-target@1.6.1(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@lit/react': 1.0.8(@types/react@19.2.17)
-      '@stencil/core': 4.43.5
+      '@stencil/core': 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
       html-react-parser: 5.2.17(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -17906,14 +17909,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@stencil/sass@3.3.2(@stencil/core@4.43.5)':
+  '@stencil/sass@3.3.2(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))':
     dependencies:
-      '@stencil/core': 4.43.5
+      '@stencil/core': 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
       sass-embedded: 1.100.0
 
-  '@stencil/store@2.2.2(@stencil/core@4.43.5)':
+  '@stencil/store@2.2.2(@stencil/core@4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1))':
     dependencies:
-      '@stencil/core': 4.43.5
+      '@stencil/core': 4.43.5(patch_hash=34bfaf9320d514b108ba4981facd6b85c4328ee5d53d357d253e3f10082a87a1)
 
   '@storybook/addon-a11y@10.5.4(storybook@10.5.4(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,3 +109,6 @@ allowBuilds:
   lmdb: true
   msgpackr-extract: true
   nx: true
+
+patchedDependencies:
+  "@stencil/core@4.43.5": patches/@stencil__core@4.43.5.patch

--- a/storybook/cypress/support/wait-for-components/wait-for-components.ts
+++ b/storybook/cypress/support/wait-for-components/wait-for-components.ts
@@ -33,6 +33,12 @@ export function waitForComponents() {
           });
       }
     });
+
+  // Wacht tot alle (async ge-preloade) webfonts geladen zijn. De cursieve Asap-variant
+  // wordt gebruikt in de disclaimer boven de footer; als die pas na de snapshot laadt,
+  // verschuift de footer verticaal en ontstaat er een diff.
+  cy.document().then((doc) => doc.fonts.ready);
+  cy.document().its("fonts.status").should("equal", "loaded");
 }
 
 function prettyPrintResults(dsoComponents: Element[]) {

--- a/storybook/src/example-pages/toepassingen/aanvragen/landingspagina.stories.ts
+++ b/storybook/src/example-pages/toepassingen/aanvragen/landingspagina.stories.ts
@@ -71,11 +71,9 @@ const Landingspagina = examplePageStories((templates) => {
                   we dit plan mogelijk maken?'. Na het Omgevingsoverleg weet u of uw project haalbaar is. Ook weet u hoe
                   u uw verzoek het beste kunt indienen.
                 </p>
-                <p>
-                  <em class="text-muted"
-                    >Let op, bekijk altijd eerst de website van uw gemeente, waterschap of provincie voor
-                    beschikbaarheid en mogelijke kosten van een Omgevingsoverleg</em
-                  >
+                <p class="dso-disclaimer">
+                  Let op, bekijk altijd eerst de website van uw gemeente, waterschap of provincie voor beschikbaarheid
+                  en mogelijke kosten van een Omgevingsoverleg
                 </p>
                 <h2>Eerst een vergunningcheck?</h2>
                 <p>

--- a/storybook/src/example-pages/toepassingen/vergunningscheck/resultaat.stories.ts
+++ b/storybook/src/example-pages/toepassingen/vergunningscheck/resultaat.stories.ts
@@ -244,17 +244,15 @@ const Resultaat = examplePageStories((templates) => {
 
         ${richContentTemplate({
           children: html`
-            <p>
-              <em class="text-muted"
-                >De Vergunningcheck is een serviceproduct van de Nederlandse overheid. Het geeft u een algemene indruk
-                of er voor uw activiteit een vergunning of melding nodig is. De makers van de Vergunningcheck hebben met
-                veel aandacht gewerkt aan de vragen en antwoorden. Toch geeft het resultaat van de Vergunningcheck u
-                geen absolute zekerheid. Bijvoorbeeld doordat sommige activiteiten of combinaties van activiteiten (nog)
-                niet in de Vergunningcheck staan. Of doordat er nog andere regels zijn waardoor u nog andere
-                vergunningen moet aanvragen of andere meldingen moet doen. U kunt daarom geen rechten ontlenen aan deze
-                Vergunningcheck. Wilt u zeker weten of en hoe u uw activiteit kunt uitvoeren? Dan raden wij u aan
-                contact op te nemen met uw gemeente en/of waterschap.</em
-              >
+            <p class="dso-disclaimer">
+              De Vergunningcheck is een serviceproduct van de Nederlandse overheid. Het geeft u een algemene indruk of
+              er voor uw activiteit een vergunning of melding nodig is. De makers van de Vergunningcheck hebben met veel
+              aandacht gewerkt aan de vragen en antwoorden. Toch geeft het resultaat van de Vergunningcheck u geen
+              absolute zekerheid. Bijvoorbeeld doordat sommige activiteiten of combinaties van activiteiten (nog) niet
+              in de Vergunningcheck staan. Of doordat er nog andere regels zijn waardoor u nog andere vergunningen moet
+              aanvragen of andere meldingen moet doen. U kunt daarom geen rechten ontlenen aan deze Vergunningcheck.
+              Wilt u zeker weten of en hoe u uw activiteit kunt uitvoeren? Dan raden wij u aan contact op te nemen met
+              uw gemeente en/of waterschap.
             </p>
           `,
         })}


### PR DESCRIPTION
De Stencil-runtime (4.43.5) benadert parent.__insertBefore zonder null-check, waardoor Safari op iOS crasht met 'Null is not an object (evaluating 'e.__insertBefore')'. Een pnpm patch voegt een null-guard toe in de client-, hydrate- en testing-runtime, consistent met de al null-veilige fallback.

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
