### PR TITLE
#3943 [Fixed] Map Message: NVDA leest niet voor bij verschijnen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 * Hero Image: Nieuw component ([#3797](https://github.com/dso-toolkit/dso-toolkit/issues/3797))
 
+### Fixed
+* Map Message: NVDA leest niet voor bij verschijnen ([#3943](https://github.com/dso-toolkit/dso-toolkit/issues/3943))
+
 ### Task
 * Storybook: Verwijder React Storybook ([#3929](https://github.com/dso-toolkit/dso-toolkit/issues/3929))
 

--- a/packages/core/src/components/map-message/map-message.tsx
+++ b/packages/core/src/components/map-message/map-message.tsx
@@ -26,6 +26,39 @@ export class MapMessage implements ComponentInterface {
   @State()
   hasActions = false;
 
+  // Een screenreader leest alleen wijzigingen voor binnen een live region die al in de
+  // accessibility tree staat. Dit component komt samen met zijn melding de DOM in, dus
+  // rendert de region eerst leeg en volgt de melding daarna.
+  @State()
+  showMessage = false;
+
+  private animationFrame?: number;
+
+  connectedCallback() {
+    this.showMessage = false;
+  }
+
+  componentDidRender() {
+    if (!this.showMessage && this.animationFrame === undefined) {
+      // De browser werkt de accessibility tree gebatcht bij; vallen lege region en melding in
+      // dezelfde batch, dan blijft de screenreader stil. Eén render-tick afstand bleek te kort
+      // (NVDA, #3943); twee animatieframes is de kleinste afstand die betrouwbaar werkt.
+      this.animationFrame = requestAnimationFrame(() => {
+        this.animationFrame = requestAnimationFrame(() => {
+          this.animationFrame = undefined;
+          this.showMessage = true;
+        });
+      });
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.animationFrame !== undefined) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = undefined;
+    }
+  }
+
   private handleActionsSlotChange = (event: Event) => {
     const target = event.target;
     if (target instanceof HTMLSlotElement) {
@@ -44,14 +77,10 @@ export class MapMessage implements ComponentInterface {
           "has-icon": iconName !== undefined,
           "has-actions": this.hasActions,
         }}
-        role={role}
-        aria-atomic="true"
       >
-        <div class="map-message-body">
+        <div class="map-message-body" role={role} aria-atomic="true">
           {iconName && <dso-icon class="map-message-icon" icon={iconName} aria-hidden="true" />}
-          <span class="map-message-text">
-            <slot name="message" />
-          </span>
+          <span class="map-message-text">{this.showMessage && <slot name="message" />}</span>
         </div>
         <slot name="actions" onSlotchange={this.handleActionsSlotChange} />
       </div>

--- a/storybook/cypress/e2e/map-message.cy.ts
+++ b/storybook/cypress/e2e/map-message.cy.ts
@@ -5,22 +5,101 @@ describe("dso-map-message - Storybook slot rendering", () => {
   it("renders success variant and ARIA role", () => {
     cy.visit(`${storybookBaseUrl}success`);
     cy.get(mapMessageSelector).should("have.attr", "variant", "success");
-    cy.get(mapMessageSelector).shadow().find(".map-message-content").should("have.attr", "role", "status");
+    cy.get(mapMessageSelector).shadow().find(".map-message-body").should("have.attr", "role", "status");
     cy.get(mapMessageSelector).find('[slot="message"]').should("exist");
   });
 
   it("renders error variant and ARIA role", () => {
     cy.visit(`${storybookBaseUrl}error`);
     cy.get(mapMessageSelector).should("have.attr", "variant", "error");
-    cy.get(mapMessageSelector).shadow().find(".map-message-content").should("have.attr", "role", "alert");
+    cy.get(mapMessageSelector).shadow().find(".map-message-body").should("have.attr", "role", "alert");
     cy.get(mapMessageSelector).find('[slot="message"]').should("exist");
   });
 
   it("renders instruction variant and ARIA role", () => {
     cy.visit(`${storybookBaseUrl}instruction`);
     cy.get(mapMessageSelector).should("have.attr", "variant", "instruction");
-    cy.get(mapMessageSelector).shadow().find(".map-message-content").should("have.attr", "role", "status");
+    cy.get(mapMessageSelector).shadow().find(".map-message-body").should("have.attr", "role", "status");
     cy.get(mapMessageSelector).find('[slot="message"]').should("exist");
+  });
+
+  // #3943: komen live region en melding tegelijk de DOM in, dan leest een screenreader
+  // het kaartbericht niet voor.
+  it("renders the live region empty first and adds the message in a later frame", () => {
+    cy.visit(`${storybookBaseUrl}instruction`);
+    cy.get(mapMessageSelector).should("exist");
+
+    cy.window().then((win) => {
+      type RegionState = { frame: number; slotPresent: boolean; flatText: string };
+
+      return new Cypress.Promise<RegionState[]>((resolve) => {
+        const doc = win.document;
+        const states: RegionState[] = [];
+        let frame = 0;
+
+        const countFrames = () => {
+          frame++;
+          win.requestAnimationFrame(countFrames);
+        };
+        win.requestAnimationFrame(countFrames);
+
+        const origAttachShadow = win.Element.prototype.attachShadow;
+        win.Element.prototype.attachShadow = function (init: ShadowRootInit): ShadowRoot {
+          const shadowRoot = origAttachShadow.call(this, init);
+
+          if (this.tagName === "DSO-MAP-MESSAGE") {
+            win.Element.prototype.attachShadow = origAttachShadow;
+
+            const record = () => {
+              const region = shadowRoot.querySelector('[role="status"], [role="alert"]');
+              if (!region) {
+                return;
+              }
+
+              const slot = region.querySelector<HTMLSlotElement>('slot[name="message"]');
+              const flatText = slot
+                ? slot
+                    .assignedNodes({ flatten: true })
+                    .map((node) => node.textContent)
+                    .join("")
+                    .trim()
+                : "";
+
+              states.push({ frame, slotPresent: slot !== null, flatText });
+
+              if (flatText !== "") {
+                resolve(states);
+              }
+            };
+
+            new win.MutationObserver(record).observe(shadowRoot, { subtree: true, childList: true });
+            record();
+          }
+
+          return shadowRoot;
+        };
+
+        doc.querySelector("dso-map-message")?.remove();
+
+        const mapMessage = doc.createElement("dso-map-message");
+        mapMessage.setAttribute("variant", "instruction");
+        const message = doc.createElement("span");
+        message.slot = "message";
+        message.textContent = "Klik in de kaart om een punt te tekenen";
+        mapMessage.append(message);
+        doc.body.append(mapMessage);
+      }).then((states) => {
+        const empty = states.find((state) => !state.slotPresent);
+        const filled = states.find((state) => state.flatText !== "");
+
+        expect(empty, "live region is rendered empty first").to.not.equal(undefined);
+        expect(filled, "message is added to the live region").to.not.equal(undefined);
+
+        if (empty && filled) {
+          expect(filled.frame, "message is added in a later animation frame").to.be.greaterThan(empty.frame);
+        }
+      });
+    });
   });
 
   it("should be accessible", () => {


### PR DESCRIPTION
Fixes #3943

Een live region wordt alleen voorgelezen bij een wijziging binnen een region die al in de accessibility tree staat. Map Message komt met melding en al de DOM in; daarom rendert de live region nu eerst leeg en volgt de melding twee animatieframes later. De `role` verhuist van `.map-message-content` naar `.map-message-body`, zodat de action-knoppen buiten de atomic live region vallen.

Getest met NVDA in Chrome en Edge op Windows 11 🎉

- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
-~[ ] Etaleren/aanpassen van een nieuw component op de website (n.v.t., geen nieuw component)~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl