### PR TITLE
#3925 [Changed] Viewer Grid: Document-tab conditioneel kunnen verbergen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Changed
+* Viewer Grid: Document-tab conditioneel kunnen verbergen ([#3925](https://github.com/dso-toolkit/dso-toolkit/issues/3925))
+
 ## 🪅 Release 100.2.0 - 2026-08-25
 
 ### Added

--- a/packages/core/src/components/viewer-grid/viewer-grid.tsx
+++ b/packages/core/src/components/viewer-grid/viewer-grid.tsx
@@ -304,6 +304,8 @@ export class ViewerGrid {
   }
 
   render() {
+    const tabs = viewerGridTabs.filter((tab) => tab !== "document" || this.documentPanelOpen);
+
     return (
       <Fragment>
         <slot name="top-bar" />
@@ -311,7 +313,7 @@ export class ViewerGrid {
           {this.tabView && (
             <nav class="dso-navbar">
               <ul class="dso-nav dso-nav-sub">
-                {viewerGridTabs.map((tab) => (
+                {tabs.map((tab) => (
                   <li key={tab} class={clsx({ "dso-active": this.activeTab === tab })}>
                     <button
                       type="button"
@@ -332,7 +334,7 @@ export class ViewerGrid {
               mainSize={this.mainSize}
               documentPanelOpen={this.documentPanelOpen}
               mainPanelExpanded={this.mainPanelExpanded}
-              mainPanelHidden={this.mainPanelHidden}
+              mainPanelHidden={this.tabView ? false : this.mainPanelHidden}
               toggleMainPanel={this.toggleMainPanel}
               dsoMainSizeChangeAnimationEnd={this.dsoMainSizeChangeAnimationEnd}
               printFilterPanel={
@@ -350,7 +352,7 @@ export class ViewerGrid {
             </div>
           )}
           {((!this.tabView && this.documentPanelOpen) ||
-            (this.tabView && this.activeTab === "document") ||
+            (this.tabView && this.activeTab === "document" && this.documentPanelOpen) ||
             this.print) && (
             <DocumentPanel
               tabView={this.tabView}

--- a/storybook/cypress/e2e/viewer-grid.cy.ts
+++ b/storybook/cypress/e2e/viewer-grid.cy.ts
@@ -241,6 +241,7 @@ describe("Viewer Grid", () => {
     cy.viewport(400, 600)
       .get("dso-viewer-grid.hydrated")
       .then((e) => e.on("dsoActiveTabSwitch", cy.stub().as("dsoActiveTabSwitch")))
+      .invoke("attr", "document-panel-open", "")
       .invoke("attr", "active-tab", "search")
       .shadow()
       .as("dsoViewerGrid")
@@ -314,6 +315,71 @@ describe("Viewer Grid", () => {
       .and("be.visible");
   });
 
+  it("should update aria-current when active tab changes", () => {
+    cy.viewport(400, 600);
+    cy.visit(url);
+
+    cy.get("dso-viewer-grid.hydrated").as("grid").invoke("prop", "activeTab", "search");
+
+    cy.get("@grid").shadow().find("nav button").eq(0).should("have.attr", "aria-current", "page");
+
+    cy.get("@grid").invoke("prop", "activeTab", "map");
+
+    cy.get("@grid").shadow().find("nav button").eq(1).should("have.attr", "aria-current", "page");
+
+    cy.get("@grid").shadow().find("nav button").eq(0).should("not.have.attr", "aria-current");
+  });
+
+  it("should only show the Document tab on mobile when documentPanelOpen is set", () => {
+    cy.viewport(400, 600);
+    cy.visit(url);
+
+    cy.get("dso-viewer-grid.hydrated")
+      .shadow()
+      .find("nav > ul > li")
+      .should("have.length", 2)
+      .and("not.contain.text", "Document");
+
+    cy.get("dso-viewer-grid.hydrated")
+      .invoke("attr", "document-panel-open", "")
+      .shadow()
+      .find("nav > ul > li")
+      .should("have.length", 3)
+      .and("contain.text", "Document");
+  });
+
+  it("should not show Document tab or panel when no document is selected", () => {
+    cy.viewport(400, 600);
+    cy.visit(url);
+
+    cy.get("dso-viewer-grid.hydrated")
+      .shadow()
+      .find("nav > ul > li")
+      .should("have.length", 2)
+      .and("not.contain.text", "Document");
+
+    cy.get("dso-viewer-grid.hydrated")
+      .invoke("attr", "active-tab", "document")
+      .shadow()
+      .find(".dso-document-panel")
+      .should("not.exist");
+  });
+
+  it("should keep main panel content visible in mobile view even when mainPanelHidden is true", () => {
+    cy.viewport(400, 600);
+    cy.visit(url);
+
+    cy.get("dso-viewer-grid.hydrated")
+      .invoke("attr", "active-tab", "search")
+      .invoke("attr", "main-panel-hidden", "")
+      .shadow()
+      .find(".dso-main-panel")
+      .should("exist")
+      .and("be.visible")
+      .find(".content")
+      .should("not.have.class", "invisible");
+  });
+
   it("should have the correct aria-label on the filter panel", () => {
     cy.visit(url);
     cy.get("dso-viewer-grid.hydrated")
@@ -380,18 +446,3 @@ function shouldHavePhrase(size: string) {
     .find(".sizing-buttons > span.sr-only")
     .should("have.text", `Breedte documentpaneel: ${size}`);
 }
-
-it("should update aria-current when active tab changes", () => {
-  cy.viewport(400, 600);
-  cy.visit(url);
-
-  cy.get("dso-viewer-grid.hydrated").as("grid").invoke("prop", "activeTab", "search");
-
-  cy.get("@grid").shadow().find("nav button").eq(0).should("have.attr", "aria-current", "page");
-
-  cy.get("@grid").invoke("prop", "activeTab", "map");
-
-  cy.get("@grid").shadow().find("nav button").eq(1).should("have.attr", "aria-current", "page");
-
-  cy.get("@grid").shadow().find("nav button").eq(0).should("not.have.attr", "aria-current");
-});


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [x] De wijziging heeft een e2e test
- ~[ ] Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
