### PR TITLE
#3917 [Changed] Advanced Select: Meerdere aanpassingen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * Viewer Grid: Document-tab conditioneel kunnen verbergen ([#3925](https://github.com/dso-toolkit/dso-toolkit/issues/3925))
 * Document Card: Toevoeging label row ([#3716](https://github.com/dso-toolkit/dso-toolkit/issues/3716))
+* Advanced Select: Meerdere aanpassingen ([#3917](https://github.com/dso-toolkit/dso-toolkit/issues/3917))
 
 ### Fixed
 * Map Message: NVDA leest niet voor bij verschijnen ([#3943](https://github.com/dso-toolkit/dso-toolkit/issues/3943))

--- a/packages/core/src/components/advanced-select/advanced-select.interfaces.ts
+++ b/packages/core/src/components/advanced-select/advanced-select.interfaces.ts
@@ -2,6 +2,11 @@ export type AdvancedSelectVariant = "primary" | "success" | "info" | "warning" |
 
 export interface AdvancedSelectOption<T> {
   label: string;
+  /**
+   * An optional label to display for the option when it is the active option.
+   * Falls back to `label` when not set.
+   */
+  selectedLabel?: string;
   value?: T;
 }
 
@@ -21,6 +26,9 @@ export interface AdvancedSelectGroup<T> {
   toggletip?: string;
 }
 
+/**
+ * Use this interface to create a placeholder option in the case a AdvancedSelectGroup has no options.
+ */
 export interface AdvancedSelectPlaceholder {
   label: string;
   redirect?: AdvancedSelectGroupRedirect;

--- a/packages/core/src/components/advanced-select/advanced-select.scss
+++ b/packages/core/src/components/advanced-select/advanced-select.scss
@@ -14,9 +14,17 @@
 
 @include utilities.box-sizing();
 
+.advanced-select-container {
+  container-type: inline-size;
+}
+
 .advanced-select {
   display: flex;
   flex-direction: row;
+
+  @container (max-width: 480px) {
+    flex-direction: column;
+  }
 }
 
 .advanced-select-button {
@@ -75,6 +83,12 @@
   gap: advanced-select.$block-padding;
   padding-block-start: units.$u1;
   padding-inline-start: units.$u1;
+
+  @container (max-width: 480px) {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    padding-inline-start: 0;
+  }
 }
 
 .groups-container {
@@ -168,7 +182,7 @@
 
 .option {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: units.$u1;
   inline-size: 100%;
   padding-block: advanced-select.$block-padding * 2;
@@ -222,4 +236,5 @@
   padding-block: advanced-select.$block-padding * 2;
   padding-inline: advanced-select.$inline-padding;
   color: advanced-select.$option-placeholder-color;
+  font-style: italic;
 }

--- a/packages/core/src/components/advanced-select/advanced-select.tsx
+++ b/packages/core/src/components/advanced-select/advanced-select.tsx
@@ -144,96 +144,98 @@ export class AdvancedSelect implements ComponentInterface {
   render() {
     const icon = this.open ? "caret-up" : "caret-down";
     return (
-      <div class="advanced-select">
-        <div class="advanced-select-button">
-          <button
-            aria-expanded={this.open.toString()}
-            class={clsx(["active-option", { open: this.open }])}
-            type="button"
-            onClick={this.toggleOpen}
-            ref={(element) => (this.toggleButtonElementRef = element)}
-          >
-            <span class="active-option-label">
-              <ActiveGroupLabel active={this.active} options={this.options} />
-              {this.active?.label ?? "Selecteer een optie"}
+      <div class="advanced-select-container">
+        <div class="advanced-select">
+          <div class="advanced-select-button">
+            <button
+              aria-expanded={this.open.toString()}
+              class={clsx(["active-option", { open: this.open }])}
+              type="button"
+              onClick={this.toggleOpen}
+              ref={(element) => (this.toggleButtonElementRef = element)}
+            >
+              <span class="active-option-label">
+                <ActiveGroupLabel active={this.active} options={this.options} />
+                {this.active?.selectedLabel ?? this.active?.label ?? "Selecteer een optie"}
+              </span>
+              <span class="active-option-aside">
+                <dso-icon icon={icon} aria-hidden="true"></dso-icon>
+              </span>
+            </button>
+            {this.open && (
+              <div class="groups-container">
+                <ul class="groups">
+                  {this.options.map(
+                    (optionOrGroup) =>
+                      ("options" in optionOrGroup && (
+                        <li class={clsx(["group", { [`group-${optionOrGroup.variant}`]: !!optionOrGroup.variant }])}>
+                          <p class="group-label">{optionOrGroup.label}</p>
+                          <ul class="options">
+                            {optionOrGroup.options.map((option) => (
+                              <li>
+                                <OptionButton
+                                  option={option}
+                                  active={this.active}
+                                  activeHint={this.activeHint}
+                                  callback={this.handleOptionClick}
+                                  variant={optionOrGroup.variant}
+                                />
+                              </li>
+                            ))}
+                          </ul>
+                          {optionOrGroup.redirect && (
+                            <RedirectAnchor
+                              redirect={optionOrGroup.redirect}
+                              callback={this.handleRedirectClick}
+                            ></RedirectAnchor>
+                          )}
+                        </li>
+                      )) ||
+                      ("placeholder" in optionOrGroup && (
+                        <li class="group">
+                          <p class="group-label">{optionOrGroup.label}</p>
+                          <p class="placeholder">{optionOrGroup.placeholder}</p>
+                          {optionOrGroup.redirect && (
+                            <RedirectAnchor
+                              redirect={optionOrGroup.redirect}
+                              callback={this.handleRedirectClick}
+                            ></RedirectAnchor>
+                          )}
+                        </li>
+                      )) || (
+                        <li>
+                          <OptionButton
+                            option={optionOrGroup}
+                            active={this.active}
+                            activeHint={this.activeHint}
+                            callback={this.handleOptionClick}
+                          />
+                        </li>
+                      ),
+                  )}
+                </ul>
+              </div>
+            )}
+          </div>
+          {this.options.some((optionOrGroup) => "summaryCounter" in optionOrGroup && optionOrGroup?.summaryCounter) && (
+            <span class="badges">
+              {this.options
+                .filter(
+                  (option): option is AdvancedSelectGroup<unknown> =>
+                    "options" in option && "summaryCounter" in option && !!option?.summaryCounter,
+                )
+                .map((group) => (
+                  <dso-badge
+                    status={group.variant ?? "outline"}
+                    label={group.badgeLabel ?? `Toon toelichting voor ${group.label.toLowerCase()}`}
+                  >
+                    {group.options.length}
+                    <div slot="toggletip">{group.toggletip}</div>
+                  </dso-badge>
+                ))}
             </span>
-            <span class="active-option-aside">
-              <dso-icon icon={icon} aria-hidden="true"></dso-icon>
-            </span>
-          </button>
-          {this.open && (
-            <div class="groups-container">
-              <ul class="groups">
-                {this.options.map(
-                  (optionOrGroup) =>
-                    ("options" in optionOrGroup && (
-                      <li class={clsx(["group", { [`group-${optionOrGroup.variant}`]: !!optionOrGroup.variant }])}>
-                        <p class="group-label">{optionOrGroup.label}</p>
-                        <ul class="options">
-                          {optionOrGroup.options.map((option) => (
-                            <li>
-                              <OptionButton
-                                option={option}
-                                active={this.active}
-                                activeHint={this.activeHint}
-                                callback={this.handleOptionClick}
-                                variant={optionOrGroup.variant}
-                              />
-                            </li>
-                          ))}
-                        </ul>
-                        {optionOrGroup.redirect && (
-                          <RedirectAnchor
-                            redirect={optionOrGroup.redirect}
-                            callback={this.handleRedirectClick}
-                          ></RedirectAnchor>
-                        )}
-                      </li>
-                    )) ||
-                    ("placeholder" in optionOrGroup && (
-                      <li class="group">
-                        <p class="group-label">{optionOrGroup.label}</p>
-                        <p class="placeholder">{optionOrGroup.placeholder}</p>
-                        {optionOrGroup.redirect && (
-                          <RedirectAnchor
-                            redirect={optionOrGroup.redirect}
-                            callback={this.handleRedirectClick}
-                          ></RedirectAnchor>
-                        )}
-                      </li>
-                    )) || (
-                      <li>
-                        <OptionButton
-                          option={optionOrGroup}
-                          active={this.active}
-                          activeHint={this.activeHint}
-                          callback={this.handleOptionClick}
-                        />
-                      </li>
-                    ),
-                )}
-              </ul>
-            </div>
           )}
         </div>
-        {this.options.some((optionOrGroup) => "summaryCounter" in optionOrGroup && optionOrGroup?.summaryCounter) && (
-          <span class="badges">
-            {this.options
-              .filter(
-                (option): option is AdvancedSelectGroup<unknown> =>
-                  "options" in option && "summaryCounter" in option && !!option?.summaryCounter,
-              )
-              .map((group) => (
-                <dso-badge
-                  status={group.variant ?? "outline"}
-                  label={group.badgeLabel ?? `Toon toelichting voor ${group.label.toLowerCase()}`}
-                >
-                  {group.options.length}
-                  <div slot="toggletip">{group.toggletip}</div>
-                </dso-badge>
-              ))}
-          </span>
-        )}
       </div>
     );
   }
@@ -254,6 +256,7 @@ const OptionButton: FunctionalComponent<OptionButtonProps> = ({ option, active, 
     <button
       class={clsx(["option", { "option-active": active === option }])}
       type="button"
+      aria-current={active === option ? "true" : undefined}
       onClick={(e) => callback(e, option)}
     >
       <dso-icon icon={icon} aria-hidden="true" />

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.args.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.args.ts
@@ -21,7 +21,6 @@ export interface AdvancedSelectArgs {
 }
 
 export const advancedSelectArgs: AdvancedSelectArgs = {
-  activeHint: "Deze bekijkt u nu",
   optionsOrGroup: options,
   dsoChange: fn(),
   dsoRedirect: fn(),

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.content.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.content.ts
@@ -11,6 +11,7 @@ export const options: (AdvancedSelectOption<unknown> | AdvancedSelectGroup<unkno
     options: [
       {
         label: "In werking (laatst gewijzigd: 01-01-2024)",
+        selectedLabel: "Geldende versie",
       },
     ],
   },

--- a/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
+++ b/packages/dso-toolkit/src/components/advanced-select/advanced-select.models.ts
@@ -2,6 +2,7 @@ export type AdvancedSelectVariant = "primary" | "success" | "info" | "warning" |
 
 export interface AdvancedSelectOption<T> {
   label: string;
+  selectedLabel?: string;
   value?: T;
 }
 

--- a/storybook/cypress/e2e/advanced-select.cy.ts
+++ b/storybook/cypress/e2e/advanced-select.cy.ts
@@ -16,6 +16,14 @@ describe("AdvancedSelect", () => {
     cy.get("dso-advanced-select.hydrated").matchImageSnapshot("advanced-select--default");
   });
 
+  it("matches snapshot closed with badges below the button on a narrow viewport", () => {
+    cy.viewport(400, 400);
+
+    cy.visit("http://localhost:45000/iframe.html?id=core-advanced-select--default");
+
+    cy.get("dso-advanced-select.hydrated").matchImageSnapshot("advanced-select--default-narrow-viewport");
+  });
+
   it("matches snapshots", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-advanced-select--default");
 
@@ -47,7 +55,7 @@ describe("AdvancedSelect", () => {
       .should("exist");
   });
 
-  it("should show active hint on active option when options are shown", () => {
+  it("shows active option with aria-current and optionally with active hint when options are shown", () => {
     cy.visit("http://localhost:45000/iframe.html?id=core-advanced-select--default&args=activeIndex:2");
 
     cy.get("dso-advanced-select.hydrated").shadow().find("button.active-option").as("active-option-button");
@@ -56,12 +64,25 @@ describe("AdvancedSelect", () => {
       .click()
       .get("dso-advanced-select.hydrated")
       .shadow()
+      .find(".option-active")
+      .should("have.attr", "aria-current", "true");
+
+    cy.get("@active-option-button")
+      .click()
+      .get("dso-advanced-select.hydrated")
+      .shadow()
       .find(".groups .group:first .options li:first .option-hint")
-      .should("not.exist")
+      .should("not.exist");
+
+    cy.get("dso-advanced-select.hydrated").invoke("prop", "activeHint", "Deze bekijkt u nu");
+
+    cy.get("@active-option-button")
+      .click()
       .get("dso-advanced-select.hydrated")
       .shadow()
       .find(".groups .group:nth-child(2) .options li:nth-child(2) .option-hint")
-      .should("exist");
+      .should("exist")
+      .and("have.text", "(Deze bekijkt u nu)");
   });
 
   it("should show activeLabel on active option", () => {


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom:
    - 1x New snapshot van de advanced select narrow met de badges eronder.
    - De html/css en core voorbeeldpagina hebben nu een diff , omdat de badges onder de advanced-select button staan: <img width="3840" height="600" alt="Voorbeeldpagina image snapshots (Core) -- matches image snapshot of voorbeeldpagina-s-toepassingen-regels-op-de-kaart-documenten--documenten (Core) diff" src="https://github.com/user-attachments/assets/e63ea330-60f9-4b08-9e1c-cee1fee3dbf1" />
- [x] De wijziging heeft een e2e test
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
