### PR TITLE
#3956 [Added] List: Selector `ol.dso-list-ordered-action` terugzetten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Added
+* List: Selector `ol.dso-list-ordered-action` terugzetten ([#3956](https://github.com/dso-toolkit/dso-toolkit/issues/3956))
+
 ### Changed
 * Viewer Grid: Document-tab conditioneel kunnen verbergen ([#3925](https://github.com/dso-toolkit/dso-toolkit/issues/3925))
 * Document Card: Toevoeging label row ([#3716](https://github.com/dso-toolkit/dso-toolkit/issues/3716))

--- a/packages/dso-toolkit/src/components/list/list.scss
+++ b/packages/dso-toolkit/src/components/list/list.scss
@@ -142,6 +142,8 @@ ul:has(dso-project-item) {
   }
 }
 
+/* The ol.dso-list-ordered-action selector will be removed in #3954 */
+ol.dso-list-ordered-action,
 ol.dso-action-list,
 ul.dso-action-list {
   @include list.unstyled();
@@ -182,7 +184,8 @@ ul.dso-action-list {
   }
 }
 
-ol.dso-action-list {
+ol.dso-action-list,
+ol.dso-list-ordered-action {
   li::before {
     @include step-counter.ordered-action-list();
 

--- a/packages/dso-toolkit/src/components/list/readme.md
+++ b/packages/dso-toolkit/src/components/list/readme.md
@@ -1,4 +1,4 @@
-# `ul`, `ol`, `.list-group`, `ul.dso-columns-list`, `ol.dso-columns-list`, `ol.dso-action-list`, `ul.dso-action-list`
+# `ul`, `ol`, `.list-group`, `ul.dso-columns-list`, `ol.dso-columns-list`, `ol.dso-list-ordered-action`, `ol.dso-action-list`, `ul.dso-action-list`
 
 ## Status
 


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [ ] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- ~[ ] De wijziging heeft een e2e test~
- ~[ ] Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [ ] Getest op dso-toolkit.nl
