### PR TITLE
#3667 [Changed] Functional Component Tooltip: Implementatie refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 * Accordion: Optionele Badge in handle van Accordion Section ([#3936](https://github.com/dso-toolkit/dso-toolkit/issues/3936))
 * Header: Help-knop in menu bij mobiele viewport ([#3017](https://github.com/dso-toolkit/dso-toolkit/issues/3017))
+* Functional Component Tooltip: Implementatie refactor ([#3667](https://github.com/dso-toolkit/dso-toolkit/issues/3667))
 
 ## 🧧 Release 100.3.1 - 2026-09-08
 

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -1,9 +1,10 @@
 import { Component, ComponentInterface, Element, Host, Prop, State, h } from "@stencil/core";
 import { clsx } from "clsx";
 
-import { positionTooltip } from "../../functional-components/tooltip/position-tooltip.function";
+import { ToggletipController } from "../../functional-components/tooltip/toggletip.controller";
+import { TooltipController } from "../../functional-components/tooltip/tooltip.controller";
 import { Tooltip } from "../../functional-components/tooltip/tooltip.functional-component";
-import { TooltipClean, TooltipPlacement } from "../../functional-components/tooltip/tooltip.interfaces";
+import { TooltipPlacement } from "../../functional-components/tooltip/tooltip.interfaces";
 
 import { BadgeStatus } from "./badge.interfaces";
 
@@ -23,13 +24,25 @@ export class Badge implements ComponentInterface {
   private tooltipArrowElRef?: HTMLSpanElement;
   private toggletipElRef?: HTMLDivElement;
   private toggletipArrowElRef?: HTMLSpanElement;
-  private cleanUpFunctionToggletip: TooltipClean | undefined;
-  private cleanUpFunctionTooltip: TooltipClean | undefined;
   private mutationObserver?: MutationObserver;
   private restrictContentElement?: HTMLElement;
-  private tooltipTimeout?: number;
-  private lastClickTime = 0;
-  private tooltipShowDelay = 500;
+
+  private tooltipController = new TooltipController({
+    getReferenceElement: () => this.buttonElRef,
+    getTipElement: () => this.tooltipElRef,
+    getTipArrowElement: () => this.tooltipArrowElRef,
+    getPlacement: () => "top",
+    showDelay: 500,
+    respectClickDelay: true,
+  });
+
+  private toggletipController = new ToggletipController({
+    getReferenceElement: () => this.buttonElRef,
+    getTipElement: () => this.toggletipElRef,
+    getTipArrowElement: () => this.toggletipArrowElRef,
+    getRestrictContentElement: () => this.restrictContentElement,
+    getPlacement: () => this.toggletipPlacement,
+  });
 
   @Element()
   host!: HTMLDsoBadgeElement;
@@ -59,51 +72,17 @@ export class Badge implements ComponentInterface {
   hasToggletip = false;
 
   private handleToggle() {
-    this.lastClickTime = Date.now();
+    this.tooltipController.notifyClick();
     this.toggletipActive = !this.toggletipActive;
     this.handleHideTooltip();
   }
 
   private handleShowTooltip = () => {
-    // Don't show the tooltip if the button is clicked within 500ms of the last click
-    if (Date.now() - this.lastClickTime < this.tooltipShowDelay) {
-      return;
-    }
-
-    this.clearToolTipTimeout();
-
-    this.tooltipTimeout = window.setTimeout(() => {
-      if (!this.tooltipElRef?.isConnected) {
-        return;
-      }
-
-      this.tooltipElRef?.showPopover();
-
-      if (!this.cleanUpFunctionTooltip && this.buttonElRef && this.tooltipElRef && this.tooltipArrowElRef) {
-        this.cleanUpFunctionTooltip = positionTooltip({
-          referenceElement: this.buttonElRef,
-          tipRef: this.tooltipElRef,
-          tipArrowRef: this.tooltipArrowElRef,
-          placementTip: "top",
-          topPositionSmallViewPort: false,
-          halfMainAxisOffset: false,
-          forceVisible: true,
-        });
-      }
-    }, this.tooltipShowDelay);
+    this.tooltipController.show();
   };
 
   private handleHideTooltip = () => {
-    this.clearToolTipTimeout();
-
-    if (this.tooltipElRef?.isConnected && this.tooltipElRef.matches(":popover-open")) {
-      this.tooltipElRef.hidePopover();
-    }
-
-    if (this.cleanUpFunctionTooltip) {
-      this.cleanUpFunctionTooltip();
-      this.cleanUpFunctionTooltip = undefined;
-    }
+    this.tooltipController.hide();
   };
 
   private keyDownHandler = (event: KeyboardEvent) => {
@@ -121,56 +100,14 @@ export class Badge implements ComponentInterface {
     }
   };
 
-  private clearToolTipTimeout = () => {
-    if (this.tooltipTimeout) {
-      clearTimeout(this.tooltipTimeout);
-    }
-  };
-
-  private cleanUpToggletip() {
-    this.cleanUpFunctionToggletip?.();
-    this.cleanUpFunctionToggletip = undefined;
-  }
-
-  private cleanUpTooltip() {
-    this.clearToolTipTimeout();
-
-    this.cleanUpFunctionTooltip?.();
-    this.cleanUpFunctionTooltip = undefined;
-  }
-
   componentDidRender() {
     if (!this.hasToggletip) {
-      this.toggletipElRef?.hidePopover();
-      this.cleanUpToggletip();
-      this.cleanUpTooltip();
+      this.tooltipController.hide();
+      this.toggletipController.dispose();
       return;
     }
 
-    if (
-      !this.cleanUpFunctionToggletip &&
-      this.toggletipActive &&
-      this.buttonElRef &&
-      this.toggletipElRef &&
-      this.toggletipArrowElRef
-    ) {
-      this.cleanUpFunctionToggletip = positionTooltip({
-        referenceElement: this.buttonElRef,
-        tipRef: this.toggletipElRef,
-        tipArrowRef: this.toggletipArrowElRef,
-        placementTip: this.toggletipPlacement,
-        restrictContentElement: this.restrictContentElement,
-      });
-    }
-
-    if (this.cleanUpFunctionToggletip) {
-      if (this.toggletipActive) {
-        this.toggletipElRef?.showPopover();
-      } else {
-        this.toggletipElRef?.hidePopover();
-        this.cleanUpToggletip();
-      }
-    }
+    this.toggletipController.update(this.toggletipActive);
   }
 
   connectedCallback(): void {
@@ -185,7 +122,7 @@ export class Badge implements ComponentInterface {
   }
 
   disconnectedCallback() {
-    this.cleanUpToggletip();
+    this.toggletipController.dispose();
     this.mutationObserver?.disconnect();
 
     delete this.mutationObserver;

--- a/packages/core/src/components/badge/badge.tsx
+++ b/packages/core/src/components/badge/badge.tsx
@@ -33,7 +33,6 @@ export class Badge implements ComponentInterface {
     getTipArrowElement: () => this.tooltipArrowElRef,
     getPlacement: () => "top",
     showDelay: 500,
-    respectClickDelay: true,
   });
 
   private toggletipController = new ToggletipController({
@@ -96,7 +95,6 @@ export class Badge implements ComponentInterface {
   private focusOutHandler = (event: FocusEvent) => {
     if (!this.host.contains(event.relatedTarget as Node)) {
       this.toggletipActive = false;
-      this.toggletipElRef?.hidePopover();
     }
   };
 
@@ -104,6 +102,7 @@ export class Badge implements ComponentInterface {
     if (!this.hasToggletip) {
       this.tooltipController.hide();
       this.toggletipController.dispose();
+
       return;
     }
 
@@ -123,6 +122,8 @@ export class Badge implements ComponentInterface {
 
   disconnectedCallback() {
     this.toggletipController.dispose();
+    this.tooltipController.dispose();
+
     this.mutationObserver?.disconnect();
 
     delete this.mutationObserver;

--- a/packages/core/src/components/icon-button/icon-button.tsx
+++ b/packages/core/src/components/icon-button/icon-button.tsx
@@ -1,8 +1,8 @@
 import { Component, ComponentInterface, Event, EventEmitter, Method, Prop, h } from "@stencil/core";
 
-import { positionTooltip } from "../../functional-components/tooltip/position-tooltip.function";
+import { TooltipController } from "../../functional-components/tooltip/tooltip.controller";
 import { Tooltip } from "../../functional-components/tooltip/tooltip.functional-component";
-import { TooltipClean, TooltipPlacement } from "../../functional-components/tooltip/tooltip.interfaces";
+import { TooltipPlacement } from "../../functional-components/tooltip/tooltip.interfaces";
 import { IconAlias } from "../icon/icon.interfaces";
 
 import { IconButtonClickEvent, IconButtonVariant } from "./icon-button.interfaces";
@@ -16,10 +16,15 @@ export class IconButton implements ComponentInterface {
   private buttonElRef?: HTMLButtonElement;
   private tooltipElRef?: HTMLDivElement;
   private tooltipArrowElRef?: HTMLSpanElement;
-  private tooltipTimeout?: number;
-  private cleanUpFunction: TooltipClean | undefined;
-  private lastClickTime = 0;
-  private tooltipShowDelay = 500;
+
+  private tooltipController = new TooltipController({
+    getReferenceElement: () => this.buttonElRef,
+    getTipElement: () => this.tooltipElRef,
+    getTipArrowElement: () => this.tooltipArrowElRef,
+    getPlacement: () => this.tooltipPlacement,
+    showDelay: 500,
+    respectClickDelay: true,
+  });
 
   /**
    * The alias of the icon in the button.
@@ -82,63 +87,19 @@ export class IconButton implements ComponentInterface {
       return;
     }
 
-    // Don't show the tooltip if the button is clicked within 500ms of the last click
-    if (Date.now() - this.lastClickTime < this.tooltipShowDelay) {
-      return;
-    }
-
-    this.clearToolTipTimeout();
-
-    this.tooltipTimeout = window.setTimeout(() => {
-      if (!this.tooltipElRef?.isConnected) {
-        return;
-      }
-
-      this.tooltipElRef?.showPopover();
-
-      if (!this.cleanUpFunction && this.buttonElRef && this.tooltipElRef && this.tooltipArrowElRef) {
-        this.cleanUpFunction = positionTooltip({
-          referenceElement: this.buttonElRef,
-          tipRef: this.tooltipElRef,
-          tipArrowRef: this.tooltipArrowElRef,
-          placementTip: this.tooltipPlacement,
-          topPositionSmallViewPort: false,
-          halfMainAxisOffset: false,
-          forceVisible: true,
-        });
-      }
-    }, this.tooltipShowDelay);
-  };
-
-  private cleanUpTooltip() {
-    this.cleanUpFunction?.();
-    this.cleanUpFunction = undefined;
-  }
-
-  disconnectedCallback() {
-    this.clearToolTipTimeout();
-
-    this.cleanUpTooltip();
-  }
-
-  private clearToolTipTimeout = () => {
-    if (this.tooltipTimeout) {
-      clearTimeout(this.tooltipTimeout);
-    }
+    this.tooltipController.show();
   };
 
   private handleHideTooltip = () => {
-    this.clearToolTipTimeout();
-
-    if (this.tooltipElRef?.isConnected && this.tooltipElRef.matches(":popover-open")) {
-      this.tooltipElRef.hidePopover();
-    }
-
-    this.cleanUpTooltip();
+    this.tooltipController.hide();
   };
 
+  disconnectedCallback() {
+    this.tooltipController.dispose();
+  }
+
   private handleClick = (event: MouseEvent) => {
-    this.lastClickTime = Date.now();
+    this.tooltipController.notifyClick();
     this.handleHideTooltip();
     this.dsoClick.emit({ originalEvent: event, toggled: !this.toggled });
   };

--- a/packages/core/src/components/icon-button/icon-button.tsx
+++ b/packages/core/src/components/icon-button/icon-button.tsx
@@ -23,7 +23,6 @@ export class IconButton implements ComponentInterface {
     getTipArrowElement: () => this.tooltipArrowElRef,
     getPlacement: () => this.tooltipPlacement,
     showDelay: 500,
-    respectClickDelay: true,
   });
 
   /**

--- a/packages/core/src/components/info-button/info-button.tsx
+++ b/packages/core/src/components/info-button/info-button.tsx
@@ -12,9 +12,9 @@ import {
   h,
 } from "@stencil/core";
 
-import { positionTooltip } from "../../functional-components/tooltip/position-tooltip.function";
+import { ToggletipController, isEventOutside } from "../../functional-components/tooltip/toggletip.controller";
 import { Tooltip } from "../../functional-components/tooltip/tooltip.functional-component";
-import { TooltipClean, TooltipPlacement } from "../../functional-components/tooltip/tooltip.interfaces";
+import { TooltipPlacement } from "../../functional-components/tooltip/tooltip.interfaces";
 
 import { InfoButtonToggleEvent } from "./info-button.interfaces";
 
@@ -27,9 +27,16 @@ export class InfoButton implements ComponentInterface {
   private button?: HTMLDsoIconButtonElement;
   private toggletipElRef?: HTMLDivElement;
   private toggletipArrowElRef?: HTMLSpanElement;
-  private cleanUpFunction: TooltipClean | undefined;
   private mutationObserver?: MutationObserver;
   private restrictContentElement?: HTMLElement;
+
+  private toggletipController = new ToggletipController({
+    getReferenceElement: () => this.button,
+    getTipElement: () => this.toggletipElRef,
+    getTipArrowElement: () => this.toggletipArrowElRef,
+    getRestrictContentElement: () => this.restrictContentElement,
+    getPlacement: () => this.toggletipPlacement,
+  });
 
   @Element()
   host!: HTMLDsoInfoButtonElement;
@@ -93,7 +100,7 @@ export class InfoButton implements ComponentInterface {
       return;
     }
 
-    if (!event.composedPath().includes(this.host)) {
+    if (isEventOutside(this.host, event)) {
       this.closeToggletip();
     }
   };
@@ -119,48 +126,16 @@ export class InfoButton implements ComponentInterface {
   private closeToggletip() {
     this.toggletipActive = false;
 
-    if (this.toggletipElRef?.isConnected && this.toggletipElRef.matches(":popover-open")) {
-      this.toggletipElRef.hidePopover();
-    }
-
-    this.cleanUpTooltip();
-  }
-
-  private cleanUpTooltip() {
-    this.cleanUpFunction?.();
-    this.cleanUpFunction = undefined;
+    this.toggletipController.update(false);
   }
 
   componentDidRender() {
     if (!this.hasToggletip) {
-      this.toggletipElRef?.hidePopover();
-      this.cleanUpTooltip();
+      this.toggletipController.update(false);
       return;
     }
 
-    if (
-      !this.cleanUpFunction &&
-      this.toggletipActive &&
-      this.button &&
-      this.toggletipElRef &&
-      this.toggletipArrowElRef
-    ) {
-      this.cleanUpFunction = positionTooltip({
-        referenceElement: this.button,
-        tipRef: this.toggletipElRef,
-        tipArrowRef: this.toggletipArrowElRef,
-        placementTip: this.toggletipPlacement,
-        restrictContentElement: this.restrictContentElement,
-      });
-    }
-
-    if (this.cleanUpFunction) {
-      if (this.toggletipActive) {
-        this.toggletipElRef?.showPopover();
-      } else {
-        this.closeToggletip();
-      }
-    }
+    this.toggletipController.update(this.toggletipActive);
   }
 
   connectedCallback(): void {

--- a/packages/core/src/components/info-button/info-button.tsx
+++ b/packages/core/src/components/info-button/info-button.tsx
@@ -130,12 +130,7 @@ export class InfoButton implements ComponentInterface {
   }
 
   componentDidRender() {
-    if (!this.hasToggletip) {
-      this.toggletipController.update(false);
-      return;
-    }
-
-    this.toggletipController.update(this.toggletipActive);
+    this.toggletipController.update(this.hasToggletip && this.toggletipActive);
   }
 
   connectedCallback(): void {
@@ -150,7 +145,7 @@ export class InfoButton implements ComponentInterface {
   }
 
   disconnectedCallback() {
-    this.closeToggletip();
+    this.toggletipController.dispose();
     this.mutationObserver?.disconnect();
 
     delete this.mutationObserver;

--- a/packages/core/src/components/label/label.tsx
+++ b/packages/core/src/components/label/label.tsx
@@ -15,9 +15,8 @@ import {
 import { clsx } from "clsx";
 import debounce from "debounce";
 
-import { positionTooltip } from "../../functional-components/tooltip/position-tooltip.function";
+import { TooltipController } from "../../functional-components/tooltip/tooltip.controller";
 import { Tooltip } from "../../functional-components/tooltip/tooltip.functional-component";
-import { TooltipClean } from "../../functional-components/tooltip/tooltip.interfaces";
 
 import { LabelStatus } from "./label.interfaces";
 
@@ -49,7 +48,13 @@ export class Label implements ComponentInterface {
   private mutationObserver?: MutationObserver;
   private tooltipElRef?: HTMLDivElement;
   private tooltipArrowElRef?: HTMLSpanElement;
-  private cleanUpFunction: TooltipClean | undefined;
+
+  private tooltipController = new TooltipController({
+    getReferenceElement: () => this.labelContent,
+    getTipElement: () => this.tooltipElRef,
+    getTipArrowElement: () => this.tooltipArrowElRef,
+    getPlacement: () => "top",
+  });
 
   @Element()
   private host!: HTMLDsoLabelElement;
@@ -135,11 +140,6 @@ export class Label implements ComponentInterface {
     this.labelText = this.host.textContent?.trim() ?? "";
   }
 
-  private cleanUpTooltip() {
-    this.cleanUpFunction?.();
-    this.cleanUpFunction = undefined;
-  }
-
   componentDidLoad() {
     if (this.truncate) {
       this.startTruncate();
@@ -155,31 +155,15 @@ export class Label implements ComponentInterface {
 
     this.stopMutationObserver(true);
 
-    this.cleanUpTooltip();
+    this.tooltipController.dispose();
   }
 
   private handleShowTooltip = () => {
-    this.tooltipElRef?.showPopover();
-
-    if (!this.cleanUpFunction && this.labelContent && this.tooltipElRef && this.tooltipArrowElRef) {
-      this.cleanUpFunction = positionTooltip({
-        referenceElement: this.labelContent,
-        tipRef: this.tooltipElRef,
-        tipArrowRef: this.tooltipArrowElRef,
-        placementTip: "top",
-        topPositionSmallViewPort: false,
-        halfMainAxisOffset: false,
-        forceVisible: true,
-      });
-    }
+    this.tooltipController.show();
   };
 
   private handleHideTooltip = () => {
-    if (this.tooltipElRef?.isConnected && this.tooltipElRef.matches(":popover-open")) {
-      this.tooltipElRef.hidePopover();
-    }
-
-    this.cleanUpTooltip();
+    this.tooltipController.hide();
   };
 
   /** The mutationObserver fetches the text placed inside the label, this is then used for the remove button and tooltip. */

--- a/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
+++ b/packages/core/src/components/ozon-content/components/ozon-content-toggletip/ozon-content-toggletip.tsx
@@ -1,8 +1,7 @@
 import { Component, ComponentInterface, Element, Fragment, Listen, Prop, State, h } from "@stencil/core";
 
-import { positionTooltip } from "../../../../functional-components/tooltip/position-tooltip.function";
+import { ToggletipController, isEventOutside } from "../../../../functional-components/tooltip/toggletip.controller";
 import { Tooltip } from "../../../../functional-components/tooltip/tooltip.functional-component";
-import { TooltipClean } from "../../../../functional-components/tooltip/tooltip.interfaces";
 import { IconAlias } from "../../../icon/icon.interfaces";
 
 @Component({
@@ -11,11 +10,18 @@ import { IconAlias } from "../../../icon/icon.interfaces";
   shadow: true,
 })
 export class OzonContentToggletip implements ComponentInterface {
-  private cleanUpFunction: TooltipClean | undefined;
   private container: HTMLSpanElement | undefined;
   private tooltipElRef: HTMLDivElement | undefined;
   private tooltipArrowElRef: HTMLSpanElement | undefined;
   private restrictContentElement: HTMLElement | undefined;
+
+  private toggletipController = new ToggletipController({
+    getReferenceElement: () => this.container,
+    getTipElement: () => this.tooltipElRef,
+    getTipArrowElement: () => this.tooltipArrowElRef,
+    getRestrictContentElement: () => this.restrictContentElement,
+    getPlacement: () => "top",
+  });
 
   @Element()
   host!: HTMLDsoOzonContentToggletipElement;
@@ -34,10 +40,9 @@ export class OzonContentToggletip implements ComponentInterface {
     if (!this.active) return;
 
     const path = event.composedPath();
-    const clickedInsideHost = path.includes(this.host);
     const clickedInsideTooltip = this.tooltipElRef && path.includes(this.tooltipElRef);
 
-    if (!clickedInsideHost && !clickedInsideTooltip) {
+    if (isEventOutside(this.host, event) && !clickedInsideTooltip) {
       this.toggle();
     }
 
@@ -68,33 +73,11 @@ export class OzonContentToggletip implements ComponentInterface {
   };
 
   componentDidRender() {
-    if (!this.cleanUpFunction && this.active && this.container && this.tooltipElRef && this.tooltipArrowElRef) {
-      this.cleanUpFunction = positionTooltip({
-        referenceElement: this.container,
-        tipRef: this.tooltipElRef,
-        tipArrowRef: this.tooltipArrowElRef,
-        placementTip: "top",
-        restrictContentElement: this.restrictContentElement,
-      });
-    }
-
-    if (this.cleanUpFunction && this.tooltipElRef) {
-      if (this.active) {
-        this.tooltipElRef?.showPopover();
-      } else {
-        this.tooltipElRef?.hidePopover();
-        this.cleanUpTooltip();
-      }
-    }
+    this.toggletipController.update(this.active);
   }
 
   disconnectedCallback() {
-    this.cleanUpTooltip();
-  }
-
-  private cleanUpTooltip() {
-    this.cleanUpFunction?.();
-    this.cleanUpFunction = undefined;
+    this.toggletipController.dispose();
   }
 
   render() {

--- a/packages/core/src/functional-components/tooltip/toggletip.controller.ts
+++ b/packages/core/src/functional-components/tooltip/toggletip.controller.ts
@@ -1,0 +1,65 @@
+import { positionTooltip } from "./position-tooltip.function";
+import { TooltipClean, TooltipPlacement } from "./tooltip.interfaces";
+
+export interface ToggletipControllerOptions {
+  getReferenceElement: () => HTMLElement | undefined;
+  getTipElement: () => HTMLElement | undefined;
+  getTipArrowElement: () => HTMLElement | undefined;
+  getRestrictContentElement?: () => HTMLElement | undefined;
+  getPlacement: () => TooltipPlacement;
+}
+
+/**
+ * Shared controller for the click/keyboard Toggletip behaviour used by Badge,
+ * Info Button and Ozon Content Toggletip. Intended to be called from `componentDidRender`.
+ */
+export class ToggletipController {
+  private cleanUpFunction: TooltipClean | undefined;
+
+  constructor(private options: ToggletipControllerOptions) {}
+
+  update(active: boolean): void {
+    const tipRef = this.options.getTipElement();
+
+    if (!this.cleanUpFunction && active) {
+      const referenceElement = this.options.getReferenceElement();
+      const tipArrowRef = this.options.getTipArrowElement();
+
+      if (referenceElement && tipRef && tipArrowRef) {
+        this.cleanUpFunction = positionTooltip({
+          referenceElement,
+          tipRef,
+          tipArrowRef,
+          placementTip: this.options.getPlacement(),
+          restrictContentElement: this.options.getRestrictContentElement?.(),
+        });
+      }
+    }
+
+    if (this.cleanUpFunction) {
+      if (active) {
+        tipRef?.showPopover();
+      } else {
+        tipRef?.hidePopover();
+        this.cleanUpToggletip();
+      }
+    }
+  }
+
+  dispose(): void {
+    this.cleanUpToggletip();
+  }
+
+  private cleanUpToggletip(): void {
+    this.cleanUpFunction?.();
+    this.cleanUpFunction = undefined;
+  }
+}
+
+/**
+ * Determines whether an event originated outside `host`, based on `event.composedPath()`.
+ * Used for outside-dismiss handling of a Toggletip.
+ */
+export function isEventOutside(host: Element, event: Event): boolean {
+  return !event.composedPath().includes(host);
+}

--- a/packages/core/src/functional-components/tooltip/toggletip.controller.ts
+++ b/packages/core/src/functional-components/tooltip/toggletip.controller.ts
@@ -10,14 +10,20 @@ export interface ToggletipControllerOptions {
 }
 
 /**
- * Shared controller for the click/keyboard Toggletip behaviour used by Badge,
- * Info Button and Ozon Content Toggletip. Intended to be called from `componentDidRender`.
+ * Shared controller for the positioning, showing, and hiding of a Toggletip.
  */
 export class ToggletipController {
   private cleanUpFunction: TooltipClean | undefined;
 
   constructor(private options: ToggletipControllerOptions) {}
 
+  /**
+   * Position the Toggletip and show or hide it based on the `active` parameter.
+   *
+   * Intended to be called from `componentDidRender`.
+   *
+   * @param active Whether the Toggletip should be active.
+   */
   update(active: boolean): void {
     const tipRef = this.options.getTipElement();
 
@@ -40,7 +46,10 @@ export class ToggletipController {
       if (active) {
         tipRef?.showPopover();
       } else {
-        tipRef?.hidePopover();
+        if (tipRef?.isConnected && tipRef.matches(":popover-open")) {
+          tipRef?.hidePopover();
+        }
+
         this.cleanUpToggletip();
       }
     }

--- a/packages/core/src/functional-components/tooltip/tooltip.controller.ts
+++ b/packages/core/src/functional-components/tooltip/tooltip.controller.ts
@@ -1,0 +1,103 @@
+import { positionTooltip } from "./position-tooltip.function";
+import { TooltipClean, TooltipPlacement } from "./tooltip.interfaces";
+
+export interface TooltipControllerOptions {
+  getReferenceElement: () => HTMLElement | undefined;
+  getTipElement: () => HTMLElement | undefined;
+  getTipArrowElement: () => HTMLElement | undefined;
+  getPlacement: () => TooltipPlacement;
+  /** Delay in ms before the tooltip is shown. Defaults to 0 (no delay). */
+  showDelay?: number;
+  /** When true, `show()` is ignored if it is called within `showDelay` ms of the last `notifyClick()`. */
+  respectClickDelay?: boolean;
+}
+
+/**
+ * Shared controller for the hover/focus Tooltip behaviour used by Icon Button, Badge and Label.
+ */
+export class TooltipController {
+  private cleanUpFunction: TooltipClean | undefined;
+  private tooltipTimeout?: number;
+  private lastClickTime = 0;
+
+  constructor(private options: TooltipControllerOptions) {}
+
+  /**
+   * Registers a click, used together with `respectClickDelay` to suppress the tooltip
+   * from (re)appearing right after a click on the reference element.
+   */
+  notifyClick = (): void => {
+    this.lastClickTime = Date.now();
+  };
+
+  show = (): void => {
+    const { showDelay = 0, respectClickDelay } = this.options;
+
+    if (respectClickDelay && Date.now() - this.lastClickTime < showDelay) {
+      return;
+    }
+
+    this.clearShowTimeout();
+
+    if (showDelay > 0) {
+      this.tooltipTimeout = window.setTimeout(this.doShow, showDelay);
+    } else {
+      this.doShow();
+    }
+  };
+
+  hide = (): void => {
+    this.clearShowTimeout();
+
+    const tipRef = this.options.getTipElement();
+
+    if (tipRef?.isConnected && tipRef.matches(":popover-open")) {
+      tipRef.hidePopover();
+    }
+
+    this.cleanUpTooltip();
+  };
+
+  dispose(): void {
+    this.clearShowTimeout();
+    this.cleanUpTooltip();
+  }
+
+  private doShow = (): void => {
+    const tipRef = this.options.getTipElement();
+
+    if (!tipRef?.isConnected) {
+      return;
+    }
+
+    tipRef.showPopover();
+
+    if (!this.cleanUpFunction) {
+      const referenceElement = this.options.getReferenceElement();
+      const tipArrowRef = this.options.getTipArrowElement();
+
+      if (referenceElement && tipArrowRef) {
+        this.cleanUpFunction = positionTooltip({
+          referenceElement,
+          tipRef,
+          tipArrowRef,
+          placementTip: this.options.getPlacement(),
+          topPositionSmallViewPort: false,
+          halfMainAxisOffset: false,
+          forceVisible: true,
+        });
+      }
+    }
+  };
+
+  private clearShowTimeout(): void {
+    if (this.tooltipTimeout) {
+      clearTimeout(this.tooltipTimeout);
+    }
+  }
+
+  private cleanUpTooltip(): void {
+    this.cleanUpFunction?.();
+    this.cleanUpFunction = undefined;
+  }
+}

--- a/packages/core/src/functional-components/tooltip/tooltip.controller.ts
+++ b/packages/core/src/functional-components/tooltip/tooltip.controller.ts
@@ -8,12 +8,10 @@ export interface TooltipControllerOptions {
   getPlacement: () => TooltipPlacement;
   /** Delay in ms before the tooltip is shown. Defaults to 0 (no delay). */
   showDelay?: number;
-  /** When true, `show()` is ignored if it is called within `showDelay` ms of the last `notifyClick()`. */
-  respectClickDelay?: boolean;
 }
 
 /**
- * Shared controller for the hover/focus Tooltip behaviour used by Icon Button, Badge and Label.
+ * Shared controller for the positioning, showing, and hiding of a Tooltip.
  */
 export class TooltipController {
   private cleanUpFunction: TooltipClean | undefined;
@@ -26,14 +24,16 @@ export class TooltipController {
    * Registers a click, used together with `respectClickDelay` to suppress the tooltip
    * from (re)appearing right after a click on the reference element.
    */
-  notifyClick = (): void => {
+  notifyClick(): void {
     this.lastClickTime = Date.now();
-  };
+  }
 
-  show = (): void => {
-    const { showDelay = 0, respectClickDelay } = this.options;
+  show(): void {
+    const { showDelay = 0 } = this.options;
 
-    if (respectClickDelay && Date.now() - this.lastClickTime < showDelay) {
+    this.clearShowTimeout();
+
+    if (Date.now() - this.lastClickTime < showDelay) {
       return;
     }
 
@@ -44,9 +44,9 @@ export class TooltipController {
     } else {
       this.doShow();
     }
-  };
+  }
 
-  hide = (): void => {
+  hide(): void {
     this.clearShowTimeout();
 
     const tipRef = this.options.getTipElement();
@@ -56,7 +56,7 @@ export class TooltipController {
     }
 
     this.cleanUpTooltip();
-  };
+  }
 
   dispose(): void {
     this.clearShowTimeout();

--- a/packages/core/src/functional-components/tooltip/tooltip.controller.ts
+++ b/packages/core/src/functional-components/tooltip/tooltip.controller.ts
@@ -21,8 +21,8 @@ export class TooltipController {
   constructor(private options: TooltipControllerOptions) {}
 
   /**
-   * Registers a click, used together with `respectClickDelay` to suppress the tooltip
-   * from (re)appearing right after a click on the reference element.
+   * Registers a click to suppress the tooltip from (re)appearing within showDelay milliseconds after a click on the
+   * reference element.
    */
   notifyClick(): void {
     this.lastClickTime = Date.now();
@@ -36,8 +36,6 @@ export class TooltipController {
     if (Date.now() - this.lastClickTime < showDelay) {
       return;
     }
-
-    this.clearShowTimeout();
 
     if (showDelay > 0) {
       this.tooltipTimeout = window.setTimeout(this.doShow, showDelay);


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl

### Vraag:

Wat weerhoudt ons ervan om niet alsnog 2 spec files toe te voegen voor beide controllers?

### Antwoord:

Niets fundamenteels — het kán, maar er zijn wel een paar praktische drempels die verklaren waarom het niet triviaal is:

1. **Geen testinfrastructuur in `packages/core`.** Er is geen test-runner geconfigureerd (geen jest/vitest/stencil-spec setup, geen `test`-target in nx). Twee spec-files toevoegen betekent eerst een runner + config + CI-integratie opzetten. Dat is een grotere ingreep dan "2 bestandjes".

2. **Browser-API's die de controllers gebruiken.** `showPopover()`/`hidePopover()`, de `:popover-open`-matcher, `requestAnimationFrame` en `@floating-ui/dom`'s `autoUpdate` (layout-afhankelijk) draaien niet zonder meer in jsdom/happy-dom. Popover-API wordt daar historisch niet/gedeeltelijk ondersteund, dus je moet flink mocken — waarmee je vooral je mocks test i.p.v. echt gedrag.

3. **De echt waardevolle logica is timing/DOM-gedrag.** Wat je wil borgen (show-delay, `respectClickDelay`-guard, `update()` state-overgangen, cleanup) leunt op timers en de popover-state. Dat valideren we nu al betrouwbaar via de storybook e2e (Cypress, echte browser). Unit-tests zouden dat deels dupliceren met minder realisme.

Kortom: het is geen blokkade, maar een **kosten/baten-afweging**. Zinvol te unit-testen zonder DOM zijn vooral de pure stukjes: de `showDelay`/`respectClickDelay`-beslissing en `isEventOutside()`. Voor de rest voegt e2e meer zekerheid toe.

Advies: als we het doen, dan als aparte issue met (a) een minimale vitest/jsdom-setup, (b) fake timers voor de delay-logica, en (c) mocks voor `positionTooltip`/popover. 
