### PR TITLE
#3963 [Fixed] Header: Menu klapt niet open in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Next
 
+### Fixed
+* Header: Menu klapt niet open in Safari ([#3963](https://github.com/dso-toolkit/dso-toolkit/issues/3963))
+
 ## 🕵 Release 100.3.0 - 2026-08-31
 
 ### Added

--- a/packages/core/src/components/dropdown-menu/dropdown-menu.scss
+++ b/packages/core/src/components/dropdown-menu/dropdown-menu.scss
@@ -56,6 +56,8 @@ button {
   inline-size: max-content;
   padding: 0;
   z-index: zindex.$dropdown-options;
+
+  --_dso-scrollable-block-size: auto; // niet leunen op block-size:100% tegen fit-content popover (Safari collapse)
 }
 
 ::slotted(dso-dropdown-menu-group:not(:last-child)) {

--- a/packages/core/src/components/header/header.scss
+++ b/packages/core/src/components/header/header.scss
@@ -193,6 +193,8 @@ div[popover] {
     padding-inline: 0;
     z-index: zindex.$dropdown-options;
 
+    --_dso-scrollable-block-size: auto; // niet leunen op block-size:100% tegen fit-content popover (Safari collapse)
+
     ul {
       margin: 0;
       padding: 0;

--- a/packages/core/src/components/scrollable/scrollable.scss
+++ b/packages/core/src/components/scrollable/scrollable.scss
@@ -3,7 +3,7 @@
 
 :host {
   display: block;
-  block-size: 100%;
+  block-size: var(--_dso-scrollable-block-size, 100%);
   overflow-y: hidden;
   border-radius: var(--_dso-scrollable-border-radius, 0);
 }


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom.
  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
  Geverifieerd op een iPhone met iOS Version 26.6.1 in Safari:
<img width="375" height="667" alt="Core  Header - Default ⋅ Storybook" src="https://github.com/user-attachments/assets/042d5a66-766f-401e-864a-d197fe655545" />

  
