### PR TITLE
#3972 [Fixed] Grid: `.row.dso-featured` direct na `dso-hero-image` krijgt margin-block-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 * Header: Menu klapt niet open in Safari ([#3963](https://github.com/dso-toolkit/dso-toolkit/issues/3963))
 * Alert & Icon: Geen exceptie bij ontbrekende of onbekende input ([#3970](https://github.com/dso-toolkit/dso-toolkit/issues/3970))
+* Grid: `.row.dso-featured` direct na `dso-hero-image` krijgt margin-block-start ([#3972](https://github.com/dso-toolkit/dso-toolkit/issues/3972))
 
 ## 🕵 Release 100.3.0 - 2026-08-31
 

--- a/packages/dso-toolkit/src/components/grid/grid.scss
+++ b/packages/dso-toolkit/src/components/grid/grid.scss
@@ -165,6 +165,10 @@ form {
 
 dso-hero-image + .row {
   margin-block-start: units.$u3;
+
+  &.dso-featured {
+    margin-block-start: 0;
+  }
 }
 
 .row-no-gutters {

--- a/storybook/src/example-pages/toepassingen/aanvragen/landingspagina.stories.ts
+++ b/storybook/src/example-pages/toepassingen/aanvragen/landingspagina.stories.ts
@@ -20,29 +20,23 @@ const Landingspagina = examplePageStories((templates) => {
     <div class="container">
       ${headerPartial(templates, { ...header, mainMenu: mainMenu("Aanvragen") })}
       <main>
-        <!-- START DEPRECATED: use <dso-hero-image> -->
-        <div
-          class="row dso-banner dso-banner-implementation-specific-image"
-          style="background-image: url('images/hands-on-trackpad.jpg'); padding-block-end: 16px;"
-        >
-          <div class="col-lg-6 col-sm-8">
-            ${highlightBoxTemplate({
-              white: true,
-              content: richContentTemplate({
-                children: html`
-                  <h1>Direct een aanvraag of melding indienen</h1>
-                  <p>
-                    De Bouwregelgeving is een database met alle bouwregelgeving in Nederland, die op zodanige wijze moet
-                    zijn ingericht en ontsloten dat die voldoet aan de eisen van de Omgevingswet (3B's), en daarmee
-                    bruikbaar is in de ontwerp- en toetsingsfase van ieder bouwwerk.
-                  </p>
-                  <p>${linkTemplate({ label: "Start met aanvragen", url: "#", modifier: "dso-primary" })}</p>
-                `,
-              }),
-            })}
-          </div>
-        </div>
-        <!-- END DEPRECATED -->
+        <dso-hero-image>
+          <div slot="image" style="background-image: url('images/hands-on-trackpad.jpg')"></div>
+          ${highlightBoxTemplate({
+            white: true,
+            content: richContentTemplate({
+              children: html`
+                <h1>Direct een aanvraag of melding indienen</h1>
+                <p>
+                  De Bouwregelgeving is een database met alle bouwregelgeving in Nederland, die op zodanige wijze moet
+                  zijn ingericht en ontsloten dat die voldoet aan de eisen van de Omgevingswet (3B's), en daarmee
+                  bruikbaar is in de ontwerp- en toetsingsfase van ieder bouwwerk.
+                </p>
+                <p>${linkTemplate({ label: "Start met aanvragen", url: "#", modifier: "dso-primary" })}</p>
+              `,
+            }),
+          })}
+        </dso-hero-image>
         <div class="row">
           <div class="col-lg-8">
             ${highlightBoxTemplate({

--- a/storybook/src/example-pages/toepassingen/loket/helpcentrum.stories.ts
+++ b/storybook/src/example-pages/toepassingen/loket/helpcentrum.stories.ts
@@ -22,27 +22,26 @@ const Helpcentrum = examplePageStories((templates) => {
     <div class="container">
       ${headerPartial(templates, { ...header, mainMenu: mainMenu("Regels op de kaart") })}
       <main>
-        <!-- START DEPRECATED: use <dso-hero-image> -->
-        <div
-          class="row dso-banner no-button-banner dso-banner-implementation-specific-image"
-          style="background-image: url('images/hero2.jpeg')"
-        >
-          <div class="col-lg-6 col-sm-8">
-            ${highlightBoxTemplate({
-              white: true,
-              content: richContentTemplate({
-                children: html`
-                  <h1>Helpcentrum</h1>
-                  <p>
-                    Heeft u een vraag over de werking van de Vergunningcheck of over geldende regelgeving? Wij hebben de
-                    veelgestelde vragen per thema voor u op een rij gezet.
-                  </p>
-                `,
-              }),
-            })}
-          </div>
-        </div>
-        <!-- END DEPRECATED -->
+        <style>
+          .my-beautiful-image {
+            background-image: url("images/hero2.jpeg");
+          }
+        </style>
+        <dso-hero-image>
+          <div slot="image" class="my-beautiful-image"></div>
+          ${highlightBoxTemplate({
+            white: true,
+            content: richContentTemplate({
+              children: html`
+                <h1>Helpcentrum</h1>
+                <p>
+                  Heeft u een vraag over de werking van de Vergunningcheck of over geldende regelgeving? Wij hebben de
+                  veelgestelde vragen per thema voor u op een rij gezet.
+                </p>
+              `,
+            }),
+          })}
+        </dso-hero-image>
         <h2>Waarmee kunnen we u helpen?</h2>
         <div class="row">
           <div class="col-md-8">

--- a/storybook/src/example-pages/toepassingen/loket/homepage.stories.ts
+++ b/storybook/src/example-pages/toepassingen/loket/homepage.stories.ts
@@ -35,29 +35,26 @@ const Homepage = examplePageStories((templates) => {
       <div id="navigation"><!-- for skiplink --></div>
       ${headerPartial(templates, { ...header, mainMenu: mainMenu("Regels op de kaart") })}
       <main id="main">
-        <!-- START DEPRECATED: use <dso-hero-image> -->
-        <div
-          class="row dso-banner no-button-banner my-beautiful-image"
-          style="background-image: url('images/hero2.jpeg')"
-        >
-          <!-- ^^ background-image set by inline style purely for demo purposes. Please use a class (like the
-             dummy class above) to set your desired background-image! -->
-          <div class="col-lg-6 col-sm-8">
-            ${highlightBoxTemplate({
-              white: true,
-              content: richContentTemplate({
-                children: html`
-                  <h1>Homepage</h1>
-                  <p>
-                    Een vergunning aanvragen of melding doen, bijvoorbeeld voor een nieuwe dakkapel, een nieuw
-                    bedrijfspand of een activiteit op of aan een dijk. Het kan met het nieuwe Omgevingsloket.
-                  </p>
-                `,
-              }),
-            })}
-          </div>
-        </div>
-        <!-- END DEPRECATED -->
+        <style>
+          .my-beautiful-image {
+            background-image: url("images/hero2.jpeg");
+          }
+        </style>
+        <dso-hero-image>
+          <div slot="image" class="my-beautiful-image"></div>
+          ${highlightBoxTemplate({
+            white: true,
+            content: richContentTemplate({
+              children: html`
+                <h1>Homepage</h1>
+                <p>
+                  Een vergunning aanvragen of melding doen, bijvoorbeeld voor een nieuwe dakkapel, een nieuw
+                  bedrijfspand of een activiteit op of aan een dijk. Het kan met het nieuwe Omgevingsloket.
+                </p>
+              `,
+            }),
+          })}
+        </dso-hero-image>
         <div class="row dso-featured dso-equal-heights">
           <div class="col-xs-12">
             ${highlightBoxTemplate({

--- a/storybook/src/example-pages/toepassingen/maatregelen-op-maat/landingspagina.stories.ts
+++ b/storybook/src/example-pages/toepassingen/maatregelen-op-maat/landingspagina.stories.ts
@@ -22,29 +22,28 @@ const Landingspagina = examplePageStories((templates) => {
     <div class="container">
       ${headerPartial(templates, { ...header, mainMenu: mainMenu("Maatregelen op maat") })}
       <main>
-        <!-- START DEPRECATED: use <dso-hero-image> -->
-        <div
-          class="row dso-banner dso-banner-implementation-specific-image"
-          style="background-image: url('images/hero4.jpeg')"
-        >
-          <div class="col-lg-6 col-sm-8">
-            ${highlightBoxTemplate({
-              white: true,
-              content: richContentTemplate({
-                children: html`
-                  <h1>Maatregelen op maat</h1>
-                  <p>
-                    De Bouwregelgeving is een database met alle bouwregelgeving in Nederland, die op zodanige wijze moet
-                    zijn ingericht en ontsloten dat die voldoet aan de eisen van de Omgevingswet (3B's), en daarmee
-                    bruikbaar is in de ontwerp- en toetsingsfase van ieder bouwwerk.
-                  </p>
-                  <p>${linkTemplate({ label: "Start maatregelen op maat", url: "#", modifier: "dso-primary" })}</p>
-                `,
-              }),
-            })}
-          </div>
-        </div>
-        <!-- END DEPRECATED -->
+        <style>
+          .my-beautiful-image {
+            background-image: url("images/hero4.jpeg");
+          }
+        </style>
+        <dso-hero-image>
+          <div slot="image" class="my-beautiful-image"></div>
+          ${highlightBoxTemplate({
+            white: true,
+            content: richContentTemplate({
+              children: html`
+                <h1>Maatregelen op maat</h1>
+                <p>
+                  De Bouwregelgeving is een database met alle bouwregelgeving in Nederland, die op zodanige wijze moet
+                  zijn ingericht en ontsloten dat die voldoet aan de eisen van de Omgevingswet (3B's), en daarmee
+                  bruikbaar is in de ontwerp- en toetsingsfase van ieder bouwwerk.
+                </p>
+                <p>${linkTemplate({ label: "Start maatregelen op maat", url: "#", modifier: "dso-primary" })}</p>
+              `,
+            }),
+          })}
+        </dso-hero-image>
         <div class="row">
           <div class="col-md-8">
             <h2>Voldoen aan de regels</h2>


### PR DESCRIPTION
- [x] PR voldoet aan scope van issue, afwijkingen worden toegelicht.
  - Bijvoorbeeld in PR of het issue.
- [x] PR bestaat uit logische commits.
- [x] PR is gekoppeld met het issue.
- [x] Succesvolle build:
  - Danger tevreden.
  - Indien de build faalt vanwege visuele regressie, onderbouwen waarom:
    - De voorbeeldpagina diff van Homepage Loket toont aan dat de Hero Image by design afwijkt van de eerdere .row.dso-banner implementatie en tevens is zichtbaar dat de `margin-block-start` van 32px er niet meer is. ✅ 
    
<img width="3000" height="2055" alt="Voorbeeldpagina image snapshots (Core) -- matches image snapshot of voorbeeldpagina-s-toepassingen-loket-homepage--homepage (Core) diff" src="https://github.com/user-attachments/assets/6e70a0cc-4746-45d5-acc1-032d8705bf7e" />

  - Als er een flaky test wordt uitgezet, onderbouwen in PR met verwijzing naar nieuw issue.
- [ ] ~De wijziging heeft een e2e test~
- [ ] ~Etaleren/aanpassen van een nieuw component op de website~
- [x] Eigen PR doorgenomen.
- [x] Getest op dso-toolkit.nl
